### PR TITLE
Use semantic versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ MPIFLAGS   := -I$(MPI_HOME)/include -L$(MPI_HOME)/lib -lmpi
 INCEXPORTS  := nccl.h
 LIBSRCFILES := libwrap.cu core.cu all_gather.cu all_reduce.cu broadcast.cu reduce.cu reduce_scatter.cu
 LIBNAME     := libnccl.so
-APIVER      := 0
+VER_MAJOR   := 1
+VER_MINOR   := 0
+VER_PATCH   := 0
 TESTS       := all_gather_test all_reduce_test broadcast_test reduce_test reduce_scatter_test
 MPITESTS    := mpi_test
 
@@ -66,7 +68,8 @@ TSTDIR := $(BUILDDIR)/test
 MPITSTDIR := $(BUILDDIR)/mpitest
 
 INCTARGETS := $(patsubst %, $(INCDIR)/%, $(INCEXPORTS))
-LIBTARGET  := $(patsubst %, $(LIBDIR)/%.$(APIVER), $(LIBNAME))
+LIBSONAME  := $(patsubst %,%.$(VER_MAJOR),$(LIBNAME))
+LIBTARGET  := $(patsubst %,%.$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH),$(LIBNAME))
 LIBLINK    := $(patsubst lib%.so, -l%, $(LIBNAME))
 LIBOBJ     := $(patsubst %.cu, $(OBJDIR)/%.o, $(filter %.cu, $(LIBSRCFILES)))
 TESTBINS   := $(patsubst %, $(TSTDIR)/%, $(TESTS))
@@ -80,8 +83,9 @@ lib : $(INCTARGETS) $(LIBTARGET)
 $(LIBTARGET) : $(LIBOBJ)
 	@printf "Linking   %-25s\n" $@
 	@mkdir -p $(LIBDIR)
-	@$(GPP) $(CPPFLAGS) $(CXXFLAGS) -shared -Wl,-soname,$(LIBNAME).$(APIVER) -o $@ $(LDFLAGS) $(LIBOBJ)
-	@ln -sf $(LIBNAME).$(APIVER) $(LIBDIR)/$(LIBNAME)
+	@$(GPP) $(CPPFLAGS) $(CXXFLAGS) -shared -Wl,-soname,$(LIBSONAME) -o $(LIBDIR)/$@ $(LDFLAGS) $(LIBOBJ)
+	@ln -sf $(LIBSONAME) $(LIBDIR)/$(LIBNAME)
+	@ln -sf $(LIBTARGET) $(LIBDIR)/$(LIBSONAME)
 
 $(INCDIR)/%.h : src/%.h
 	@printf "Grabbing  %-25s > %-25s\n" $< $@


### PR DESCRIPTION
Adherence to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
```
build/lib/
├── libnccl.so -> libnccl.so.1
├── libnccl.so.1 -> libnccl.so.1.0.0
└── libnccl.so.1.0.0
```
Necessary to build a proper deb package (https://github.com/NVIDIA/nccl/pull/2).

/cc @borisfom 