### PR TITLE
Enable compilation with older g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ BUILDDIR := build
 
 NVCC       := $(CUDA_HOME)/bin/nvcc
 
-GPP        := g++
+GPP        ?= g++
 CPPFLAGS   := -I$(CUDA_HOME)/include
 CXXFLAGS   := -O3 -fPIC -fvisibility=hidden
-NVCUFLAGS  := $(CUDACODE) -O3 -lineinfo -std=c++11 -maxrregcount 96
+NVCUFLAGS  := $(CUDACODE) -O3 -lineinfo -std=c++11 -maxrregcount 96 -ccbin=${GPP}
 
 ifneq ($(VERBOSE), 0)
 NVCUFLAGS += -Xptxas -v -Xcompiler -Wall,-Wextra


### PR DESCRIPTION
In CUDA 7.5 nvcc only supports up to `g++ 4.9` therefore in systems where `g++` expands to `g++-5` `-ccbin=g++-4.9` has to be provided to nvcc.

If not the compiler fails:
```
$ make
Grabbing  src/nccl.h                > build/include/nccl.h     
Compiling src/libwrap.cu            > build/obj/libwrap.o      
Compiling src/core.cu               > build/obj/core.o         
Compiling src/all_gather.cu         > build/obj/all_gather.o   
/usr/lib/gcc/x86_64-linux-gnu/5/include/mwaitxintrin.h(36): error: identifier "__builtin_ia32_monitorx" is undefined

/usr/lib/gcc/x86_64-linux-gnu/5/include/mwaitxintrin.h(42): error: identifier "__builtin_ia32_mwaitx" is undefined

2 errors detected in the compilation of "/tmp/tmpxft_00003a6e_00000000-13_all_gather.compute_52.cpp1.ii".
Makefile:101: recipe for target 'build/obj/all_gather.o' failed
make: *** [build/obj/all_gather.o] Error 2
```

With my changes you may compile using:
`GPP=g++-4.9 make CUDA_HOME=<cuda install path> test`