### PR TITLE
Add --no-as-needed to make sure that cudart library gets linked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ NVCUFLAGS += -Xptxas -v -Xcompiler -Wall,-Wextra
 CXXFLAGS  += -Wall -Wextra
 endif
 
-LDFLAGS    := -L$(CUDA_HOME)/lib64 -lcudart
+LDFLAGS    := -Wl,--no-as-needed -L$(CUDA_HOME)/lib64 -lcudart
 MPIFLAGS   := -I$(MPI_HOME)/include -L$(MPI_HOME)/lib -lmpi
 TSTINC     := -Ibuild/include -Itest/include
 


### PR DESCRIPTION
This fixes ngimel/nccl.torch#5. Apparently without this flag `libcudart.so` wasn't present in the dynamic table of `libnccl.so`, and wasn't loaded when required in torch.