### PR TITLE
Some minor fixes for compile/usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ NVCC_GENCODE ?= -gencode=arch=compute_35,code=sm_35 \
 CXXFLAGS   := -I$(CUDA_INC) -fPIC -fvisibility=hidden
 NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -lineinfo -std=c++11 -maxrregcount 96
 # Use addprefix so that we can specify more than one path
-LDFLAGS    := $(addprefix -L,${CUDA_LIB}) -lcudart
+LDFLAGS    := $(addprefix -L,${CUDA_LIB}) -lcudart -lrt
 
 ifeq ($(DEBUG), 0)
 NVCUFLAGS += -O3

--- a/src/core.cu
+++ b/src/core.cu
@@ -750,7 +750,7 @@ ncclResult_t ncclCommInitRank(ncclComm_t* newcomm, int ndev, ncclUniqueId commId
 }
 
 extern "C" DSOGLOBAL
-ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, int* devlist) {
+ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   initDebug();
 
   showVersion();

--- a/src/nccl.h
+++ b/src/nccl.h
@@ -85,7 +85,7 @@ ncclResult_t ncclCommInitRank(ncclComm_t* comm, int ndev, ncclUniqueId commId, i
  * comm should be pre-allocated with size at least ndev*sizeof(ncclComm_t).
  * If devlist is NULL, the first ndev CUDA devices are used.
  * Order of devlist defines user-order of processors within the communicator. */
-ncclResult_t ncclCommInitAll(ncclComm_t* comm, int ndev, int* devlist);
+ncclResult_t ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist);
 
 /* Frees resources associated with communicator object. */
 void ncclCommDestroy(ncclComm_t comm);


### PR DESCRIPTION
Two minor modifications are included in this PR:

1. Add `-lrt` to `LDFLAGS`. `shm_open` needs this flag, and it seems that nvcc automatically adds it; however, if one wants to link `libnccl.so` manually with other projects using `ld`, it would fail due to undefined symbol.
2. Change the type of `devlist` param in `ncclCommInitAll` from `int*` to `const int*`, since it would not be modified and the user might actually pass a `const int` pointer.