### PR TITLE
minor fixes to build on Mac OS

### DIFF
--- a/src/primitives.h
+++ b/src/primitives.h
@@ -8,9 +8,17 @@
 #define PRIMITIVES_H_
 
 #include <type_traits>
+#include <cstddef>  // for nullptr_t
 #include "copy_kernel.h" // for FuncPassA
 #include "reduce_kernel.h" // for reduction funcs
 
+#ifdef __APPLE__
+// Workaround for Mac OS: when tested on Apple clang 8.0.0 and Mac OSX 10.12
+// with cuda 8.0, the host compiler did not correctly declare nullptr_t
+// although it is specified by the C++11 standard. We thus explicitly declare
+// it here.
+typedef decltype(nullptr) nullptr_t;
+#endif  // __APPLE__
 
 /* Defines primitive operations: Copy, Reduce, DoubleCopy, and ReduceCopy.
  *


### PR DESCRIPTION
This PR tries to make NCCL build on Mac - tested on Mac OS 10.12, clang 8.0.0 and cuda 8.0.

- I changed the Makefile to make sure that on Mac ("Darwin") we set the right lib and versions.
- It seems that clang 8.0.0 has an issue with nullptr_t so we need to manually specify the type.

I haven't tested this on a Linux box, but hopefully I haven't touched anything for Linux.