### PR TITLE
fix tests on maxwell

### DIFF
--- a/test/include/test_utilities.h
+++ b/test/include/test_utilities.h
@@ -310,7 +310,7 @@ double CheckDelta(const T* results, const T* expected, int N) {
   CUDACHECK(cudaHostGetDevicePointer(&devmax, &maxerr, 0));
   deltaKern<T, 512><<<1, 512>>>(results, devexp, N, devmax);
   CUDACHECK(cudaHostUnregister(&maxerr));
-  CUDACHECK(cudaHostUnregister((void*)devexp));
+  CUDACHECK(cudaHostUnregister((void*)expected));
   return maxerr;
 }
 


### PR DESCRIPTION
Tests currently fail on Maxwell cards with driver 384.

`Cuda failure test/include/test_utilities.h:313 'invalid argument'`

cudaHostUnregister is being called on the device pointer instead of the host pointer. This works on Pascal because the two are the same, and evidently worked on Maxwell with older driver versions.