### PR TITLE
Preliminary abort mechanism and an API for querying asynchronous errors.

### DIFF
--- a/src/collectives/device/reduce_scatter.h
+++ b/src/collectives/device/reduce_scatter.h
@@ -23,8 +23,8 @@ __device__ void ncclReduceScatterKernel(struct CollectiveArgs* args) {
   struct ncclComm* comm = args->comm;
   struct ncclRing* ring = comm->rings+blockIdx.x;
 
-  WaitFlag waitDoneFromNext(ring->send.conn.head, REDUCESCATTER_BUFCHUNKS*REDUCESCATTER_SUBSTEPS);
-  WaitFlag waitReadyFromPrev(ring->recv.conn.tail, REDUCESCATTER_SUBSTEPS);
+  WaitFlag waitDoneFromNext(comm->abortFlag, ring->send.conn.head, REDUCESCATTER_BUFCHUNKS*REDUCESCATTER_SUBSTEPS);
+  WaitFlag waitReadyFromPrev(comm->abortFlag, ring->recv.conn.tail, REDUCESCATTER_SUBSTEPS);
   PostFlag postDoneToPrev(ring->recv.conn.head, REDUCESCATTER_SUBSTEPS, NULL, 0);
   PostFlag postReadyToNext(ring->send.conn.tail, 0, ring->send.conn.fifo, REDUCESCATTER_BUFCHUNKS*REDUCESCATTER_SUBSTEPS);
 
@@ -35,15 +35,16 @@ __device__ void ncclReduceScatterKernel(struct CollectiveArgs* args) {
   const int buffSize = ring->buffSize / sizeof(T);
   const int sliceSize = buffSize / REDUCESCATTER_BUFCHUNKS;
   const ssize_t loopSize = args->nRings*(ssize_t)sliceSize;
+  uint32_t shouldExit = 0;
 
   if (tid == 0) {
     // Update in case we skipped some collectives
     *ring->recv.conn.opCount = args->opCount;
     // Wait for next to be ready
-    WaitFlag waitOpCountNext(ring->send.conn.opCount, 0);
-    waitOpCountNext.wait(args->opCount);
+    WaitFlag waitOpCountNext(comm->abortFlag, ring->send.conn.opCount, 0);
+    waitOpCountNext.wait(&shouldExit, args->opCount);
   }
-  __syncthreads();
+  exitIfAbortBarrier(shouldExit);
 
   uint64_t step = 0ULL;
   int poffset, noffset = 0;
@@ -111,12 +112,13 @@ __device__ void ncclReduceScatterKernel(struct CollectiveArgs* args) {
   }
 
   if (tid == 0) {
-    waitDoneFromNext.wait(REDUCESCATTER_SUBSTEPS*(step + REDUCESCATTER_BUFCHUNKS));
+    waitDoneFromNext.wait(&shouldExit, REDUCESCATTER_SUBSTEPS*(step + REDUCESCATTER_BUFCHUNKS));
     *ring->send.conn.head = 0ULL;
     *ring->recv.conn.tail = 0ULL;
     __threadfence_system();
     *ring->recv.conn.opCount = args->opCount+1;
   }
+  exitIfAbortBarrier(shouldExit);
 }
 
 #include "ll_kernel.h"
@@ -176,6 +178,7 @@ __device__ void ncclReduceScatterLLKernel(struct CollectiveArgs* args) {
 
     WAIT_NEXT;
     LL::ReduceCopy(
+        comm->abortFlag,
         thisInput  + offset,
         nextOutput + noffset,
         maxOffset, nflag, llNthreads);
@@ -190,6 +193,7 @@ __device__ void ncclReduceScatterLLKernel(struct CollectiveArgs* args) {
 
       WAIT_NEXT;
       LL::ReduceCopy(
+          comm->abortFlag,
           thisInput  + offset,
           prevInput  + poffset,
           nextOutput + noffset,
@@ -206,6 +210,7 @@ __device__ void ncclReduceScatterLLKernel(struct CollectiveArgs* args) {
     offset = chunkOffset + rankDest * size;
 
     LL::ReduceCopy(
+        comm->abortFlag,
         thisInput  + offset,
         prevInput  + poffset,
         thisOutput + chunkOffset,

--- a/src/include/core.h
+++ b/src/include/core.h
@@ -226,6 +226,14 @@ struct ncclComm {
   int groupCudaStream;
   cudaStream_t groupStream;
 
+  // Whether there has been a fatal error on the communicator
+  ncclResult_t fatalError;
+
+  // Whether the operations enqueued on this communicator should abort
+  // On host: this pointer has been obtained from cudaHostAlloc(cudaHostAllocMapped)
+  // On device:  this pointer has been obtained from cudaHostGetDevicePointer()
+  volatile uint32_t *abortFlag;
+
   // Device copy of the communicator
   struct ncclComm *devComm;
 

--- a/src/misc/enqueue.cu
+++ b/src/misc/enqueue.cu
@@ -219,6 +219,9 @@ ncclResult_t ncclEnqueueCheck(ncclFunc_t func, const char* primName, const void*
     void* recvbuff, size_t count, ncclDataType_t type, ncclRedOp_t op, int root,
     ncclComm_t comm, cudaStream_t stream) {
   if (comm == NULL) return ncclInvalidArgument;
+  if (comm->fatalError != ncclSuccess) {
+    return ncclInvalidUsage;
+  }
   // Launch asynchronously if needed
   if (ncclAsyncMode()) {
     ncclResult_t ret = ncclSuccess;

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -68,13 +68,18 @@ ncclResult_t pncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId
 ncclResult_t  ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist);
 ncclResult_t pncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist);
 
-/* Frees resources associated with communicator object. */
+/* Frees resources associated with communicator object and aborts any operations
+ * that might still be running on the device. */
 ncclResult_t  ncclCommDestroy(ncclComm_t comm);
 ncclResult_t pncclCommDestroy(ncclComm_t comm);
 
 /* Returns a human-readable error message. */
 const char*  ncclGetErrorString(ncclResult_t result);
 const char* pncclGetErrorString(ncclResult_t result);
+
+/* Checks whether the communicator has encountered any asynchronous errors. */
+ncclResult_t  ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
+ncclResult_t pncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
 
 /* Gets the number of ranks in the communicator clique. */
 ncclResult_t  ncclCommCount(const ncclComm_t comm, int* count);

--- a/src/transport.cu
+++ b/src/transport.cu
@@ -150,6 +150,7 @@ void* persistentThread(void *opaqueInfo) {
     }
     ncclResult_t res = info->func(&args);
     if (res != ncclSuccess) {
+      info->comm->fatalError = res;
       WARN("%s:%d -> %d [Proxy thread error]", __FILE__, __LINE__, res);
     }
   }


### PR DESCRIPTION
This is a proposed infrastructure and plumbing for enabling recovery from an error condition in NCCL. Users who care about fault tolerance should familiarize themselves with two changes:

- Calling ncclCommDestroy while the collective operations are running on the GPUs will now result in the collective operations being aborted. Previously the behaviour was unspecified.

- There is a new API, ncclCommGetAsyncError which allows the user to inspect whether there have been any asynchronous errors in the communicator (e.g. due to a failing network layer). Note that the only operation that is possible on a communicator which has experienced an error is ncclCommDestroy.

Please note that this is a preliminary version of the change and some limitations apply. One known issue is that in case of an error condition, it is possible for ncclCommDestroy to hang if multiple GPUs are used per process.