### PR TITLE
use full hostname instead of just prefix

### DIFF
--- a/src/misc/utils.cu
+++ b/src/misc/utils.cu
@@ -35,7 +35,7 @@ ncclResult_t getHostName(char* hostname, int maxlen) {
     return ncclSystemError;
   }
   int i = 0;
-  while ((hostname[i] != '.') && (hostname[i] != '\0') && (i < maxlen-1)) i++;
+  while ((hostname[i] != '\0') && (i < maxlen-1)) i++;
   hostname[i] = '\0';
   return ncclSuccess;
 }


### PR DESCRIPTION
Issue: #187 
fixes the issue where nccl fails when there are hosts with same prefix in the distributed setup.

Testing:

We tested on our infrastructure where we have hostname with same prefix, the change fixes the issue.