### PR TITLE
Add the exact matching modifier support "=" to the NCCL_IB_HCA variable

### DIFF
--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -66,6 +66,7 @@ static int findInterfaces(const char* prefixList, char* names, union socketAddre
 #endif
   struct netIf userIfs[MAX_IFS];
   bool searchNot = prefixList && prefixList[0] == '^';
+  bool searchExact = prefixList && prefixList[0] == '=';
   int nUserIfs = parseStringList(prefixList, userIfs, MAX_IFS);
 
   int found = 0;
@@ -92,7 +93,7 @@ static int findInterfaces(const char* prefixList, char* names, union socketAddre
     }
 
     // check against user specified interfaces
-    if (!(matchIfList(interface->ifa_name, -1, userIfs, nUserIfs) ^ searchNot)) {
+    if (!(matchIfList(interface->ifa_name, -1, userIfs, nUserIfs, searchExact) ^ searchNot)) {
       continue;
     }
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -20,6 +20,6 @@ struct netIf {
 };
 
 int parseStringList(const char* string, struct netIf* ifList, int maxList);
-bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize);
+bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact);
 
 #endif

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -147,8 +147,8 @@ int parseStringList(const char* string, struct netIf* ifList, int maxList) {
   if (!string) return 0;
 
   const char* ptr = string;
-  // Ignore "^" prefix, will be detected outside of this function
-  if (ptr[0] == '^') ptr++;
+  // Ignore "^" or "=" prefix, will be detected outside of this function
+  if (ptr[0] == '^' || ptr[0] == '=') ptr++;
 
   int ifNum = 0;
   int ifC = 0;
@@ -177,6 +177,10 @@ int parseStringList(const char* string, struct netIf* ifList, int maxList) {
   return ifNum;
 }
 
+static bool matchIf(const char* string, const char* prefix) {
+  return (strcmp(string, prefix) == 0);
+}
+
 static bool matchPrefix(const char* string, const char* prefix) {
   return (strncmp(string, prefix, strlen(prefix)) == 0);
 }
@@ -189,14 +193,23 @@ static bool matchPort(const int port1, const int port2) {
 }
 
 
-bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize) {
+bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact) {
   // Make an exception for the case where no user list is defined
   if (listSize == 0) return true;
 
   for (int i=0; i<listSize; i++) {
-    if (matchPrefix(string, ifList[i].prefix)
-        && matchPort(port, ifList[i].port)) {
-      return true;
+    if ( matchExact ) {
+      // Exact matching
+      if (matchIf(string, ifList[i].prefix)
+          && matchPort(port, ifList[i].port)) {
+        return true;
+      }
+    } else {
+      // Prefix matching
+      if (matchPrefix(string, ifList[i].prefix)
+          && matchPort(port, ifList[i].port)) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -107,6 +107,7 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction) {
       char* userIbEnv = getenv("NCCL_IB_HCA");
       struct netIf userIfs[MAX_IB_DEVS];
       bool searchNot = userIbEnv && userIbEnv[0] == '^';
+      bool searchExact = userIbEnv && userIbEnv[0] == '=';
       int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
 
       if (ncclSuccess != wrap_ibv_get_device_list(&devices, &nIbDevs)) return ncclInternalError;
@@ -136,7 +137,7 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction) {
               && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
 
           // check against user specified HCAs/ports
-          if (! (matchIfList(devices[d]->name, port, userIfs, nUserIfs) ^ searchNot)) {
+          if (! (matchIfList(devices[d]->name, port, userIfs, nUserIfs, searchExact) ^ searchNot)) {
             continue;
           }
           TRACE(NCCL_INIT|NCCL_NET,"NET/IB: [%d] %s:%d/%s ", d, devices[d]->name, port,


### PR DESCRIPTION
This PR is to add the exact matching support with the modifier “=“ to the NCCL_IB_HCA variable in order to solve a problem with the current prefix-based matching.

Background:
We have encountered the problem that we cannot specify the exact HCAs in the NCCL_IB_HCA variable when we have more than 10 HCAs with the same prefix (e.g., `mlx5_`).

For example, assuming we have `mlx5_1` and `mlx5_11`, and try to use only `mlx5_1`, we may set the variable as `NCCL_IB_HCA=“mlx5_1:1”`.  However, `mlx5_1:1` breaks down into interface `mlx5_1` and port `1` by `parseStringList()`.  Then,  `mlx5_1` is matched as a prefix, and consequently, it matches `mlx5_11` as well as `mlx5_1`.

I understand that this behavior is as-is documented, but we would like to specify the exact name of the interfaces in the NCCL_IB_HCA variable.


Summary:
This PR adds a new modifier “=“ to the NCCL_IB_HCA and NCCL_SOCKET_IFNAME variables, and passes the information to the `matchIfList()` function (through the `exactMach` bool argument) .  When this modifier is specified, exact matching `matchIf()` is performed rather than the original prefix matching `matchPrefix()` in the `matchIfList()` function.

The modifier is allowed to be specified at the beginning of the variables with the same way as the “^” modifier.  Therefore, this modifier cannot be used with the “^” modifier.
Note that we haven’t made any modifications to the rest of the variables for backward compatibility.