### PR TITLE
Refine RPM package building spec file.

### DIFF
--- a/pkg/redhat/nccl.spec.in
+++ b/pkg/redhat/nccl.spec.in
@@ -7,6 +7,7 @@ Group:          Development/Libraries
 License:        BSD
 URL:            http://developer.nvidia.com/nccl
 Source0:        nccl_${nccl:Major}.${nccl:Minor}.${nccl:Patch}${nccl:Suffix}-${pkg:Revision}+cuda${cuda:Major}.${cuda:Minor}_${pkg:Arch}.txz
+Prereq:         /sbin/ldconfig
 
 %description
 NCCL (pronounced "Nickel") is a stand-alone library of standard collective
@@ -49,6 +50,12 @@ ln -s libnccl.so.${nccl:Major} $RPM_BUILD_ROOT/%{_libdir}/libnccl.so
 
 # static
 install -m 644 lib/libnccl_static.a $RPM_BUILD_ROOT/%{_libdir}
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%post devel -p /sbin/ldconfig
+%postun devel -p /sbin/ldconfig
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Add /sbin/ldconfig into RPM package install operations.

NCCL RPM packages built with current spec file would not update the ldconfig cache.

When building TensorFlow from source, its 'configure.py' script would try to find NCCL library installation path automatically by searching ldconfig cache. This search would fail if we only installed the NCCL RPMs, thus NCCL installation path needs to be explicitly set.

This commit try to make a improvement by adding the post-installation ldconfig run into the RPM build spec.
