### PR TITLE
Rework the P2P/IPC/SHM container fix

### DIFF
--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -27,6 +27,7 @@ struct ncclPeerInfo {
   int nvmlDev;
   uint64_t hostHash;
   uint64_t pidHash;
+  dev_t shmDev;
   char busId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
 };
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -315,6 +315,13 @@ static ncclResult_t fillInfo(struct ncclPeerInfo* info, int rank, uint64_t commH
   info->hostHash=getHostHash()+commHash;
   info->pidHash=getPidHash()+commHash;
 
+  // Get the device MAJOR:MINOR of /dev/shm so we can use that
+  // information to decide whether we can use SHM for inter-process
+  // communication in a container environment
+  struct stat statbuf;
+  SYSCHECK(stat("/dev/shm", &statbuf), "stat");
+  info->shmDev = statbuf.st_dev;
+
   // Get PCI Bus Id. We need to get the bus ID through CUDA first, since the
   // cudaDev is a CUDA runtime dev number which could be different from the
   // NVML device number. Then we get the busID from NVML to be sure it is

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -61,6 +61,7 @@ ncclResult_t p2pCanConnect(ncclTvalue_t* ret, struct ncclPeerInfo* myInfo, struc
   if (ncclParamP2pDisable() == 1) p2pLevel = 0;
   if (ncclParamP2pLevel() != -2) p2pLevel = ncclParamP2pLevel();
 
+  // Disable P2P
   *ret = 0;
 
   if (p2pLevel == 0) return ncclSuccess;


### PR DESCRIPTION
Fixes: #155

Now we use /proc/sys/kernel/random/boot_id instead of the
hostname and NS uts,mnt info
A new env var; NCCL_HOSTID can be used to overload this string.