### PR TITLE
Allow choice of CUDA host compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ If CUDA is not installed in the default /usr/local/cuda path, you can define the
 $ make src.build CUDA_HOME=<path to cuda install>
 ```
 
+If you wish to use a different host C++ compiler, you can define it with:
+
+```shell
+$ make src.build CUDAHOSTCXX=<path to c++ compiler binary>
+```
+
 NCCL will be compiled and installed in `build/` unless `BUILDDIR` is set.
 
 By default, NCCL is compiled for all supported architectures. To accelerate the compilation and reduce the binary size, consider redefining `NVCC_GENCODE` (defined in `makefiles/common.mk`) to only include the architecture of the target platform :

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -13,6 +13,7 @@ TRACE ?= 0
 PROFAPI ?= 0
 
 NVCC = $(CUDA_HOME)/bin/nvcc
+CUDAHOSTCXX ?= $(CXX)
 
 CUDA_LIB ?= $(CUDA_HOME)/lib64
 CUDA_INC ?= $(CUDA_HOME)/include
@@ -48,7 +49,7 @@ CXXFLAGS   += -I $(CUDA_INC)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60
 # We would not have to set this if we used __launch_bounds__, but this only works on kernels, not on functions.
-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -std=c++11 -Xptxas -maxrregcount=96 -Xfatbin -compress-all
+NVCUFLAGS  := -ccbin $(CUDAHOSTCXX) $(NVCC_GENCODE) -std=c++11 -Xptxas -maxrregcount=96 -Xfatbin -compress-all
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt
 


### PR DESCRIPTION
Due to the hard restrictions on compiler versions imposed by CUDA, many application provide a configuration option to instruct NVCC to use a non-default C++ compiler. This branch adds a Make variable `CUDAHOSTCXX` which can be set for that purpose. The name is a common choice, used by CMake and PyTorch for example.