### PR TITLE
Allow specifying a different network plugin.

### DIFF
--- a/src/include/param.h
+++ b/src/include/param.h
@@ -77,4 +77,24 @@ int64_t ncclParam##name() { \
   return value; \
 }
 
+
+// Returns a pointer to NULL-terminated static string.
+#define NCCL_STR_PARAM(name, env, default_value) \
+pthread_mutex_t ncclParamMutex##name = PTHREAD_MUTEX_INITIALIZER; \
+char* ncclParam##name() { \
+  static_assert(default_value != NULL, "default value cannot be NULL"); \
+  static char* value = NULL; \
+  pthread_mutex_lock(&ncclParamMutex##name); \
+  if (value == NULL) { \
+    value = default_value; \
+    char* str = secure_getenv("NCCL_" env); \
+    if (str != NULL) { \
+      value = str; \
+      INFO(NCCL_ALL,"%s set by environment to %lu.", "NCCL_" env, value);  \
+    } \
+  } \
+  pthread_mutex_unlock(&ncclParamMutex##name); \
+  return value; \
+}
+
 #endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -41,6 +41,8 @@ NCCL_PARAM(GroupCudaStream, "GROUP_CUDA_STREAM", NCCL_GROUP_CUDA_STREAM);
 
 NCCL_PARAM(CheckPointers, "CHECK_POINTERS", 0);
 
+NCCL_STR_PARAM(NetPluginName, "NET_PLUGIN_NAME", "libnccl-net.so");
+
 ncclNet_t* ncclNet = NULL;
 ncclCollNet_t* ncclCollNet = NULL;
 
@@ -62,7 +64,9 @@ ncclResult_t initCollNet(ncclCollNet_t* collnet) {
 }
 
 ncclResult_t initNetPlugin(ncclNet_t** net, ncclCollNet_t** collnet) {
-  void* netPluginLib = dlopen("libnccl-net.so", RTLD_NOW | RTLD_LOCAL);
+  void* netPluginLib = dlopen(
+      strlen(ncclParamNetPluginName()) == 0 ?  NULL : ncclParamNetPluginName(),
+      RTLD_NOW | RTLD_LOCAL);
   if (netPluginLib == NULL) {
     // dlopen does not guarantee to set errno, but dlerror only gives us a
     // string, so checking errno doesn't hurt to try to provide a better


### PR DESCRIPTION
For this we introduce a new mechanism for specifying string NCCL
parameters and change the name of the library where dlopen happens.

We also introduce a special behavior when passed an empty plugin name,
namely loading the plugin from the same executable that is running NCCL.
This is useful for the cases where the plugin and NCCL are statically
linked in the same binary. This is achieved by passing NCCL to dlopen,
which will cause it to return a handle to the main program.