### PR TITLE
Extend network plugin to support allocations.

### DIFF
--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -10,12 +10,21 @@
 #include "nccl.h"
 #include "checks.h"
 #include "align.h"
+#include "net.h"
 #include <sys/mman.h>
 
 static inline ncclResult_t ncclCudaHostAlloc(void** ptr, void** devPtr, size_t size) {
   CUDACHECK(cudaHostAlloc(ptr, size, cudaHostAllocMapped));
   memset(*ptr, 0, size);
   *devPtr = *ptr;
+  return ncclSuccess;
+}
+
+static inline ncclResult_t ncclNetworkAlloc(
+    void* comm, int size, int type, void** data, void** devPtr, void** mhandle) {
+  NCCLCHECK(ncclNetAlloc(comm, data, size, type, mhandle));
+  memset(*data, 0, size);
+  if (*devPtr != nullptr) *devPtr = *data;
   return ncclSuccess;
 }
 

--- a/src/include/nccl_net.h
+++ b/src/include/nccl_net.h
@@ -70,6 +70,14 @@ typedef struct {
   ncclResult_t (*closeSend)(void* sendComm);
   ncclResult_t (*closeRecv)(void* recvComm);
   ncclResult_t (*closeListen)(void* listenComm);
+  // Allocates a host buffer to the used by the net subsystem, either allocated
+  // or registed through CUDA for host memory - For more details, refer to
+  // cudaHostRegister(). The plugin can keep track of allocation-related
+  // information by via mhandle.
+  // If this is is being used, regMR and deregMr must be set to NULL.
+  ncclResult_t (*alloc)(void* comm, int size, int type, void** data, void** mhandle);
+  // Frees the buffer identified by mhandle.
+  ncclResult_t (*free)(void* comm,  void* mhandle);
 } ncclNet_v3_t;
 
 typedef ncclNet_v3_t ncclNet_t;

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -20,6 +20,9 @@ static ncclResult_t ncclNetGetProperties(int dev, ncclNetProperties_t* props) { 
 static ncclResult_t ncclNetListen(int dev, void* handle, void** listenComm) { NCCLCHECK(ncclNet->listen(dev, handle, listenComm)); return ncclSuccess; }
 static ncclResult_t ncclNetConnect(int dev, void* handle, void** sendComm) { NCCLCHECK(ncclNet->connect(dev, handle, sendComm)); return ncclSuccess; }
 static ncclResult_t ncclNetAccept(void* listenComm, void** recvComm) { NCCLCHECK(ncclNet->accept(listenComm, recvComm)); return ncclSuccess; }
+static bool ncclUsePluginAlloc() { return (void*) ncclNet->regMr == nullptr; }
+static ncclResult_t ncclNetAlloc(void* comm, void** data, int size, int type, void** mhandle) { NCCLCHECK(ncclNet->regMr(comm, data, size, type, mhandle)); return ncclSuccess; }
+static ncclResult_t ncclNetFree(void* comm, void* mhandle) { NCCLCHECK(ncclNet->deregMr(comm, mhandle)); return ncclSuccess; }
 static ncclResult_t ncclNetRegMr(void* comm, void* data, int size, int type, void** mhandle) { NCCLCHECK(ncclNet->regMr(comm, data, size, type, mhandle)); return ncclSuccess; }
 static ncclResult_t ncclNetDeregMr(void* comm, void* mhandle) { NCCLCHECK(ncclNet->deregMr(comm, mhandle)); return ncclSuccess; }
 static ncclResult_t ncclNetIsend(void* sendComm, void* data, int size, void* mhandle, void** request) { NCCLCHECK(ncclNet->isend(sendComm, data, size, mhandle, request)); return ncclSuccess; }


### PR DESCRIPTION
Implement Alloc/Free functions to give more control over the memory
being allocated to the memory plugins, as discussed on https://github.com/NVIDIA/nccl/issues/309

These new functions are unsed instead of the memory registration
functions, so I decided to make these changes backwards-compatible by
requiring that plugins using the alloc/free calls set the reg/unreg
field to NULL.

The memory returned by alloc/free have some requirements, which are
documented in nccl_net.h.