### PR TITLE
Adding sm_75 support to the makefile for Turing

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -30,15 +30,20 @@ CUDA8_GENCODE = -gencode=arch=compute_35,code=sm_35 \
                 -gencode=arch=compute_60,code=sm_60 \
                 -gencode=arch=compute_61,code=sm_61
 CUDA9_GENCODE = -gencode=arch=compute_70,code=sm_70
+CUDA10_GENCODE = -gencode=arch=compute_75,code=sm_75
 CUDA11_GENCODE = -gencode=arch=compute_80,code=sm_80
 
 CUDA8_PTX     = -gencode=arch=compute_61,code=compute_61
 CUDA9_PTX     = -gencode=arch=compute_70,code=compute_70
+CUDA10_PTX     = -gencode=arch=compute_75,code=compute_75
 CUDA11_PTX    = -gencode=arch=compute_80,code=compute_80
 
 # Include Ampere support if we're using CUDA11 or above
 ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 11; echo $$?),0)
   NVCC_GENCODE ?= $(CUDA8_GENCODE) $(CUDA9_GENCODE) $(CUDA9_PTX) $(CUDA11_GENCODE) $(CUDA11_PTX)
+# Include Turing support if we're using CUDA10 or above
+else ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 10; echo $$?),0)
+  NVCC_GENCODE ?= $(CUDA8_GENCODE) $(CUDA9_GENCODE) $(CUDA9_PTX) $(CUDA10_GENCODE) $(CUDA10_PTX)
 # Include Volta support if we're using CUDA9 or above
 else ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 9; echo $$?),0)
   NVCC_GENCODE ?= $(CUDA8_GENCODE) $(CUDA9_GENCODE) $(CUDA9_PTX)


### PR DESCRIPTION
Noticed that there was no sm_75 support added in the makefile which is for Turing. Technically it should be fine with sm_70 but adding sm_75 support for Turing optimized SASS. 
Was there a specific reason for not adding sm_75? 