### PR TITLE
[Cleanup] Remove unused computation on basePath

### DIFF
--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -39,11 +39,6 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
   struct ncclTopoNodeList nextNodeList;
   nodeList.count = 1; nodeList.list[0] = baseNode;
   nextNodeList.count = 0;
-  struct ncclTopoLinkList* basePath;
-  NCCLCHECK(getPath(system, baseNode, baseNode->type, baseNode->id, &basePath));
-  basePath->count = 0;
-  basePath->width = LOC_WIDTH;
-  basePath->type = PATH_LOC;
 
   while (nodeList.count) {
     nextNodeList.count = 0;


### PR DESCRIPTION
In paths.cc, there's a `getPath` from `baseNode`, but the computed `basePath` is never used.

So I removed these lines of code to avoid useless computations.