### PR TITLE
add ncclCommMarkAbort api in convienence of upper ai system controller

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1026,6 +1026,15 @@ ncclResult_t ncclCommAbort(ncclComm_t comm) {
   return commDestroy(comm);
 }
 
+NCCL_API(ncclResult_t, ncclCommMarkAbort, ncclComm_t comm);
+ncclResult_t ncclCommMarkAbort(ncclComm_t comm) {
+  NVTX3_FUNC_RANGE_IN(nccl_domain);
+  if (comm == NULL)
+    return ncclSuccess;
+  *comm->abortFlag = 1;
+  return ncclSuccess;
+}
+
 NCCL_API(const char*, ncclGetErrorString, ncclResult_t code);
 const char* ncclGetErrorString(ncclResult_t code) {
   switch (code) {

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -81,6 +81,11 @@ ncclResult_t pncclCommDestroy(ncclComm_t comm);
 ncclResult_t  ncclCommAbort(ncclComm_t comm);
 ncclResult_t pncclCommAbort(ncclComm_t comm);
 
+/* Mark communicator object as abort and thus related operations will as well be
+   aborted. Should later call ncclCommDestroy or ncclCommAbort to free resources. */
+ncclResult_t ncclCommMarkAbort(ncclComm_t comm);
+ncclResult_t pncclCommMarkAbort(ncclComm_t comm);
+
 /* Returns a human-readable error message. */
 const char*  ncclGetErrorString(ncclResult_t result);
 const char* pncclGetErrorString(ncclResult_t result);


### PR DESCRIPTION
as [issue 279](https://github.com/NVIDIA/nccl/issues/279)  and [issue 549](https://github.com/NVIDIA/nccl/issues/549) discussed, it's up to upper ai system controller to handle error when some rank losts.

it 's common for upper ai system controller to call ncclCommAbort to  abort communicator related operations when rank lost situation is detected.
however, in system  where multiple nccl communicators get involved, say horovod with HOROVOD_NUM_NCCL_STREAMS set to above 1, when lost rank is detected,  trying to abort or destroy all these communicators will cause system hang. It's due to cuda implicit synchronization. 
Image a scenario with 2 communicator (say A,B), system tries to abort all nccl communicators in sequence of A,B. If cuda kernel related to communicator B keeps running and won't exit until abort is detected while controller try to free communicator A(cudaFree involved), deadlock is met. 

mark all communicator as aborted and give up all operations first, and release related resources later can avoid above problem.