### PR TITLE
Build fastsocket plugin from ext-net

### DIFF
--- a/ext-net/google-fastsocket/Makefile
+++ b/ext-net/google-fastsocket/Makefile
@@ -1,0 +1,22 @@
+CUDA_HOME?=/usr/local/cuda
+INC:=-I$(CUDA_HOME)/include
+PLUGIN_SO:=../../build/libnccl-net.so
+
+default: $(PLUGIN_SO)
+
+$(PLUGIN_SO): nccl-fastsocket/net_fastsocket.cc nccl-fastsocket/compat.cc
+	$(CC) $(INC) -fPIC -shared -o $@ -Wl,-soname,$(PLUGIN_SO) $^
+
+nccl-fastsocket/%.cc:
+	git clone https://github.com/google/nccl-fastsocket.git
+
+install: $(BUILDDIR)/lib/$(PLUGIN_SO)
+
+$(BUILDDIR)/lib/$(PLUGIN_SO): $(PLUGIN_SO)
+	@printf "Grabbing %-35s > %s\n" $< $@
+	mkdir -p $(BUILDDIR)/lib
+	install -m 644 $< $@
+
+clean:
+	rm -f $(PLUGIN_SO)
+	rm -Rf nccl-fastsocket


### PR DESCRIPTION
Adding a `Makefile` to build the https://github.com/google/nccl-fastsocket plugin from NCCL. 

Example:
```
$ make -C ext-net/google-fastsocket/ 
make: Entering directory '~/nccl/ext-net/google-fastsocket'
git clone https://github.com/google/nccl-fastsocket.git
Cloning into 'nccl-fastsocket'...
remote: Enumerating objects: 40, done.
remote: Counting objects: 100% (40/40), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 40 (delta 18), reused 34 (delta 12), pack-reused 0
Receiving objects: 100% (40/40), 29.70 KiB | 9.90 MiB/s, done.
Resolving deltas: 100% (18/18), done.
cc -I/usr/local/cuda/include -fPIC -shared -o ../../build/libnccl-net.so -Wl,-soname,../../build/libnccl-net.so nccl-fastsocket/net_fastsocket.cc nccl-fastsocket/compat.cc
make: Leaving directory '~/nccl/ext-net/google-fastsocket'
```