### PR TITLE
SM-efficient Tree algorithm

### DIFF
--- a/makefiles/version.mk
+++ b/makefiles/version.mk
@@ -1,6 +1,6 @@
 ##### version
 NCCL_MAJOR   := 2
 NCCL_MINOR   := 11
-NCCL_PATCH   := 4
-NCCL_SUFFIX  :=
+NCCL_PATCH   := 5
+NCCL_SUFFIX  := dtree
 PKG_REVISION := 1

--- a/src/collectives/device/all_reduce.h
+++ b/src/collectives/device/all_reduce.h
@@ -96,11 +96,13 @@ namespace {
 
   template<typename T, typename RedOp, typename Proto>
   __device__ __forceinline__ void runTreeUpDown(ncclWorkElem *args) {
-    const int tid = threadIdx.x;
-    const int nthreads = args->nThreads;
-    const int bid = args->coll.bid;
-    const int nChannels = args->coll.nChannels;
-    ncclTree *tree = &ncclShmem.channel.tree;
+    int tid = threadIdx.x;
+    const int nthreads = args->nThreads / NTREES;
+    const int nChannels = args->coll.nChannels * NTREES;
+    const int treeId = tid / nthreads;
+    const int bid = args->coll.bid * NTREES + treeId;
+    ncclTree *tree = ncclShmem.channel.tree + treeId;
+    tid = tid % nthreads;
     ssize_t chunkSize = int(
       Proto::Id == NCCL_PROTO_SIMPLE ? args->coll.lastChunkSize
                    /* LL & LL128 */  : Proto::calcBytePerStep()/sizeof(T));
@@ -113,9 +115,10 @@ namespace {
     if (loopSize > size)
       chunkSize = divUp((int)size, int(nChannels*minChunkSize))*int(minChunkSize);
 
+    int group = (treeId*Proto::MaxGroupWidth) | (treeId<<16);
     { // Reduce : max number of recv is 3, max number of send is 1 (binary tree + local)
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/0, Proto> prims
-        (tid, nthreads, tree->down, &tree->up, args->sendbuff, args->recvbuff, args->coll.redOpArg);
+        (tid, nthreads, tree->down, &tree->up, args->sendbuff, args->recvbuff, args->coll.redOpArg, group);
       if (tree->up == -1) {
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid*int(chunkSize);
@@ -141,7 +144,7 @@ namespace {
 
     { // Broadcast : max number of recv is 1, max number of send is 3 (binary tree + local)
       Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto> prims
-        (tid, nthreads, &tree->up, tree->down, args->sendbuff, args->recvbuff, args->coll.redOpArg);
+        (tid, nthreads, &tree->up, tree->down, args->sendbuff, args->recvbuff, args->coll.redOpArg, group);
       if (tree->up == -1) {
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid*int(chunkSize);
@@ -168,11 +171,13 @@ namespace {
 
   template<typename T, typename RedOp, typename Proto>
   __device__ __forceinline__ void runTreeSplit(ncclWorkElem *args) {
-    const int tid = threadIdx.x;
-    const int nthreads = args->nThreads;
-    const int bid = args->coll.bid;
-    const int nChannels = args->coll.nChannels;
-    ncclTree *tree = &ncclShmem.channel.tree;
+    int tid = threadIdx.x;
+    const int nthreads = args->nThreads / NTREES;
+    const int nChannels = args->coll.nChannels * NTREES;
+    const int treeId = tid / nthreads;
+    const int bid = args->coll.bid * NTREES + treeId;
+    ncclTree *tree = ncclShmem.channel.tree + treeId;
+    tid = tid % nthreads;
     ssize_t chunkSize = int(
       Proto::Id != NCCL_PROTO_LL ? args->coll.lastChunkSize
                                  : Proto::calcBytePerStep()/sizeof(T));
@@ -185,8 +190,8 @@ namespace {
 
     int nthreadsSplit;
     if (Proto::Id == NCCL_PROTO_SIMPLE) {
-      nthreadsSplit = nthreads/2;
-      if (nthreadsSplit >= 256) nthreadsSplit += 64;
+      nthreadsSplit = alignUp(nthreads/2, WARP_SIZE);
+      if (nthreads-nthreadsSplit >= 128) nthreadsSplit += WARP_SIZE;
     } else { // LL & LL128
       // Receiving from up to 3 sources is more compute intensive than sending
       // to 3 dests. Use 70% for reduce and 30% for bcast.
@@ -198,8 +203,9 @@ namespace {
 
     if (tree->up == -1) {
       // Reduce and broadcast. Max number of recv is 3, max number of send is 3
+      const int group = (2*treeId*Proto::MaxGroupWidth) | (treeId<<16);
       Primitives<T, RedOp, FanSymmetric<NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto>
-        prims(tid, nthreads, tree->down, tree->down, args->sendbuff, args->recvbuff, args->coll.redOpArg);
+        prims(tid, nthreads, tree->down, tree->down, args->sendbuff, args->recvbuff, args->coll.redOpArg, group);
       for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
         ssize_t offset = gridOffset + bid*int(chunkSize);
         int nelem = min(chunkSize, size-offset);
@@ -215,8 +221,9 @@ namespace {
        * into DirectRecv and DirectSend capabilities, this ctor would have both=0,
        * but the ctor above for tree roots would be DirectRecv=0 DirectSend=1.
        */
+      const int group = (2*treeId*Proto::MaxGroupWidth) | (treeId<<16);
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto>
-        prims(tid, nthreadsSplit, tree->down, &tree->up, args->sendbuff, args->recvbuff, args->coll.redOpArg, 0*Proto::MaxGroupWidth);
+        prims(tid, nthreadsSplit, tree->down, &tree->up, args->sendbuff, args->recvbuff, args->coll.redOpArg, group);
       if (tree->down[0] == -1) {
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid*int(chunkSize);
@@ -234,8 +241,9 @@ namespace {
     }
     else {
       // Broadcast down. Max number of recv is 1, max number of send is 3 (binary tree + local)
+      const int group = ((2*treeId+1)*Proto::MaxGroupWidth) | (treeId<<16);
       Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto>
-        prims(tid-nthreadsSplit, nthreads-nthreadsSplit, &tree->up, tree->down, args->sendbuff, args->recvbuff, args->coll.redOpArg, 1*Proto::MaxGroupWidth);
+        prims(tid-nthreadsSplit, nthreads-nthreadsSplit, &tree->up, tree->down, args->sendbuff, args->recvbuff, args->coll.redOpArg, group);
       if (tree->down[0] == -1) {
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid*int(chunkSize);

--- a/src/collectives/device/prims_ll.h
+++ b/src/collectives/device/prims_ll.h
@@ -321,16 +321,16 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL>:
     redOp(redOpArg),
     tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), group(group),
     stepLines(ncclShmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/sizeof(ncclLLFifoLine)) {
+    int connIndex = group >> 16;
 
     auto *channel = &ncclShmem.channel;
-    // If we are going to support oneshot collNet + LL, then we would need to add connector index here
     int nrecv=0, nsend=0;
     while (nrecv < MaxRecv && recvPeers[nrecv] >= 0) {
-      loadRecvConn(&channel->devPeers[recvPeers[nrecv]].recv->conn, nrecv);
+      loadRecvConn(&channel->devPeers[recvPeers[nrecv]].recv[connIndex].conn, nrecv);
       nrecv++;
     }
     while (nsend < MaxSend && sendPeers[nsend] >= 0) {
-      loadSendConn(&channel->devPeers[sendPeers[nsend]].send->conn, nsend);
+      loadSendConn(&channel->devPeers[sendPeers[nsend]].send[connIndex].conn, nsend);
       nsend++;
     }
     this->fan = Fan(nrecv, nsend);

--- a/src/collectives/device/prims_ll128.h
+++ b/src/collectives/device/prims_ll128.h
@@ -360,15 +360,16 @@ public:
     tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), warp(tid/WARP_SIZE),
     flagThread((tid%8)==7), group(group),
     stepSize(ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)) {
+    int connIndex = group >> 16;
 
     auto *channel = &ncclShmem.channel;
     int nrecv=0, nsend=0;
     while (nrecv < MaxRecv && recvPeers[nrecv] >= 0) {
-      loadRecvConn(&channel->devPeers[recvPeers[nrecv]].recv->conn, nrecv);
+      loadRecvConn(&channel->devPeers[recvPeers[nrecv]].recv[connIndex].conn, nrecv);
       nrecv++;
     }
     while (nsend < MaxSend && sendPeers[nsend] >= 0) {
-      loadSendConn(&channel->devPeers[sendPeers[nsend]].send->conn, nsend);
+      loadSendConn(&channel->devPeers[sendPeers[nsend]].send[connIndex].conn, nsend);
       nsend++;
     }
     this->fan = Fan(nrecv, nsend);

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -441,21 +441,24 @@ static ncclResult_t getAlgoInfo(struct ncclInfo* info, int collNetTypeSupport, i
   int nc = (info->nChannels > 0) ? info->nChannels : comm->nChannels;
   int nt = comm->maxThreads[info->algorithm][info->protocol];
   int threadThreshold = comm->threadThresholds[info->algorithm][info->protocol];
+  int channelFactor = comm->channelFactors[info->algorithm];
   if (info->algorithm == NCCL_ALGO_COLLNET) {
     // CollNet channel tuning
     int ncSwitch = 16;
     bool flag = true;
     while (ncSwitch >= 1 && flag) {
-      while ((flag = info->nBytes < nc*nt*info->comm->channels[0].collTree.nHeads*threadThreshold) && nc > ncSwitch) {
-        if (nc == ncSwitch+ncSwitch/2) threadThreshold /= 2;
+      while ((flag = info->nBytes < nc*nt*info->comm->channels[0].collTree.nHeads*threadThreshold*channelFactor)
+          && nc > ncSwitch) {
+        if (nc == ncSwitch+ncSwitch/2) channelFactor /= 2;
         nc--;
       }
       ncSwitch /= 2;
     }
   } else {
     // Ring/Tree channel tuning
-    while (info->nBytes < nc*nt*threadThreshold) {
+    while (info->nBytes < nc*nt*threadThreshold*channelFactor) {
       if (nc >= 2) nc--;
+      else if (channelFactor >= 2) channelFactor/=2;  // lower channel factor before reducing threads
       else if ((nt % 128) == 0) nt/=2;
       else break;
     }

--- a/src/graph/connect.cc
+++ b/src/graph/connect.cc
@@ -23,8 +23,8 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm,
   for (int c=0; c<nChannels; c++) {
     struct ncclChannel* channel = comm->channels+c;
     channel->ring.prev = channel->ring.next = -1;
-    channel->tree.up = -1;
-    for (int i=0; i<NCCL_MAX_TREE_ARITY; i++) channel->tree.down[i] = -1;
+    channel->tree[0].up = channel->tree[1].up = -1;
+    for (int i=0; i<NCCL_MAX_TREE_ARITY; i++) channel->tree[0].down[i] = channel->tree[1].down[i] = -1;
     channel->collTree.out = -1;
     channel->collTree.headRank = -1;
     channel->collTree.nHeads = 0;
@@ -50,8 +50,8 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm,
         topoRanks->treeToParent[c] = treeIntra[parentIndex];
         topoRanks->treeToChild0[c] = treeIntra[child0Index];
         topoRanks->treeToChild1[c] = treeIntra[child1Index];
-        channel->tree.up         = i == 0 ? -1 : treeIntra[i-1];
-        channel->tree.down[0]    = i == localRanks-1 ? -1 : treeIntra[i+1];
+        channel->tree[0].up = channel->tree[1].up = i == 0 ? -1 : treeIntra[i-1];
+        channel->tree[0].down[0] = channel->tree[1].down[0] = i == localRanks-1 ? -1 : treeIntra[i+1];
       }
     }
     topoRanks->ringPrev[c] = channel->ring.prev;
@@ -139,24 +139,26 @@ static ncclResult_t connectTrees(struct ncclComm* comm, int* treeToParent, int* 
      NCCLCHECK(getIndexes(treeToChild0+c*comm->nRanks, ranksToChild0, nNodes, firstRanks));
      NCCLCHECK(getIndexes(treeToChild1+c*comm->nRanks, ranksToChild1, nNodes, firstRanks));
      if (comm->rank == ranksToParent[node]) {
-       NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ranksToChild0 : ranksToChild1, t0u));
-       NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ranksToChild0 : ranksToChild1, t1u));
+       NCCLCHECK(setTreeUp(channel0->tree+0, t0ChildType == 0 ? ranksToChild0 : ranksToChild1, t0u));
+       NCCLCHECK(setTreeUp(channel0->tree+1, t1ChildType == 0 ? ranksToChild0 : ranksToChild1, t1u));
      }
      if (comm->rank == ranksToChild0[node]) {
-       NCCLCHECK(setTreeDown(&channel0->tree, ranksToParent, t0d0));
-       NCCLCHECK(setTreeDown(&channel1->tree, ranksToParent, t1d0));
+       NCCLCHECK(setTreeDown(channel0->tree+0, ranksToParent, t0d0));
+       NCCLCHECK(setTreeDown(channel0->tree+1, ranksToParent, t1d0));
      }
      if (comm->rank == ranksToChild1[node]) {
-       NCCLCHECK(setTreeDown(&channel0->tree, ranksToParent, t0d1));
-       NCCLCHECK(setTreeDown(&channel1->tree, ranksToParent, t1d1));
+       NCCLCHECK(setTreeDown(channel0->tree+0, ranksToParent, t0d1));
+       NCCLCHECK(setTreeDown(channel0->tree+1, ranksToParent, t1d1));
      }
      if (comm->rank == ranksToParent[node] ||
          comm->rank == ranksToChild0[node] ||
          comm->rank == ranksToChild1[node]) {
-       INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c,           channel0->tree.up, comm->rank, channel0->tree.down[0], channel0->tree.down[1], channel0->tree.down[2]);
-       INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c+nChannels, channel1->tree.up, comm->rank, channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
+       INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c,           channel0->tree[0].up, comm->rank, channel0->tree[0].down[0], channel0->tree[0].down[1], channel0->tree[0].down[2]);
+       INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c+nChannels, channel0->tree[1].up, comm->rank, channel0->tree[1].down[0], channel0->tree[1].down[1], channel0->tree[1].down[2]);
      }
-     channel0->tree.depth = channel1->tree.depth = depth;
+     channel0->tree[0].depth = channel0->tree[1].depth = depth;
+     // Duplicate both tree0 and tree1 to the mirroring channel
+     memcpy(channel1->tree, channel0->tree, 2*sizeof(struct ncclTree));
   }
   free(ranksToParent);
   free(ranksToChild0);

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -141,6 +141,9 @@ struct ncclComm {
   float latencies[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
   float bandwidths[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
   int maxThreads[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+  // Parallelism factor for tuning number of channels used at run time
+  // e.g. for tree algorithm: 1 or 2 (NTREES)
+  int channelFactors[NCCL_NUM_ALGORITHMS];
 
   // An internal CUDA stream for NCCL kernel CGMD launches
   int groupCudaStream;

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -204,11 +204,12 @@ struct ncclWork {
   };
 };
 
+#define NTREES 2
 struct ncclChannel {
   union {
     struct {
       struct ncclRing ring;
-      struct ncclTree tree;
+      struct ncclTree tree[NTREES];
       struct ncclDirect collTree;
 
       int id;

--- a/src/init.cc
+++ b/src/init.cc
@@ -774,7 +774,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, ncclUniqueId* comm
   char line[1024];
   line[0]='\0';
   for (int c=0; c<comm->nChannels; c++) {
-    struct ncclTree* tree = &comm->channels[c].tree;
+    struct ncclTree* tree = &comm->channels[c].tree[0];
     snprintf(line+strlen(line), 1023-strlen(line), " [%d] %d/%d/%d->%d->%d",
         c, tree->down[0], tree->down[1], tree->down[2], rank, tree->up);
     INFO(NCCL_GRAPH, "Ring %02d : %d -> %d -> %d", c, comm->channels[c].ring.prev, comm->rank, comm->channels[c].ring.next);
@@ -806,14 +806,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, ncclUniqueId* comm
   INFO(NCCL_INIT, "Connected all rings");
 
   // Connect Trees
-  for (int c=0; c<comm->nChannels; c++) {
-    struct ncclChannel* channel = comm->channels+c;
-    if (comm->nRanks == 1) continue;
-    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, channel, NCCL_MAX_TREE_ARITY, channel->tree.down, 1, &channel->tree.up, 0), ret, affinity_restore);
-    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, channel, 1, &channel->tree.up, NCCL_MAX_TREE_ARITY, channel->tree.down, 0), ret, affinity_restore);
+  for (int t=0; t<NTREES; t++) { // Connect both trees in a channel
+    for (int c=0; c<comm->nChannels; c++) {
+      struct ncclChannel* channel = comm->channels+c;
+      if (comm->nRanks == 1) continue;
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, channel, NCCL_MAX_TREE_ARITY, channel->tree[t].down, 1, &channel->tree[t].up, t), ret, affinity_restore);
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, channel, 1, &channel->tree[t].up, NCCL_MAX_TREE_ARITY, channel->tree[t].down, t), ret, affinity_restore);
+    }
+    NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &treeGraph, t), ret, affinity_restore);
   }
-  NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &treeGraph, 0), ret, affinity_restore);
-  INFO(NCCL_INIT, "Connected all trees");
+  INFO(NCCL_INIT, "Connected all double trees");
 
   // Check if we can setup CollNet
   if (comm->collNetSupport > 0) {

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -223,15 +223,19 @@ ncclResult_t ncclProxySaveColl(struct ncclProxyArgs* args, int nranks) {
   }
   if (pattern == ncclPatternTreeUp || pattern == ncclPatternTreeUpDown) {
     // Tree up
-    struct ncclTree* tree = &channel->tree;
-    for (int i=0; i<NCCL_MAX_TREE_ARITY; i++) NCCLCHECK(SaveProxy(proxyRecv, tree->down[i], args, 0));
-    NCCLCHECK(SaveProxy(proxySend, tree->up, args, 0));
+    for (int t=0; t<NTREES; t++) { // for both trees in a channel
+      struct ncclTree* tree = channel->tree + t;
+      for (int i=0; i<NCCL_MAX_TREE_ARITY; i++) NCCLCHECK(SaveProxy(proxyRecv, tree->down[i], args, t));
+      NCCLCHECK(SaveProxy(proxySend, tree->up, args, t));
+    }
   }
   if (pattern == ncclPatternTreeDown || pattern == ncclPatternTreeUpDown) {
     // Tree down
-    struct ncclTree* tree = &channel->tree;
-    for (int i=0; i< NCCL_MAX_TREE_ARITY; i++) NCCLCHECK(SaveProxy(proxySend, tree->down[i], args, 0));
-    NCCLCHECK(SaveProxy(proxyRecv, tree->up, args, 0));
+    for (int t=0; t<NTREES; t++) { // for both trees in a channel
+      struct ncclTree* tree = channel->tree + t;
+      for (int i=0; i< NCCL_MAX_TREE_ARITY; i++) NCCLCHECK(SaveProxy(proxySend, tree->down[i], args, t));
+      NCCLCHECK(SaveProxy(proxyRecv, tree->up, args, t));
+    }
   }
   if (pattern == ncclPatternCollTreeUpDown) {
     // CollTree up

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -174,7 +174,7 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;
   info->read = useRead;
   // For CollNet, use write for scatter-reduce (conn 1), read for broadcast-gather (conn 0)
-  if (graph && connIndex == 1) info->read = 0;
+  if (graph && graph->collNet && connIndex == 1) info->read = 0;
   const char* useReadStr = info->read ? "/read" : "";
 
   int sendSize = sizeof(struct ncclSendMem);
@@ -220,7 +220,7 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;
   info->read = useRead;
   // For CollNet, use write for scatter-reduce (conn 1), read for broadcast-gather (conn 0)
-  if (graph && connIndex == 1) info->read = 0;
+  if (graph && graph->collNet && connIndex == 1) info->read = 0;
 
   int recvSize = sizeof(struct ncclRecvMem);
   // For P2P Read the SIMPLE buffer is tagged on the end of the ncclSendMem structure


### PR DESCRIPTION
Reduce NCCL channels (hence SM usage) by merging two complementary binary trees into the same channel.
On systems with per-NIC speed <= 100 Gbit/s, this reduces SM usage by half without lowering performance.
On systems with per-NIC speed of 200 Gbit/s, the original number of channels is used.
Also avoids tree overlapping in multi-communicator cases.