### PR TITLE
[nccl][profiler] Add and implement an API to enable and disable proxy thread tracing

### DIFF
--- a/src/include/profiler.h
+++ b/src/include/profiler.h
@@ -33,5 +33,7 @@ enum ncclProxyProfileState {
 
 ncclResult_t ncclProfilingRecord(struct ncclProxyArgs* args, int sub, int step, int state);
 void ncclProfilingDump();
+bool ncclProfilerEnable();
+bool ncclProfilerDisable();
 
 #endif

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -6,7 +6,7 @@
 
 #ifndef NCCL_TIMER_H_
 #define NCCL_TIMER_H_
-#if ENABLE_TIMER
+
 #include <unistd.h>
 #include <sys/time.h>
 #include <x86intrin.h>
@@ -27,6 +27,7 @@ static inline double gettime() {
   if (freq == -1) calibrate();
   return __rdtsc()/freq;
 }
+#if ENABLE_TIMER
 static uint64_t counts[8];
 static double times[8];
 static double startTimes[8];

--- a/src/init.cc
+++ b/src/init.cc
@@ -16,6 +16,7 @@
 #include "enqueue.h"
 #include "graph.h"
 #include "argcheck.h"
+#include "profiler.h"
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
@@ -114,6 +115,18 @@ ncclResult_t ncclGetUniqueId(ncclUniqueId* out) {
   TRACE_CALL("ncclGetUniqueId(0x%llx)", (unsigned long long)hashUniqueId(*out));
   return res;
 }
+
+NCCL_API(ncclResult_t, ncclProfilerStart);
+ncclResult_t ncclProfilerStart() {
+  ncclProfilerEnable();
+  return ncclSuccess;
+};
+
+NCCL_API(ncclResult_t, ncclProfilerStop);
+ncclResult_t ncclProfilerStop() {
+  ncclProfilerDisable();
+  return ncclSuccess;
+};
 
 // Prevent compiler from optimizing out these operations
 #ifdef __clang__

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -358,6 +358,13 @@ ncclResult_t pncclGroupStart();
 ncclResult_t  ncclGroupEnd();
 ncclResult_t pncclGroupEnd();
 
+
+/*
+ * Hack : Enable and disable NCCL proxy thread profiler.
+ */
+bool ncclProfilerEnable();
+bool ncclProfilerDisable();
+void ncclProfilingDump();
 #ifdef __cplusplus
 } // end extern "C"
 #endif


### PR DESCRIPTION
Adds api to enable and disable proxy thread profiler and dump the collected trace
- APIs added to nccl.h
- Profiler looks for an atomic flag to record events
- Some events need priori state so this will skip generating them if the profiler was not enabled when the start of the event was to be recoreded.