### PR TITLE
[INIT] enable comm id initialization from different subnets

### DIFF
--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -30,7 +30,7 @@ ncclResult_t bootstrapNetInit() {
           WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
           return ncclInvalidArgument;
         }
-        if (ncclFindInterfaceMatchSubnet(bootstrapNetIfName, &bootstrapNetIfAddr, &remoteAddr, MAX_IF_NAME_SIZE, 1) <= 0) {
+        if (ncclFindInterfaces(bootstrapNetIfName, &bootstrapNetIfAddr, MAX_IF_NAME_SIZE, 1) <= 0) {
           WARN("NET/Socket : No usable listening interface found");
           return ncclSystemError;
         }

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -293,8 +293,8 @@ int ncclFindInterfaces(char* ifNames, union ncclSocketAddress *ifAddrs, int ifNa
     if (nIfs == 0) {
       char* commId = getenv("NCCL_COMM_ID");
       if (commId && strlen(commId) > 1) {
-	INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", commId);
-	// Try to find interface that is in the same subnet as the IP in comm id
+        INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", commId);
+        // Try to find interface that is in the same subnet as the IP in comm id
         union ncclSocketAddress idAddr;
         ncclGetSocketAddrFromString(&idAddr, commId);
         nIfs = ncclFindInterfaceMatchSubnet(ifNames, ifAddrs, &idAddr, ifNameMaxSize, maxIfs);


### PR DESCRIPTION
With change, one can init NCCL without CPU communication mechanism to broadcast ncclId by setting env `NCCL_COMM_ID`.

For example, one can init NCCL comm as follows,
```
const int rank = atoi(getenv("RANK"));
const int size = atoi(getenv("SIZE"));

ncclUniqueId id; 
ncclComm_t comm;

ncclGetUniqueId(&id);
NCCLCHECK(ncclCommInitRank(&comm, size, id, rank));
```
by running the following command in multi-nodes.
```
RANK=0 SIZE=2 NCCL_COMM_ID=<ip-1>:56321 ./example  # node <ip-1>
RANK=1 SIZE=2 NCCL_COMM_ID=<ip-1>:56321 ./example  # node <ip-2>
```

This change will not introduce risk thanks to the consideration in `ncclFindInterfaces` call `ncclFindInterfaceMatchSubnet` first,
https://github.com/NVIDIA/nccl/blob/v2.15.1-1/src/misc/socket.cc#L300
while, it makes the initialization more flexible.
