### PR TITLE
Fix `suggest braces around initialization of subobject` from clang

### DIFF
--- a/src/include/nvtx3.hpp
+++ b/src/include/nvtx3.hpp
@@ -1666,9 +1666,9 @@ class event_attributes {
         0,                              // color value
         NVTX_PAYLOAD_UNKNOWN,           // payload type
         0,                              // reserved 4B
-        0,                              // payload value (union)
+        {0},                            // payload value (union)
         NVTX_MESSAGE_UNKNOWN,           // message type
-        0                               // message value (union)
+        {0}                             // message value (union)
       }
   {
   }


### PR DESCRIPTION
Fixes a clang warning:
```
include/nvtx3.hpp:1669:9: warning: suggest braces around initialization of subobject [-Wmissing-braces]
        0,                              // payload value (union)
        ^
        {}
include/nvtx3.hpp:1671:9: warning: suggest braces around initialization of subobject [-Wmissing-braces]
        0                               // message value (union)
        ^
        {}
```