### PR TITLE
Fix maximum handle size for NCCL Net v4 API

### DIFF
--- a/ext-net/example/nccl/net_v3.h
+++ b/ext-net/example/nccl/net_v3.h
@@ -5,7 +5,6 @@
 #ifndef NCCL_NET_V3_H_
 #define NCCL_NET_V3_H_
 
-#define NCCL_NET_HANDLE_MAXSIZE_V3 64
 #define NCCL_NET_MAX_REQUESTS_V3 16
 
 typedef ncclNetProperties_v4_t ncclNetProperties_v3_t;

--- a/ext-net/example/nccl/net_v4.h
+++ b/ext-net/example/nccl/net_v4.h
@@ -5,6 +5,8 @@
 #ifndef NCCL_NET_V4_H_
 #define NCCL_NET_V4_H_
 
+#define NCCL_NET_HANDLE_MAXSIZE_V4 64
+
 typedef struct {
   char* name;     // Used mostly for logging.
   char* pciPath;  // Path to the PCI device in /sys.


### PR DESCRIPTION
NCCL Net v4 supports a maximum handle size of 64 bytes whereas the ext-net example header files set it for NCCL Net v3. Since, `aws-ofi-nccl` plugin plans to follow the example header files, fix it here.

Signed-off-by: Rashika Kheria <rashika@amazon.com>