### PR TITLE
NCCL performance tuner plugin: tuner interface and default implementation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ INCEXPORTS  := nccl.h nccl_net.h
 LIBSRCFILES := init.cc init_nvtx.cc channel.cc bootstrap.cc transport.cc enqueue.cc group.cc debug.cc proxy.cc net.cc \
 		misc/cudawrap.cc misc/nvmlwrap.cc misc/ibvwrap.cc misc/gdrwrap.cc \
 		misc/utils.cc misc/argcheck.cc misc/socket.cc misc/shmutils.cc misc/profiler.cc misc/param.cc misc/strongstream.cc \
-		misc/ipcsocket.cc \
+		misc/ipcsocket.cc misc/performance_tuner.cc \
 		transport/p2p.cc transport/shm.cc transport/net.cc transport/net_socket.cc transport/net_ib.cc transport/coll_net.cc transport/nvls.cc \
                 collectives/sendrecv.cc collectives/all_reduce.cc collectives/all_gather.cc collectives/broadcast.cc collectives/reduce.cc collectives/reduce_scatter.cc \
                 graph/topo.cc graph/paths.cc graph/search.cc graph/connect.cc graph/rings.cc graph/trees.cc graph/tuning.cc graph/xml.cc

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1145,7 +1145,7 @@ static inline ncclResult_t getCollNetSupport(struct ncclInfo* info, int* collNet
 }
 
 // numPipeOps: number of pipelined ops. Can be greater than 1 in aggregation mode. Used to adjust latency.
-static ncclResult_t getAlgoInfo(struct ncclInfo* info, int collNetTypeSupport, int numPipeOps) {
+static ncclResult_t topoGetAlgoInfo(struct ncclInfo* info, int collNetTypeSupport, int numPipeOps) {
   struct ncclComm* comm = info->comm;
   if (comm->nRanks == 1) {
     info->algorithm = NCCL_ALGO_RING;
@@ -1216,6 +1216,17 @@ static ncclResult_t getAlgoInfo(struct ncclInfo* info, int collNetTypeSupport, i
   info->nChannels = nc;
   info->nThreads = nt;
   return ncclSuccess;
+}
+
+// Use the default topo-based tuner if tuner plugin is not successful.
+static ncclResult_t getAlgoInfo(struct ncclInfo* info, int collNetTypeSupport, int numPipeOps) {
+  if (info->comm->performanceTuner != NULL &&
+      info->comm->performanceTuner->getCollInfo(
+          info->coll, info->nBytes, &info->algorithm, &info->protocol,
+          &info->nChannels, &info->nThreads) == ncclSuccess) {
+    return ncclSuccess;
+  }
+  return topoGetAlgoInfo(info, collNetTypeSupport, numPipeOps);
 }
 
 static ncclResult_t getPatternInfo(struct ncclInfo* info) {

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -10,6 +10,7 @@
 #include "transport.h"
 #include "p2p.h"
 #include "collectives.h"
+#include "nccl_performance_tuner.h"
 #include "proxy.h"
 #include "strongstream.h"
 
@@ -307,6 +308,9 @@ struct ncclComm {
   bool finalizeCalled;
   // shared structures for finalization
   int finalizeRankCnt;
+
+  // Performance tuning plugin
+  ncclPerformanceTuner_t* performanceTuner;
 };
 
 enum ncclLaunchMode {

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -8,25 +8,12 @@
 #define NCCL_DEVICE_H_
 
 #include "nccl.h"
+#include "nccl_performance_tuner.h"
 #include "align.h"
 #include <stdint.h>
 
-#define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
-typedef enum { ncclFuncBroadcast, ncclFuncReduce, ncclFuncAllGather, ncclFuncReduceScatter, ncclFuncAllReduce, ncclFuncSendRecv, ncclFuncSend, ncclFuncRecv, ncclNumFuncs} ncclFunc_t;
 extern const char* ncclFuncStr[NCCL_NUM_FUNCTIONS];
-
-#define NCCL_NUM_ALGORITHMS 5 // Tree/Ring/CollNet*
-#define NCCL_ALGO_TREE 0
-#define NCCL_ALGO_RING 1
-#define NCCL_ALGO_COLLNET_DIRECT 2
-#define NCCL_ALGO_COLLNET_CHAIN 3
-#define NCCL_ALGO_NVLS 4
 extern const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS];
-
-#define NCCL_NUM_PROTOCOLS 3 // Simple/LL/LL128
-#define NCCL_PROTO_LL 0
-#define NCCL_PROTO_LL128 1
-#define NCCL_PROTO_SIMPLE 2
 extern const char* ncclProtoStr[NCCL_NUM_PROTOCOLS];
 
 #define NCCL_MAX_OPS 2048

--- a/src/include/nccl_performance_tuner.h
+++ b/src/include/nccl_performance_tuner.h
@@ -1,0 +1,56 @@
+#ifndef NCCL_PERFORMANCE_TUNER_H_
+#define NCCL_PERFORMANCE_TUNER_H_
+
+#include "nccl.h"
+#include "nccl_net.h"
+
+// Symbol name for NCCL performance tuner plugin
+#define NCCL_PERFORMANCE_TUNER_SYMBOL "ncclPerformanceTunerSymbol"
+
+#define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
+typedef enum { ncclFuncBroadcast, ncclFuncReduce, ncclFuncAllGather, ncclFuncReduceScatter, ncclFuncAllReduce, ncclFuncSendRecv, ncclFuncSend, ncclFuncRecv, ncclNumFuncs} ncclFunc_t;
+
+#define NCCL_NUM_ALGORITHMS 5 // Tree/Ring/CollNet*
+#define NCCL_ALGO_TREE 0
+#define NCCL_ALGO_RING 1
+#define NCCL_ALGO_COLLNET_DIRECT 2
+#define NCCL_ALGO_COLLNET_CHAIN 3
+#define NCCL_ALGO_NVLS 4
+
+#define NCCL_NUM_PROTOCOLS 3 // Simple/LL/LL128
+#define NCCL_PROTO_LL 0
+#define NCCL_PROTO_LL128 1
+#define NCCL_PROTO_SIMPLE 2
+
+// API to be implemented by external performance tuner
+typedef struct {
+  // Name of the performance tuner
+  const char* name;
+
+  // Initializes tuner states.
+  // nRanks: number of ranks in current communicator. Each communicator initialize its own tuner.
+  // nNodes: number of nodes in current communicator.
+  // logFunction: a logFunction can be useful to integrate logging together with NCCL core.
+  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction);
+
+  // Gets info (algo, protocol, number of ctas and threads) for a given collective.
+  // Inputs:
+  //   - collType: collective type , e.g., allreduce, allgather…
+  //   - nBytes: collective size in bytes
+  // Outputs:
+  //   - algo: selected algorithm to be used for the given collective
+  //   - protocol: selected protocol to be used for the given collective
+  //   - nChannels: number of channels to be used for the given collective
+  //   - nThreads: number of threads to be used for the given collective
+  //
+  // If getCollInfo() returns other than ncclSuccess, NCCL core will fall back
+  // to the default topo-based tuning for the given collective.
+  ncclResult_t (*getCollInfo)(ncclFunc_t collType, size_t nBytes, int *algo,
+                              int *protocol, int *nChannels, int *nThreads);
+
+  // Terminates the plugin and cleans up any resources that the plugin allocated.
+  ncclResult_t (*destroy)();
+} ncclPerformanceTuner_v1_t;
+
+typedef ncclPerformanceTuner_v1_t ncclPerformanceTuner_t;
+#endif

--- a/src/include/performance_tuner.h
+++ b/src/include/performance_tuner.h
@@ -1,0 +1,15 @@
+#ifndef PERFORMANCE_TUNER_H_
+#define PERFORMANCE_TUNER_H_
+
+#include "nccl_performance_tuner.h"
+
+// Performance tuner utility to be called by NCCL internal core.
+
+// Attempts to load NCCL performance tuner from environmental variable.
+// Returns ncclSuccess if the correct tuner symbol has been found and
+// successully loaded.  Otherwise returns an error and also logs the error.
+ncclResult_t ncclLoadPerformanceTuner(ncclPerformanceTuner_t** tuner);
+
+// Cleans up NCCL performance tuner plugin.
+ncclResult_t ncclClosePerformanceTuner(ncclPerformanceTuner_t** tuner);
+#endif

--- a/src/misc/performance_tuner.cc
+++ b/src/misc/performance_tuner.cc
@@ -1,0 +1,53 @@
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "debug.h"
+#include "nccl_performance_tuner.h"
+
+void* tunerPluginLib = nullptr;
+
+ncclResult_t ncclLoadPerformanceTuner(ncclPerformanceTuner_t** tuner) {
+  // Initialize to nullptr by default if plugin tuner cannot be loaded.
+  *tuner = nullptr;
+
+  const char* name = getenv("NCCL_TUNER_PLUGIN");
+  if (name == nullptr) {
+    INFO(NCCL_TUNING, "Env NCCL_TUNER_PLUGIN not set, using default.");
+    return ncclInvalidArgument;
+  }
+
+  tunerPluginLib = dlopen(name, RTLD_LAZY | RTLD_LOCAL);
+  if (tunerPluginLib == nullptr) {
+    // dlopen does not guarantee to set errno, but dlerror only gives us a
+    // string, so checking errno doesn't hurt to try to provide a better
+    // error message
+    if (errno == ENOENT) {
+      INFO(NCCL_TUNING, "Performance tuner: no plugin found '%s', using default tuner instead.", name);
+    } else {
+      INFO(NCCL_TUNING, "Performance tuner: plugin load '%s' returned error (%d : %s), using default tuner instead.", name, errno, dlerror());
+    }
+    return ncclSystemError;
+  }
+
+  *tuner = (ncclPerformanceTuner_t*)dlsym(tunerPluginLib, NCCL_PERFORMANCE_TUNER_SYMBOL);
+  if (*tuner == nullptr) {
+    INFO(NCCL_TUNING, "Performance tuner: failed to find ncclPerformanceTunerSymbol in plugin (%s), using default tuner instead.", name);
+    dlclose(tunerPluginLib);
+    tunerPluginLib = nullptr;
+    return ncclSystemError;
+  }
+
+  INFO(NCCL_TUNING, "Using performance tuner: '%s'", (*tuner)->name);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclClosePerformanceTuner(ncclPerformanceTuner_t** tuner) {
+  if (tunerPluginLib != nullptr) {
+    INFO(NCCL_TUNING, "Closing performance tuner: '%s'", (*tuner)->name);
+    dlclose(tunerPluginLib);
+  }
+  tunerPluginLib = nullptr;
+  *tuner = nullptr;
+  return ncclSuccess;
+}


### PR DESCRIPTION
Currently NCCL performance tuner is implemented as a built-in NCCL component in graph/tuning.cc.
We'd like to explore possible custom tuners separately for various scenarios (e.g., network topologies, hardware platforms) that may exist simultaneously in production.

This PR proposes an interface so that NCCL can support external performance tuner plugin, fully configurable at run time. Note that the existing tuner implementation is still the default tuner when there is no external plugin being specified.
- NCCL_TUNER_PLUGIN: the environment variable to specify plugin shared object
- nccl_performance_tuner.h: defines the tuner interface 
- init.cc: initializes and destroys the tuner plugin
- enqueue.cc: calls the plugin's method to decide the collective algorithm. Falls back the the default topo-based tuning algorithm if necessary.