### PR TITLE
fix NCCL_DEBUG initialization

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -6,6 +6,7 @@
 
 #include "core.h"
 #include "nccl_net.h"
+#include "param.h"
 #include <stdlib.h>
 #include <stdarg.h>
 #include <sys/syscall.h>
@@ -25,6 +26,7 @@ static __thread int tid = -1;
 void ncclDebugInit() {
   pthread_mutex_lock(&ncclDebugLock);
   if (ncclDebugLevel != -1) { pthread_mutex_unlock(&ncclDebugLock); return; }
+  initEnv();
   const char* nccl_debug = getenv("NCCL_DEBUG");
   int tempNcclDebugLevel = -1;
   if (nccl_debug == NULL) {

--- a/src/misc/param.cc
+++ b/src/misc/param.cc
@@ -17,6 +17,8 @@
 #include <pthread.h>
 #include <pwd.h>
 
+static bool envInitialized = false;
+
 const char* userHomeDir() {
   struct passwd *pwUser = getpwuid(getuid());
   return pwUser == NULL ? NULL : pwUser->pw_dir;
@@ -49,14 +51,17 @@ void setEnvFile(const char* fileName) {
 }
 
 void initEnv() {
-  char confFilePath[1024];
-  const char * userDir = userHomeDir();
-  if (userDir) {
-    sprintf(confFilePath, "%s/.nccl.conf", userDir);
+  if (!envInitialized) {
+    char confFilePath[1024];
+    const char * userDir = userHomeDir();
+    if (userDir) {
+      sprintf(confFilePath, "%s/.nccl.conf", userDir);
+      setEnvFile(confFilePath);
+    }
+    sprintf(confFilePath, "/etc/nccl.conf");
     setEnvFile(confFilePath);
+    envInitialized = true;
   }
-  sprintf(confFilePath, "/etc/nccl.conf");
-  setEnvFile(confFilePath);
 }
 
 void ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, int64_t* cache) {


### PR DESCRIPTION
Since `ncclDebugInit` only happens once at the first appearance of `ncclDebugLog` (i.e., when calling TRACE, INFO...), it is possible NCCL attempts to call debug log before setting environment variables from a config file, which happens in `ncclInit` now. This results in discrepancy between rank-0 and other ranks, e.g., rank-0 prints log but other ranks won't, because rank-0 performs `ncclInit` during `ncclGetUniqueId` while other ranks would wait until actual initialization (e.g., `ncclCudaLibraryInit` in https://github.com/NVIDIA/nccl/blob/master/src/init.cc#L1578 may call INFO before reading config file`).

This patch adds extra logic to call `initEnvs` in `ncclDebugLog` and make sure `initEnvs` only performed once. Alternatively, we could also move `ncclInit` before any other calls, but I'm not sure if it has any side effects.