### PR TITLE
Allow overriding `NVCC` in `common.mk`

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -14,7 +14,7 @@ PROFAPI ?= 1
 NVTX ?= 1
 RDMA_CORE ?= 0
 
-NVCC = $(CUDA_HOME)/bin/nvcc
+NVCC ?= $(CUDA_HOME)/bin/nvcc
 
 CUDA_LIB ?= $(CUDA_HOME)/lib64
 CUDA_INC ?= $(CUDA_HOME)/include


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/nccl/issues/853