### PR TITLE
Print qp num in wc error, for trace rdma network flow

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1291,8 +1291,8 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
             localGidStr = inet_ntop(AF_INET6, &r->gidInfo->localGid, localGidString, sizeof(localGidString));
             remoteGidStr = inet_ntop(AF_INET6, &r->gidInfo->remoteGid, remoteGidString, sizeof(remoteGidString));
         }
-        WARN("NET/IB : Got completion from peer %s with error %d, opcode %d, len %d, vendor err %d (%s)%s%s%s%s",
-            ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->vendor_err, reqTypeStr[r->type],
+        WARN("NET/IB : Got completion from peer %s with error %d, opcode %d, qp num %d, len %d, vendor err %d (%s)%s%s%s%s",
+            ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->qp_num, wc->byte_len, wc->vendor_err, reqTypeStr[r->type],
             localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGid ":"", remoteGidString);
         return ncclRemoteError;
       }


### PR DESCRIPTION
qp num is the field `Dest QP`'s value in `InfiniBand Base Transport Header`, it is useful when the rdma network have a Traffic Analysis system that collect the ib packet by qp num.

ref an annoying problem

> NCCL WARN NET/IB : Got completion with error 12, opcode 1, len 0, vendor err 129

generally, it turns out when the network latency is increasing (due to loss packet, specially, in RoCE network), print qp num, can help find out the specific network flow problem