### PR TITLE
Prevent WR index truncation in the InfiniBand transport code

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1064,7 +1064,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, int size, int tag, void* mh
   int slot = (comm->fifoHead)%MAX_REQUESTS;
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
   slots = comm->fifo[slot];
-  int idx = comm->fifoHead+1;
+  uint64_t idx = comm->fifoHead+1;
   if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
   nreqs = slots[0].nreqs;
   // Wait until all data has arrived


### PR DESCRIPTION
_note: this was originally discovered and fixed by @dmitrygx in an internal NCCL fork; in this PR I'm only trying to get the fix upstream_

**tl;dr**

`ncclIbIsend()` in `net_ib.cc` doesn't actually start sending until the receiver has posted a confirmation indicating it is ready to receive the request we're about to send (`comm->fifoHead+1`). However, when comparing the confirmation index present in `comm->fifo[...][0].idx` (a 64-bit value) to the expected one (also a 64-bit value), the sender truncates the expected index to 32 bits. This essentially prevents NCCL from posting any InfiniBand requests once `comm->fifoHead+1` exceeds `INT_MAX` (i.e., when `2^31-1` requests have been transferred over an InfiniBand channel).

**How to reproduce**

I'm moderately sure that any long-running NCCL process using InfiniBand will eventually stop making progress and hang. For convenience, here's a minimal, pure CUDA/NCCL (no MPI/PyTorch/etc.) reproducer that only uses 2 ranks and p2p communications, so that there is 1:1 correspondence between the pairs of `ncclSend()/ncclRecv()` and IB work requests being posted:

<details>
<summary>
run with "NCCL_COMM_ID=RENDEZVOUS_HOST ./main 0" on rank 0 and "NCCL_COMM_ID=RENDEZVOUS_HOST ./main 1" on rank 1
</summary>

```cpp
#include <cuda_runtime.h>
#include <nccl.h>

#include <cstdlib>
#include <ctime>

#include <functional>
#include <iostream>
#include <string>

void NcclOrDie(ncclResult_t result, const char* action) {
    if (result != ncclSuccess) {
        std::cerr << action << ": " << ncclGetErrorString(result) << std::endl;
        exit(EXIT_FAILURE);
    }
}

void CudaOrDie(cudaError_t result, const char* action) {
    if (result != cudaSuccess) {
        std::cerr << action << ": " << cudaGetErrorString(result) << std::endl;
        exit(EXIT_FAILURE);
    }
}

void PrintUsageAndExit() {
    std::cerr << "Usage: ./main RANK (either 0 or 1)" << std::endl;
    exit(EXIT_FAILURE);
}

int main(int argc, char** argv) {
    if (!std::getenv("NCCL_COMM_ID")) {
        std::cerr << "NCCL_COMM_ID should be set explicitly" << std::endl;
        exit(EXIT_FAILURE);
    }

    if (argc != 2) {
        PrintUsageAndExit();
    }
    
    int rank = -1;
    if (strcmp(argv[1], "0") == 0) {
        rank = 0;
    } else if (strcmp(argv[1], "1") == 0) {
        rank = 1;
    } else {
        PrintUsageAndExit();
    }

    ncclComm_t comm;
    ncclUniqueId id;
    cudaStream_t stream;
    uint64_t* value;

    CudaOrDie(cudaSetDevice(0), "selecting GPU #0");
    CudaOrDie(cudaMalloc(&value, sizeof(uint64_t)), "allocating 8 bytes of GPU memory");
    CudaOrDie(cudaStreamCreate(&stream), "creating CUDA stream");

    NcclOrDie(ncclGetUniqueId(&id), "generating unique ID for the communicator");
    NcclOrDie(ncclCommInitRank(&comm, 2, id, rank), "initializing communicator");

    // Run 3 billion work requests just to be sure we're safe.
    for (uint64_t i = 0; i < 3000000000ULL; ++i) {
        if (rank == 0) {
            NcclOrDie(ncclSend(value, 1, ncclUint64, 1, comm, stream), "sending data");
        } else {
            NcclOrDie(ncclRecv(value, 1, ncclUint64, 0, comm, stream), "receiving data");
        }

        if (i % 10000ULL == 0) {
            time_t curTime;
            std::time(&curTime);
            char curTimeBuf[256];
            strftime(curTimeBuf, sizeof(curTimeBuf), "[%Y-%m-%d %H:%M:%S]", std::localtime(&curTime));
            std::cerr << curTimeBuf << " Ran " << i << " requests" << std::endl;
        }
    }
    CudaOrDie(cudaStreamSynchronize(stream), "synchronizing CUDA stream at the very end");

    NcclOrDie(ncclCommDestroy(comm), "destroying communicator");
    CudaOrDie(cudaStreamDestroy(stream), "destroying CUDA stream");
    CudaOrDie(cudaFree(value), "freeing GPU memory");
}
```
</details>

It might take a while to reach `2^31-1` requests, so here's a hacky patch that will trigger the hang much sooner:

<details>
<summary>
Should work against NCCL 2.18.3
</summary>

```diff
--- a/net_ib.cc    (index)
+++ b/net_ib.cc    (working tree)
@@ -579,6 +579,8 @@ ncclResult_t ncclIbListen(int dev, void* opaqueHandle, void** listenComm) {
   return ncclSuccess;
 }
 
+constexpr uint64_t NCCL_INITIAL_FIFO_POS = (1ULL << 31) - 5000000ULL;
+
 ncclResult_t ncclIbConnect(int dev, void* opaqueHandle, void** sendComm) {
   struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
   enum ncclSocketState conState;
@@ -594,6 +596,7 @@ ncclResult_t ncclIbConnect(int dev, void* opaqueHandle, void** sendComm) {
   }
 
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
+  comm->fifoHead = NCCL_INITIAL_FIFO_POS;
   NCCLCHECK(ncclSocketInit(&comm->sock, &handle->connectAddr, NULL, 1));
   stage->comm = comm;
   stage->state = ncclIbCommStateConnect;
@@ -681,6 +684,7 @@ ncclResult_t ncclIbAccept(void* listenComm, void** recvComm) {
   }
 
   NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
+  rComm->remFifo.fifoTail = NCCL_INITIAL_FIFO_POS;
   stage->comm = rComm;
   stage->state = ncclIbCommStateAccept;
   NCCLCHECK(ncclSocketInit(&rComm->sock, NULL, lComm->sock.abortFlag, 1));
```
</details>

**Some additional background on this**

* This was discovered when we updated the NCCL version before training a large model using A100 hosts connected with InfiniBand (my hunch is that the problem was introduced in [2.12.7](https://github.com/NVIDIA/nccl/commit/3c223c105a24dff651a67c26fd5f92ba45844345#diff-9d8bca27b23828e4b2e27640179cf6dea6e774a21317f5b434aaec3a67d8983eR984)). The training process started experiencing random hangs approximately every 16 hours. In theory, this could be explained by hardware misbehaving, but the weird thing was that the [watchdog](https://github.com/pytorch/pytorch/blob/7bb40be143bc8517a7aa33636cd96d332c649b8e/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L450) from PyTorch was consistently reporting that the timeout happened while waiting for a `ReduceScatter` with particular index (`0x1cf175`).
* Previous `ReduceScatter`'s with exactly the same size and sendbuff/recvbuff completed thousands of times without any problems during any given training run, but (just to be sure) we checked there was no problems on our side:
   * we only used one communicator and one stream in a thread-safe manner
   * there was no diverging control flow, so the history of collective operations was the same on all GPUs
   * all GPUs called the problematic `ReduceScatter` with the same parameters (element count, data type, reduction operation, etc.)
* We combed through CPU stack traces trying to find a rogue host that was stuck in some sort of infinite loop on the CPU side, but they were all just waiting for NCCL kernels to complete. We tried running with [`NCCL_PROXY_DUMP_SIGNAL=10`](https://github.com/NVIDIA/nccl/blob/master/src/proxy.cc#L825C30-L825C47) to dump the proxy state via `SIGUSR1` when the hang happened, but no proxy reported unfinished active ops (to be honest, I'm still not sure why).
* Stumped, we inserted an ad-hoc watchdog directly inside [the Simple protocol primitives](https://github.com/nvidia/nccl/blob/master/src/collectives/device/prims_simple.h#L130), which would `printf()` as much information as possible about why the `ReduceScatter` kernel wasn't able to finish. The first attempt was inconclusive: on any given rank, either a `RoleWaitSend` or a `RoleWaitRecv` thread was unable to return from `waitPeer()` due to its head/tail counter, but the reasons were unclear. We decided we should print both head and tail counter from every hanging thread to see if there was some sort of logical deadlock (if head/tail counters were consistent on all GPUs) or a network/proxy problem (if they were not), and then report the issue upstream.
* However, at this point we accidentally stumbled upon a suspicious integer cast in `net_ib.cc` while reading the code. We weren't sure it was problematic, so we changed it just to see what would happen. Suddenly, the hangs stopped. We started digging deeper into the code, and then realized that there was no way for this code to work once the index exceeds `INT_MAX`. And, as it turns out, it doesn't. :)