### PR TITLE
Fix undefined behavior in ncclKernel()

### DIFF
--- a/src/collectives/device/common.h
+++ b/src/collectives/device/common.h
@@ -166,7 +166,8 @@ __device__ void ncclKernel(
       bytes = 0;
       break;
     }
-    copyToShmem16(tid%WARP_SIZE, dst, src, bytes);
+    if (bytes)
+      copyToShmem16(tid%WARP_SIZE, dst, src, bytes);
   }
   __syncthreads(); // publish ncclShmem
 


### PR DESCRIPTION
We never set src/dst in the default case and, when compiled with clang, it allows compiler to consider the default branch unreachable (better than launching rockets, I guess) and that leads to a miscompilation with recent clang builds.