### PR TITLE
Introduce UBSAN support and fix found issues

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -9,6 +9,10 @@ PREFIX ?= /usr/local
 VERBOSE ?= 0
 KEEP ?= 0
 DEBUG ?= 0
+# Note that user must set ASAN_OPTIONS="protect_shadow_gap=0"
+# because it is required when ASAN is run within a CUDA application.
+# Otherwise, CUDA would return an OOM error.
+ASAN ?= 0
 TRACE ?= 0
 PROFAPI ?= 1
 NVTX ?= 1
@@ -83,6 +87,11 @@ CXXFLAGS  += -O3 -g
 else
 NVCUFLAGS += -O0 -G -g
 CXXFLAGS  += -O0 -g -ggdb3
+endif
+
+ifneq ($(ASAN), 0)
+CXXFLAGS += -fsanitize=address
+LDFLAGS += -fsanitize=address
 endif
 
 ifneq ($(VERBOSE), 0)

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -13,6 +13,7 @@ DEBUG ?= 0
 # because it is required when ASAN is run within a CUDA application.
 # Otherwise, CUDA would return an OOM error.
 ASAN ?= 0
+UBSAN ?= 0
 TRACE ?= 0
 PROFAPI ?= 1
 NVTX ?= 1
@@ -92,6 +93,11 @@ endif
 ifneq ($(ASAN), 0)
 CXXFLAGS += -fsanitize=address
 LDFLAGS += -fsanitize=address
+endif
+
+ifneq ($(UBSAN), 0)
+CXXFLAGS += -fsanitize=undefined
+LDFLAGS += -fsanitize=undefined
 endif
 
 ifneq ($(VERBOSE), 0)

--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -65,8 +65,12 @@ ncclResult_t ncclRealloc(T** ptr, size_t oldNelem, size_t nelem) {
     WARN("Failed to malloc %ld bytes", nelem*sizeof(T));
     return ncclSystemError;
   }
-  memcpy(p, oldp, oldNelem*sizeof(T));
-  free(oldp);
+
+  if (oldp != NULL) {
+    memcpy(p, oldp, oldNelem*sizeof(T));
+    free(oldp);
+  }
+
   memset(p+oldNelem, 0, (nelem-oldNelem)*sizeof(T));
   *ptr = (T*)p;
   INFO(NCCL_ALLOC, "Mem Realloc old size %ld, new size %ld pointer %p", oldNelem*sizeof(T), nelem*sizeof(T), *ptr);

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -31,7 +31,9 @@ typedef struct ncclComm* ncclComm_t;
 #define NCCL_COMM_NULL NULL
 
 #define NCCL_UNIQUE_ID_BYTES 128
-typedef struct { char internal[NCCL_UNIQUE_ID_BYTES]; } ncclUniqueId;
+typedef struct {
+    char internal[NCCL_UNIQUE_ID_BYTES];
+} ncclUniqueId __attribute__((aligned(8)));
 
 /* Error type */
 typedef enum { ncclSuccess                 =  0,


### PR DESCRIPTION
UBSAN (Undefined Behaviour Sanitizer) is a useful tool to catch code usage that results in undefined behaviour.
Such as array subscript out of bounds (where the bounds can be statically determined), bitwise shifts that are out of bounds for their data type, dereferencing misaligned or null pointers, signed integer overflow and etc.

Introduce flag to build NCCL with UBSAN and fix 2 issues it have found when running nccl-tests.

Note that this PR is based on the PR that introduce ASAN to NCCL: https://github.com/NVIDIA/nccl/pull/953.