### PR TITLE
Fix select net code in case when a node has more GPUs than NICs.

### DIFF
--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -387,6 +387,8 @@ ncclResult_t ncclTopoSelectNets(struct ncclTopoSystem* system, int typeInter, in
       NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, localNets+localNetCount));
       if (localNetCount > 0 && localNets[localNetCount] == localNets[0]) break;
       localNetCount++;
+
+      if (localNetCount == system->nodes[NET].count) break;
     }
     // Append NICs to list
     for (int i=0; i<localNetCount; i++) {


### PR DESCRIPTION
I faced with ASAN failure in this part of code on the line:
if (localNetCount > 0 && localNets[localNetCount] == localNets[0]) break;

IIUC the problem here is in addressing localNets array outside of the boundary.
I assume this is happening in cases when nodes have more GPUs than NICs.

