### PR TITLE
Simplify code around `xmlGetAttrIndex`

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -355,8 +355,7 @@ ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* s
   for (int s=0; s<xmlNic->nSubs; s++) {
     struct ncclXmlNode* xmlNet = xmlNic->subs[s];
     if (strcmp(xmlNet->name, "net") != 0) continue;
-    int index = xmlGetAttrIndex(xmlNet, "dev");
-    if (index == -1) continue;
+    if (!xmlHasAttr(xmlNet, "dev")) continue;
     NCCLCHECK(ncclTopoAddNet(xmlNet, system, nic));
   }
   return ncclSuccess;
@@ -392,8 +391,7 @@ ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* s
   NCCLCHECK(xmlGetSub(xmlPci, "gpu", &xmlGpu));
   if (xmlGpu != NULL) {
     type = GPU;
-    int index = xmlGetAttrIndex(xmlGpu, "rank");
-    if (index == -1) return ncclSuccess;
+    if (!xmlHasAttr(xmlGpu, "rank")) return ncclSuccess;
     NCCLCHECK(ncclTopoCreateNode(system, &node, type, busId));
     NCCLCHECK(ncclTopoAddGpu(xmlGpu, system, node));
   }

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -355,8 +355,7 @@ ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* s
   for (int s=0; s<xmlNic->nSubs; s++) {
     struct ncclXmlNode* xmlNet = xmlNic->subs[s];
     if (strcmp(xmlNet->name, "net") != 0) continue;
-    int index;
-    NCCLCHECK(xmlGetAttrIndex(xmlNet, "dev", &index));
+    int index = xmlGetAttrIndex(xmlNet, "dev");
     if (index == -1) continue;
     NCCLCHECK(ncclTopoAddNet(xmlNet, system, nic));
   }
@@ -393,8 +392,7 @@ ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* s
   NCCLCHECK(xmlGetSub(xmlPci, "gpu", &xmlGpu));
   if (xmlGpu != NULL) {
     type = GPU;
-    int index;
-    NCCLCHECK(xmlGetAttrIndex(xmlGpu, "rank", &index));
+    int index = xmlGetAttrIndex(xmlGpu, "rank");
     if (index == -1) return ncclSuccess;
     NCCLCHECK(ncclTopoCreateNode(system, &node, type, busId));
     NCCLCHECK(ncclTopoAddGpu(xmlGpu, system, node));
@@ -595,8 +593,7 @@ NCCL_PARAM(TopoDumpFileRank, "TOPO_DUMP_FILE_RANK", 0);
 
 // Only set values if not already set
 static ncclResult_t xmlInitAttrInt(struct ncclXmlNode* node, const char* attrName, const int value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) {
     index = node->nAttrs++;
     strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
@@ -605,8 +602,7 @@ static ncclResult_t xmlInitAttrInt(struct ncclXmlNode* node, const char* attrNam
   return ncclSuccess;
 }
 static ncclResult_t xmlInitAttrUint64(struct ncclXmlNode* node, const char* attrName, const uint64_t value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) {
     index = node->nAttrs++;
     strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
@@ -615,8 +611,7 @@ static ncclResult_t xmlInitAttrUint64(struct ncclXmlNode* node, const char* attr
   return ncclSuccess;
 }
 static ncclResult_t xmlInitAttrFloat(struct ncclXmlNode* node, const char* attrName, const float value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) {
     index = node->nAttrs++;
     strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -372,8 +372,7 @@ ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* pat
 }
 
 ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* xml) {
-  int index = xmlGetAttrIndex(cpuNode, "affinity");
-  if (index == -1) {
+  if (!xmlHasAttr(cpuNode, "affinity")) {
     const char* numaId;
     NCCLCHECK(xmlGetAttr(cpuNode, "numaid", &numaId));
     if (numaId == NULL) {
@@ -386,8 +385,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     NCCLCHECK(ncclTopoSetAttrFromSys(cpuNode, cpumaskPath, "cpumap", "affinity"));
   }
 
-  index = xmlGetAttrIndex(cpuNode, "arch");
-  if (index == -1) {
+  if (!xmlHasAttr(cpuNode, "arch")) {
     // Fill CPU type / vendor / model
 #if defined(__PPC__)
     NCCLCHECK(xmlSetAttr(cpuNode, "arch", "ppc64"));
@@ -399,8 +397,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
   }
 
 #if defined(__x86_64__)
-  index = xmlGetAttrIndex(cpuNode, "vendor");
-  if (index == -1) {
+  if (!xmlHasAttr(cpuNode, "vendor")) {
     union {
       struct {
         // CPUID 0 String register order
@@ -418,8 +415,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     NCCLCHECK(xmlSetAttr(cpuNode, "vendor", vendor));
   }
 
-  index = xmlGetAttrIndex(cpuNode, "familyid");
-  if (index == -1) {
+  if (!xmlHasAttr(cpuNode, "familyid")) {
     union {
       struct {
         unsigned steppingId:4;
@@ -477,25 +473,20 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
     NCCLCHECK(ncclTopoSetAttrFromSys(pciNode, path, "class", "class"));
   }
   ncclDebugNoWarn = NCCL_GRAPH;
-  int index = xmlGetAttrIndex(pciNode, "vendor");
-  if (index == -1) {
+  if (!xmlHasAttr(pciNode, "vendor")) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "vendor", "vendor");
   }
-  index = xmlGetAttrIndex(pciNode, "device");
-  if (index == -1) {
+  if (!xmlHasAttr(pciNode, "device")) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "device", "device");
   }
-  index = xmlGetAttrIndex(pciNode, "subsystem_vendor");
-  if (index == -1) {
+  if (!xmlHasAttr(pciNode, "subsystem_vendor")) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "subsystem_vendor", "subsystem_vendor");
   }
-  index = xmlGetAttrIndex(pciNode, "subsystem_device");
-  if (index == -1) {
+  if (!xmlHasAttr(pciNode, "subsystem_device")) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "subsystem_device", "subsystem_device");
   }
   ncclDebugNoWarn = 0;
-  index = xmlGetAttrIndex(pciNode, "link_speed");
-  if (index == -1) {
+  if (!xmlHasAttr(pciNode, "link_speed")) {
     if (path) {
       char deviceSpeedStr[MAX_STR_LEN];
       float deviceSpeed;
@@ -510,8 +501,7 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       NCCLCHECK(xmlSetAttr(pciNode, "link_speed", ""));
     }
   }
-  index = xmlGetAttrIndex(pciNode, "link_width");
-  if (index == -1) {
+  if (!xmlHasAttr(pciNode, "link_width")) {
     if (path) {
       char strValue[MAX_STR_LEN];
       NCCLCHECK(ncclTopoGetStrFromSys(path, "max_link_width", strValue));
@@ -606,16 +596,14 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
   if (gpuNode == NULL) NCCLCHECK(xmlAddNode(xml, pciNode, "gpu", &gpuNode));
 
   int dev = -1;
-  int index = xmlGetAttrIndex(gpuNode, "dev");
-  if (index == -1) {
+  if (!xmlHasAttr(gpuNode, "dev")) {
     NCCLCHECK(ncclNvmlDeviceGetIndex(nvmlDev, (unsigned int*)&dev));
     NCCLCHECK(xmlSetAttrInt(gpuNode, "dev", dev));
   }
   NCCLCHECK(xmlGetAttrInt(gpuNode, "dev", &dev));
   if (dev == -1) { *gpuNodeRet = NULL; return ncclSuccess; }
 
-  index = xmlGetAttrIndex(gpuNode, "sm");
-  if (index == -1) {
+  if (!xmlHasAttr(gpuNode, "sm")) {
     int cudaMajor, cudaMinor;
     if (nvmlDev == NULL) {
       cudaDeviceProp devProp;
@@ -726,8 +714,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
   for (int s=0; s<gpuNode->nSubs; s++) {
     struct ncclXmlNode* sub = gpuNode->subs[s];
     if (strcmp(sub->name, "nvlink") != 0) continue;
-    int index = xmlGetAttrIndex(sub, "tclass");
-    if (index == -1) {
+    if (!xmlHasAttr(sub, "tclass")) {
       const char* busId;
       NCCLCHECK(xmlGetAttr(sub, "target", &busId));
       char* path;

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -372,8 +372,7 @@ ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* pat
 }
 
 ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* xml) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(cpuNode, "affinity", &index));
+  int index = xmlGetAttrIndex(cpuNode, "affinity");
   if (index == -1) {
     const char* numaId;
     NCCLCHECK(xmlGetAttr(cpuNode, "numaid", &numaId));
@@ -387,7 +386,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     NCCLCHECK(ncclTopoSetAttrFromSys(cpuNode, cpumaskPath, "cpumap", "affinity"));
   }
 
-  NCCLCHECK(xmlGetAttrIndex(cpuNode, "arch", &index));
+  index = xmlGetAttrIndex(cpuNode, "arch");
   if (index == -1) {
     // Fill CPU type / vendor / model
 #if defined(__PPC__)
@@ -400,7 +399,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
   }
 
 #if defined(__x86_64__)
-  NCCLCHECK(xmlGetAttrIndex(cpuNode, "vendor", &index));
+  index = xmlGetAttrIndex(cpuNode, "vendor");
   if (index == -1) {
     union {
       struct {
@@ -419,7 +418,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     NCCLCHECK(xmlSetAttr(cpuNode, "vendor", vendor));
   }
 
-  NCCLCHECK(xmlGetAttrIndex(cpuNode, "familyid", &index));
+  index = xmlGetAttrIndex(cpuNode, "familyid");
   if (index == -1) {
     union {
       struct {
@@ -477,26 +476,25 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
   if (path) {
     NCCLCHECK(ncclTopoSetAttrFromSys(pciNode, path, "class", "class"));
   }
-  int index;
   ncclDebugNoWarn = NCCL_GRAPH;
-  NCCLCHECK(xmlGetAttrIndex(pciNode, "vendor", &index));
+  int index = xmlGetAttrIndex(pciNode, "vendor");
   if (index == -1) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "vendor", "vendor");
   }
-  NCCLCHECK(xmlGetAttrIndex(pciNode, "device", &index));
+  index = xmlGetAttrIndex(pciNode, "device");
   if (index == -1) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "device", "device");
   }
-  NCCLCHECK(xmlGetAttrIndex(pciNode, "subsystem_vendor", &index));
+  index = xmlGetAttrIndex(pciNode, "subsystem_vendor");
   if (index == -1) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "subsystem_vendor", "subsystem_vendor");
   }
-  NCCLCHECK(xmlGetAttrIndex(pciNode, "subsystem_device", &index));
+  index = xmlGetAttrIndex(pciNode, "subsystem_device");
   if (index == -1) {
     if (path) ncclTopoSetAttrFromSys(pciNode, path, "subsystem_device", "subsystem_device");
   }
   ncclDebugNoWarn = 0;
-  NCCLCHECK(xmlGetAttrIndex(pciNode, "link_speed", &index));
+  index = xmlGetAttrIndex(pciNode, "link_speed");
   if (index == -1) {
     if (path) {
       char deviceSpeedStr[MAX_STR_LEN];
@@ -512,7 +510,7 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       NCCLCHECK(xmlSetAttr(pciNode, "link_speed", ""));
     }
   }
-  NCCLCHECK(xmlGetAttrIndex(pciNode, "link_width", &index));
+  index = xmlGetAttrIndex(pciNode, "link_width");
   if (index == -1) {
     if (path) {
       char strValue[MAX_STR_LEN];
@@ -607,10 +605,8 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
   NCCLCHECK(xmlGetSub(pciNode, "gpu", &gpuNode));
   if (gpuNode == NULL) NCCLCHECK(xmlAddNode(xml, pciNode, "gpu", &gpuNode));
 
-  int index = -1;
-
   int dev = -1;
-  NCCLCHECK(xmlGetAttrIndex(gpuNode, "dev", &index));
+  int index = xmlGetAttrIndex(gpuNode, "dev");
   if (index == -1) {
     NCCLCHECK(ncclNvmlDeviceGetIndex(nvmlDev, (unsigned int*)&dev));
     NCCLCHECK(xmlSetAttrInt(gpuNode, "dev", dev));
@@ -618,7 +614,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
   NCCLCHECK(xmlGetAttrInt(gpuNode, "dev", &dev));
   if (dev == -1) { *gpuNodeRet = NULL; return ncclSuccess; }
 
-  NCCLCHECK(xmlGetAttrIndex(gpuNode, "sm", &index));
+  index = xmlGetAttrIndex(gpuNode, "sm");
   if (index == -1) {
     int cudaMajor, cudaMinor;
     if (nvmlDev == NULL) {
@@ -730,8 +726,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
   for (int s=0; s<gpuNode->nSubs; s++) {
     struct ncclXmlNode* sub = gpuNode->subs[s];
     if (strcmp(sub->name, "nvlink") != 0) continue;
-    int index;
-    NCCLCHECK(xmlGetAttrIndex(sub, "tclass", &index));
+    int index = xmlGetAttrIndex(sub, "tclass");
     if (index == -1) {
       const char* busId;
       NCCLCHECK(xmlGetAttr(sub, "target", &busId));

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -60,21 +60,18 @@ ncclResult_t ncclTopoTrimXml(struct ncclXml* xml);
 /* Functions  */
 /**************/
 
-static ncclResult_t xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrName, int* index) {
-  *index = -1;
+static int xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrName) {
   const int nAttrs = node->nAttrs;
   for (int a=0; a<nAttrs; a++) {
     if (strncmp(node->attrs[a].key, attrName, MAX_STR_LEN) == 0) {
-      *index = a;
-      return ncclSuccess;
+      return a;
     }
   }
-  return ncclSuccess;
+  return -1;
 }
 
 static ncclResult_t xmlGetAttr(struct ncclXmlNode* node, const char* attrName, const char** value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   *value = index == -1 ? NULL : node->attrs[index].value;
   return ncclSuccess;
 }
@@ -138,8 +135,7 @@ static ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struc
 }
 
 static ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, const char* value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) {
     index = node->nAttrs++;
     strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
@@ -151,8 +147,7 @@ static ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, c
 }
 
 static ncclResult_t xmlSetAttrIfUnset(struct ncclXmlNode* node, const char* attrName, const char* value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index != -1) return ncclSuccess;
   index = node->nAttrs++;
   strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
@@ -163,8 +158,7 @@ static ncclResult_t xmlSetAttrIfUnset(struct ncclXmlNode* node, const char* attr
 }
 
 static ncclResult_t xmlSetAttrInt(struct ncclXmlNode* node, const char* attrName, const int value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) {
     index = node->nAttrs++;
     strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
@@ -176,8 +170,7 @@ static ncclResult_t xmlSetAttrInt(struct ncclXmlNode* node, const char* attrName
 }
 
 static ncclResult_t xmlSetAttrFloat(struct ncclXmlNode* node, const char* attrName, const float value) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) {
     index = node->nAttrs++;
     strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
@@ -189,8 +182,7 @@ static ncclResult_t xmlSetAttrFloat(struct ncclXmlNode* node, const char* attrNa
 }
 
 static ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName) {
-  int index;
-  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  int index = xmlGetAttrIndex(node, attrName);
   if (index == -1) return ncclSuccess;
   for (int i=index+1; i<node->nAttrs; i++) {
     strcpy(node->attrs[i-1].key, node->attrs[i].key);

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -70,6 +70,10 @@ static int xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrName) {
   return -1;
 }
 
+static bool xmlHasAttr(struct ncclXmlNode* node, const char* attrName) {
+  return xmlGetAttrIndex(node, attrName) != -1;
+}
+
 static ncclResult_t xmlGetAttr(struct ncclXmlNode* node, const char* attrName, const char** value) {
   int index = xmlGetAttrIndex(node, attrName);
   *value = index == -1 ? NULL : node->attrs[index].value;


### PR DESCRIPTION
I recently observed a bug when using GCC 12.2 where the stacktrace led to `xmlGetAttrIndex`.

My suspicion was, that GCC misoptimizes around that out-parameter and I changed the function to return the index instead of an error code which is always "no error". It didn't solve the bug which is likely in the inline-asm for `cpuid` (see my [upstream GCC report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112513)) but I think this changeset is still worth including especially as it gives rise to `xmlHasAttr` instead of repeated code like
```
    int index;
    NCCLCHECK(xmlGetAttrIndex(xmlNet, "dev", &index));
    if (index == -1) ...
```

It also makes the optimizers work easier by basically removing the whole code introduced by `NCCLCHECK` which will/should be removed entirely by the optimizer.

2 observations while touching this code:
- The same can be done to `xmlGetAttr` which also always returns success and could simply return the NULL-or-valid pointer
- The `xmlInitAttr*` function might need a range check around `index = node->nAttrs++;` to not overflow the `node->attrs` array in case there are more attributes than expected.