### PR TITLE
Fix use of CPUID overwriting registers in use

### DIFF
--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -12,6 +12,9 @@
 #include "core.h"
 #include "nvmlwrap.h"
 #include "xml.h"
+#if defined(__x86_64__)
+#include <cpuid.h>
+#endif
 
 /*******************/
 /* XML File Parser */
@@ -412,7 +415,8 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
       char vendor[12];
     } cpuid0;
 
-    asm volatile("cpuid" : "=b" (cpuid0.ebx), "=c" (cpuid0.ecx), "=d" (cpuid0.edx) : "a" (0) : "memory");
+    unsigned unused;
+    __cpuid(0, unused, cpuid0.ebx, cpuid0.ecx, cpuid0.edx);
     char vendor[13];
     strncpy(vendor, cpuid0.vendor, 12);
     vendor[12] = '\0';
@@ -434,7 +438,8 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
       };
       uint32_t val;
     } cpuid1;
-    asm volatile("cpuid" : "=a" (cpuid1.val) : "a" (1) : "memory");
+    unsigned unused;
+    __cpuid(1, cpuid1.val, unused, unused, unused);
     int familyId = cpuid1.familyId + (cpuid1.extFamilyId << 4);
     int modelId = cpuid1.modelId + (cpuid1.extModelId << 4);
     NCCLCHECK(xmlSetAttrInt(cpuNode, "familyid", familyId));


### PR DESCRIPTION
I debugged a segmentation fault happening with GCC 12 and high optimizations. The cause is that CPUID writes to EAX, EBX, ECX, and EDX so the inline-asm must state that. Otherwise currently in-use register might get overwritten which may cause all kinds of failures like segfaults or wrong results.

Hence `asm volatile("cpuid" : "=a" (cpuid1.val) : "a" (1) : "memory");` is wrong as it doesn't state that and at least needs to be replaced by `asm volatile("cpuid" : "=a" (cpuid1.val) : "a" (1) : "ebx", "ecx", "edx", "memory");`

Similar also for `asm volatile("cpuid" : "=b" (cpuid0.ebx), "=c" (cpuid0.ecx), "=d" (cpuid0.edx) : "a" (0) : "memory");` which doesn't mention the clobbering of the EAX register.

Alternatively `__cpuid` can be used which avoids this and related issues. So do that as suggested in the GCC issue https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112513   
See that also for stacktraces of the observed crash and debug-logs showing a modified parameter leading to this issue

See also https://faydoc.tripod.com/cpu/cpuid.htm for documentation of `cpuid` and the modified registers and https://wiki.osdev.org/CPUID for a wiki entry about `__cpuid` (especially with the "unused" parameter)