### PR TITLE
fix protoEnable array when setting LL128

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -255,6 +255,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   if (protoStr) {
     INFO(NCCL_ENV, "NCCL_PROTO set by environment to %s", protoStr);
     NCCLCHECK(parseList(protoStr, ncclProtoStr, NCCL_NUM_PROTOCOLS, protoEnable));
+    if (protoEnable[1]) protoEnable[1] = 2;
   }
   const char *algoStr = ncclGetEnv("NCCL_ALGO");
   if (algoStr) {


### PR DESCRIPTION
```
int protoEnable[NCCL_NUM_PROTOCOLS] = { 1, 2, 1 };
```
When using LL128, `protoEnable[1]` is set by value 2 as initialization. However, if setting `NCCL_PROTO=LL128`, the value `protoEnable[1]` will be 1 after `parseList`, because parseList can only set 0 or 1 which will invalidate the following code in Line 287.
```
if (pEnable == 2 && p == NCCL_PROTO_LL128) {
```