### PR TITLE
Add support for allocating persistent plans using async alloc

### DIFF
--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -175,6 +175,8 @@ struct ncclKernelPlan {
   struct ncclKernelPlan* next;
 
   bool persistent; // aka captured in a graph
+  cudaStream_t persistentAllocStream; // stream for allocating persistent plans
+
   bool kernelSpecialized;
   void *kernelFn;
   int channelUbound; // only channels c < channelUbound are present
@@ -387,6 +389,9 @@ struct ncclComm {
 
   // Tuning plugin
   ncclTuner_t* tuner;
+
+  // Stream that was used to allocate persistent plan.
+  cudaStream_t persistentAllocStream;
 };
 
 enum ncclLaunchMode {

--- a/src/init.cc
+++ b/src/init.cc
@@ -2253,6 +2253,18 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void* handle) {
   return ret;
 }
 
+NCCL_API(ncclResult_t, ncclCommSetPersistentAllocStream, const ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclCommSetPersistentAllocStream(const ncclComm_t comm, cudaStream_t stream) {
+  comm->persistentAllocStream = stream;
+  return ncclSuccess;
+}
+
+NCCL_API(ncclResult_t, ncclCommGetPersistentAllocStream, const ncclComm_t comm, cudaStream_t* stream);
+ncclResult_t  ncclCommGetPersistentAllocStream(const ncclComm_t comm, cudaStream_t* stream) {
+  *stream = comm->persistentAllocStream;
+  return ncclSuccess;
+}
+
 NCCL_API(ncclResult_t, ncclMemAlloc, void **ptr, size_t size);
 ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
   NVTX3_FUNC_RANGE_IN(nccl_domain);

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -434,6 +434,22 @@ ncclResult_t pncclCommRegister(const ncclComm_t comm, void* buff, size_t size, v
 ncclResult_t  ncclCommDeregister(const ncclComm_t comm, void* handle);
 ncclResult_t pncclCommDeregister(const ncclComm_t comm, void* handle);
 
+/* Sets CUDA stream for allocating and initializing persistent plans on device
+ * using stream ordered allocation.
+ *
+ * When NCCL operations captured into CUDA graphs persistent state associated
+ * with captured graphs allocated on device and freed when CUDA graph is
+ * destroyed. It is a user responsibility to serialize captured CUDA graph
+ * execution after allocations recorded on a given stream: launch captured graph
+ * on the same stream, or add an event after graph capture is completed.
+ * */
+ncclResult_t  ncclCommSetPersistentAllocStream(const ncclComm_t comm, cudaStream_t stream);
+ncclResult_t pncclCommSetPersistentAllocStream(const ncclComm_t comm, cudaStream_t stream);
+
+/* Gets CUDA stream for allocating and initializing persistent plans on device */
+ncclResult_t  ncclCommGetPersistentAllocStream(const ncclComm_t comm, cudaStream_t* stream);
+ncclResult_t pncclCommGetPersistentAllocStream(const ncclComm_t comm, cudaStream_t* stream);
+
 #ifdef __cplusplus
 } // end extern "C"
 #endif


### PR DESCRIPTION
Currently when NCCL operations captured in CUDA graphs NCCL allocates an on-device storage for pointer to plan using sync allocations, which adds significant overheads to graph capture.

Add an option to set up a stream for stream ordered allocator to allocate persistent state on device.