### PR TITLE
Fix a handful of memory leaks in NCCL error paths.

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -629,6 +629,7 @@ static ncclResult_t xmlInitAttrFloat(struct ncclXmlNode* node, const char* attrN
 ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** system) {
   struct ncclXml* xml;
   NCCLCHECK(ncclCalloc(&xml, 1));
+  std::unique_ptr<void, void(*)(void*)> xml_ptr(xml, free);
   const char* xmlTopoFile = ncclGetEnv("NCCL_TOPO_FILE");
   if (xmlTopoFile) {
     INFO(NCCL_ENV, "NCCL_TOPO_FILE set by environment to %s", xmlTopoFile);
@@ -709,7 +710,6 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
   }
 
   NCCLCHECK(ncclTopoGetSystemFromXml(xml, system));
-  free(xml);
   return ncclSuccess;
 }
 

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -478,6 +478,7 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
   char* path = NULL;
   ncclDebugNoWarn = NCCL_GRAPH;
   getPciPath(busId, &path);
+  std::unique_ptr<void, void(*)(void*)> path_ptr(path, free);
   ncclDebugNoWarn = 0;
 
   if (path) {
@@ -604,7 +605,6 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
   } else if (strcmp(parent->name, "cpu") == 0) {
     NCCLCHECK(ncclTopoGetXmlFromCpu(parent, xml));
   }
-  free(path);
   return ncclSuccess;
 }
 
@@ -744,13 +744,13 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
       char* path;
       ncclDebugNoWarn = NCCL_GRAPH;
       getPciPath(busId, &path);
+      std::unique_ptr<void, void(*)(void*)> path_ptr(path, free);
       ncclDebugNoWarn = 0;
       if (path == NULL || strcmp(busId, "fffffff:ffff:ff") == 0) {
         // Remote NVLink device is not visible inside this VM. Assume NVSwitch.
         NCCLCHECK(xmlSetAttr(sub, "tclass", "0x068000"));
       } else {
         NCCLCHECK(ncclTopoSetAttrFromSys(sub, path, "class", "tclass"));
-        free(path);
       }
     }
   }


### PR DESCRIPTION
There are many cases in which NCCL fails to arrange that memory is freed if an error occurs. This PR fixes a couple I noticed occurring in practice.