### PR TITLE
Fix clang template function call.

### DIFF
--- a/src/device/all_gather.h
+++ b/src/device/all_gather.h
@@ -281,7 +281,7 @@ struct RunWorkElement<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCC
         scat.args = args;
         scat.chunkSize = chunkSize;
         scat.railGridOffset = railGridOffset;
-        prims.process</*Recv=*/1, /*Send=*/1>(scat);
+        prims.template process</*Recv=*/1, /*Send=*/1>(scat);
       }
       return;
     }
@@ -298,7 +298,7 @@ struct RunWorkElement<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCC
         scat.args = args;
         scat.chunkSize = chunkSize;
         scat.railGridOffset = railGridOffset;
-        prims.process</*Recv=*/1, /*Send=*/0>(scat);
+        prims.template process</*Recv=*/1, /*Send=*/0>(scat);
       }
       return;
     }

--- a/src/device/reduce_scatter.h
+++ b/src/device/reduce_scatter.h
@@ -254,7 +254,7 @@ struct RunWorkElement<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT,
         scat.args = args;
         scat.chunkSize = chunkSize;
         scat.railGridOffset = railGridOffset;
-        prims.process</*Recv=*/0, /*Send=*/1>(scat);
+        prims.template process</*Recv=*/0, /*Send=*/1>(scat);
       }
       return;
     }
@@ -271,7 +271,7 @@ struct RunWorkElement<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT,
         scat.args = args;
         scat.chunkSize = chunkSize;
         scat.railGridOffset = railGridOffset;
-        prims.process</*Recv=*/1, /*Send=*/1>(scat);
+        prims.template process</*Recv=*/1, /*Send=*/1>(scat);
       }
       return;
     }


### PR DESCRIPTION
Clang can't disambiguation template method call after ".", so we need to specify it manually.