### PR TITLE
[bugfix]save undo plans in some case

### DIFF
--- a/src/group.cc
+++ b/src/group.cc
@@ -142,7 +142,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
     }
 
     while (true) { // Iterate rounds of launches for clique.
-      bool moreRounds;
+      bool moreRounds = false;
       comm = cliqueHead;
       do { // Iterate clique members.
         struct ncclComm* next = comm->groupNext;
@@ -150,7 +150,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
           // Barrier reduction result tells us if this was the final round.
           moreRounds = 0 != ncclCommIntraBarrierOut(comm);
         } else {
-          moreRounds = comm->unlaunchedPlansHead != nullptr;
+          moreRounds |= comm->unlaunchedPlansHead != nullptr;
         }
         if (moreRounds) {
           // Pop next unlaunched kernel


### PR DESCRIPTION
In the original logic, some comm‘s plans will be missed in some cases. 

For example,  suppose there is a comm list here, containing two comms. The first comm contains three plans, and the second comm contains one plan. In the first round of the loop, the first plan of the two comms will start the corresponding kernel. In the second round of the loop, the second plan of the first comm will start the corresponding kernel, and then the second comm has no undo plan, so moreround is set to false, and finally the loop exits. The final result is that the third plan of the first comm has not been executed, the second plan has not yet finish stream sync, and the collective communication is over.

Although this possibility is relatively small, because the work budget of a plan is so large.