### PR TITLE
fix clang errors

### DIFF
--- a/src/include/nvtx3/nvtx3.hpp
+++ b/src/include/nvtx3/nvtx3.hpp
@@ -1937,9 +1937,9 @@ class event_attributes {
         0,                              // color value
         NVTX_PAYLOAD_UNKNOWN,           // payload type
         0,                              // reserved 4B
-        0,                              // payload value (union)
+        {0},                              // payload value (union)
         NVTX_MESSAGE_UNKNOWN,           // message type
-        0                               // message value (union)
+        {0}                               // message value (union)
       }
   {
   }

--- a/src/net.cc
+++ b/src/net.cc
@@ -48,7 +48,7 @@ static ncclResult_t ncclNet_v7_as_v8_getProperties(int dev, ncclNetProperties_v8
 }
 
 static ncclResult_t ncclNet_v7_as_v8_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1<<31) return ncclInternalError;
+  if (size >= 1UL<<31) return ncclInternalError;
   return ncclNet_v7->regMr(comm, data, (int) size, type, mhandle);
 }
 
@@ -95,7 +95,7 @@ static ncclResult_t ncclNet_v6_as_v8_getProperties(int dev, ncclNetProperties_v8
 }
 
 static ncclResult_t ncclNet_v6_as_v8_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1<<31) return ncclInternalError;
+  if (size >= 1UL<<31) return ncclInternalError;
   return ncclNet_v6->regMr(comm, data, (int) size, type, mhandle);
 }
 
@@ -150,7 +150,7 @@ static ncclResult_t ncclNet_v5_as_v8_getProperties(int dev, ncclNetProperties_v8
 }
 
 static ncclResult_t ncclNet_v5_as_v8_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1<<31) return ncclInternalError;
+  if (size >= 1UL<<31) return ncclInternalError;
   return ncclNet_v5->regMr(comm, data, (int) size, type, mhandle);
 }
 
@@ -207,7 +207,7 @@ static ncclResult_t ncclCollNet_v5_as_v8_getProperties(int dev, ncclNetPropertie
 }
 
 static ncclResult_t ncclCollNet_v5_as_v8_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1<<31) return ncclInternalError;
+  if (size >= 1UL<<31) return ncclInternalError;
   return ncclCollNet_v5->regMr(comm, data, (int) size, type, mhandle);
 }
 
@@ -254,7 +254,7 @@ static ncclResult_t ncclCollNet_v6_as_v8_getProperties(int dev, ncclNetPropertie
 }
 
 static ncclResult_t ncclCollNet_v6_as_v8_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1<<31) return ncclInternalError;
+  if (size >= 1UL<<31) return ncclInternalError;
   return ncclCollNet_v6->regMr(comm, data, (int) size, type, mhandle);
 }
 
@@ -301,7 +301,7 @@ static ncclResult_t ncclCollNet_v7_as_v8_getProperties(int dev, ncclNetPropertie
 }
 
 static ncclResult_t ncclCollNet_v7_as_v8_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1<<31) return ncclInternalError;
+  if (size >= 1UL<<31) return ncclInternalError;
   return ncclCollNet_v7->regMr(comm, data, (int) size, type, mhandle);
 }
 


### PR DESCRIPTION
Fixes two errors, specifically when compiling with clang-15

1. `-Wmissing-braces`: add missing brackets around object construction in`nctx3.hpp`. Upstream PR of nvtx from https://github.com/NVIDIA/NVTX/pull/88

2. `-Wshift-sign-overflow`
reproducer: `CXX=clang++ CC=clang CXXFLAGS="-Werror -Wshift-sign-overflow" make src.build CUDA_HOME=/usr/local/cuda`
error:
```
net.cc:304:16: error: signed shift result (0x80000000) sets the sign bit of the shift expression's type ('int') and becomes negative [-Werror,-Wshift-sign-overflow]
  if (size >= 1<<31) return ncclInternalError;
```