### PR TITLE
Bugfix：Avoid deadlock issues caused by logging in a loop

### DIFF
--- a/src/misc/param.cc
+++ b/src/misc/param.cc
@@ -61,10 +61,6 @@ void initEnv() {
 
 void ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, int64_t* cache) {
   static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-  if (__builtin_expect(__atomic_load_n(cache, __ATOMIC_RELAXED) != uninitialized, true)) {
-    return;
-  }
-
   pthread_mutex_lock(&mutex);
   if (__atomic_load_n(cache, __ATOMIC_RELAXED) == uninitialized) {
     const char* str = ncclGetEnv(env);

--- a/src/misc/param.cc
+++ b/src/misc/param.cc
@@ -61,21 +61,29 @@ void initEnv() {
 
 void ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, int64_t* cache) {
   static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+  if (__builtin_expect(__atomic_load_n(cache, __ATOMIC_RELAXED) != uninitialized, true)) {
+    return;
+  }
+
   pthread_mutex_lock(&mutex);
   if (__atomic_load_n(cache, __ATOMIC_RELAXED) == uninitialized) {
     const char* str = ncclGetEnv(env);
     int64_t value = deftVal;
-    if (str && strlen(str) > 0) {
-      errno = 0;
-      value = strtoll(str, nullptr, 0);
-      if (errno) {
-        value = deftVal;
-        INFO(NCCL_ALL,"Invalid value %s for %s, using default %lld.", str, env, (long long)deftVal);
-      } else {
-        INFO(NCCL_ENV,"%s set by environment to %lld.", env, (long long)value);
-      }
+    if (!str || strlen(str) <= 0) {
+      __atomic_store_n(cache, value, __ATOMIC_RELAXED);
+      pthread_mutex_unlock(&mutex);
+      return;
     }
-    __atomic_store_n(cache, value, __ATOMIC_RELAXED);
+    errno = 0;
+    value = strtoll(str, nullptr, 0);
+    // To prevent deadlock issues caused by logging in a loop,
+    // so cache the value before the log operation.
+    __atomic_store_n(cache, errno ? deftVal : value, __ATOMIC_RELAXED);
+    if (errno) {
+      INFO(NCCL_ALL,"Invalid value %s for %s, using default %lld.", str, env, (long long)deftVal);
+    } else {
+      INFO(NCCL_ENV,"%s set by environment to %lld.", env, (long long)value);
+    }
   }
   pthread_mutex_unlock(&mutex);
 }


### PR DESCRIPTION
To prevent deadlock issues caused by logging in a loop, so cache the value before the log operation.
Here are the related function call paths：
```
ncclDebugLog -> ncclLoadParam(lock) -> ncclDebugLog -> ncclLoadParam(deadlock)
```

https://github.com/NVIDIA/nccl/blob/ab2b89c4c339bd7f816fbc114a4b05d386b66290/src/misc/param.cc#L62-L76

The following stack is happend local development.
![image](https://github.com/NVIDIA/nccl/assets/8215757/55ee83cb-2cd7-4148-9aa7-1e4f5781a8d1)
