### PR TITLE
[bugfix]fix graph/xml.cc with checkBDFFormat typo bug

### DIFF
--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -542,9 +542,9 @@ ncclResult_t ncclTopoGetPciNode(struct ncclXml* xml, const char* busId, struct n
 int isHex(char c) { return ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')); }
 int checkBDFFormat(char* bdf) {
   if (bdf[4] != ':' || bdf[7] != ':' || bdf[10] != '.') return 0;
-  if (isHex(bdf[0]) == 0 || isHex(bdf[1] == 0) || isHex(bdf[2] == 0) || isHex(bdf[3] == 0) ||
-      isHex(bdf[5] == 0) || isHex(bdf[6] == 0) || isHex(bdf[8] == 0) || isHex(bdf[9] == 0) ||
-      isHex(bdf[11] == 0)) return 0;
+  if (isHex(bdf[0]) == 0 || isHex(bdf[1]) == 0 || isHex(bdf[2]) == 0 || isHex(bdf[3]) == 0 ||
+      isHex(bdf[5]) == 0 || isHex(bdf[6]) == 0 || isHex(bdf[8]) == 0 || isHex(bdf[9]) == 0 ||
+      isHex(bdf[11]) == 0) return 0;
   return 1;
 }
 


### PR DESCRIPTION

fix type: `checkBDFFormat`
 `isHex(char == 0)` => `isHex(false)` => false and makes

```C++
  if (isHex(bdf[0]) == 0 || isHex(bdf[1] == 0) || isHex(bdf[2] == 0) || isHex(bdf[3] == 0) ||
      isHex(bdf[5] == 0) || isHex(bdf[6] == 0) || isHex(bdf[8] == 0) || isHex(bdf[9] == 0) ||
      isHex(bdf[11] == 0)) return 0;
```

 always true. should be

```C++
  if (isHex(bdf[0]) == 0 || isHex(bdf[1]) == 0 || isHex(bdf[2]) == 0 || isHex(bdf[3]) == 0 ||
      isHex(bdf[5]) == 0 || isHex(bdf[6]) == 0 || isHex(bdf[8]) == 0 || isHex(bdf[9]) == 0 ||
      isHex(bdf[11]) == 0) return 0;
```

