### PR TITLE
Include the CUDA call that failed in errors.

### DIFF
--- a/src/include/cudawrap.h
+++ b/src/include/cudawrap.h
@@ -30,7 +30,7 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
     if( err != CUDA_SUCCESS ) {				      \
       const char *errStr;				      \
       (void) pfn_cuGetErrorString(err, &errStr);	      \
-      WARN("Cuda failure %d '%s'", err, errStr);	      \
+      WARN("Cuda failure %d '%s' from %s", err, errStr, #cmd);	      \
       return ncclUnhandledCudaError;			      \
     }							      \
 } while(false)
@@ -40,7 +40,7 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
     if( err != CUDA_SUCCESS ) {				      \
       const char *errStr;				      \
       (void) pfn_cuGetErrorString(err, &errStr);	      \
-      WARN("Cuda failure %d '%s'", err, errStr);	      \
+      WARN("Cuda failure %d '%s' from %s", err, errStr, #cmd);	      \
       res = ncclUnhandledCudaError;			      \
       goto label;					      \
     }							      \
@@ -52,7 +52,7 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
     if( err != CUDA_SUCCESS ) {						\
       const char *errStr;						\
       (void) pfn_cuGetErrorString(err, &errStr);			\
-      INFO(NCCL_ALL,"%s:%d Cuda failure %d '%s'", __FILE__, __LINE__, err, errStr); \
+      INFO(NCCL_ALL,"%s:%d Cuda failure %d '%s' from %s", __FILE__, __LINE__, err, errStr, #cmd); \
     }									\
 } while(false)
 


### PR DESCRIPTION
To make debugging easier.