### PR TITLE
add ncclLastResult to report library error

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -18,6 +18,7 @@ int ncclDebugLevel = -1;
 static int pid = -1;
 static char hostname[1024];
 thread_local int ncclDebugNoWarn = 0;
+ncclResult_t ncclLastResult = ncclSuccess;
 char ncclLastError[1024] = ""; // Global string for the last error in human readable form
 static uint64_t ncclDebugMask = NCCL_INIT|NCCL_ENV; // Default debug sub-system mask is INIT and ENV
 FILE *ncclDebugFile = stdout;

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -23,6 +23,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
 
 // Let code temporarily downgrade WARN into INFO
 extern thread_local int ncclDebugNoWarn;
+extern ncclResult_t ncclLastResult;
 extern char ncclLastError[];
 
 #define VERSION(...) ncclDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __LINE__, __VA_ARGS__)

--- a/src/init.cc
+++ b/src/init.cc
@@ -2107,6 +2107,14 @@ const char* ncclGetErrorString(ncclResult_t code) {
   }
 }
 
+/* Returns a ncclResult_t of the last error that occurred.
+ * comm is currently unused and can be set to NULL
+ */
+NCCL_API(ncclResult_t, ncclGetLastResult, const ncclComm_t comm);
+ncclResult_t ncclGetLastResult(ncclComm_t comm) {
+  return ncclLastResult;
+}
+
 /* Returns a human-readable message of the last error that occurred.
  * comm is currently unused and can be set to NULL
  */

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -172,6 +172,9 @@ ncclResult_t pncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t *new
 const char*  ncclGetErrorString(ncclResult_t result);
 const char* pncclGetErrorString(ncclResult_t result);
 
+/* Returns a ncclResult_t of the last error that occurred. */
+ncclResult_t ncclGetLastResult(ncclComm_t comm);
+
 /* Returns a human-readable message of the last error that occurred. */
 const char*  ncclGetLastError(ncclComm_t comm);
 const char* pncclGetLastError(ncclComm_t comm);

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1523,6 +1523,13 @@ void* ncclProxyService(void* _args) {
       }
 
       if (closeConn) {
+        INFO(NCCL_PROXY, "Close connection since error %s", ncclGetErrorString(res));
+        if (res != ncclSuccess && res != ncclInProgress) {
+          ncclLastResult = res;
+          const char *error_string = ncclGetErrorString(ncclLastResult);
+          strcpy(ncclLastError, error_string);
+        }
+
         ncclSocketClose(sock);
 
         if (op != nullptr) {


### PR DESCRIPTION
add ncclLastResult API to report library error, rather than ncclComm error from ncclCommGetAsyncError