### PR TITLE
delete duplicated code in sendProxySetup() in net.cc

### DIFF
--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -598,9 +598,6 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   resources->netDeviceVersion = props.netDeviceVersion;
   resources->netDeviceType = props.netDeviceType;
 
-  resources->netDeviceVersion = props.netDeviceVersion;
-  resources->netDeviceType = props.netDeviceType;
-
   // We don't return any data
   if (respSize != 0) return ncclInternalError;
   *done = 1;


### PR DESCRIPTION
The sendProxySetup() function in src/transport/net.cc has duplicated code. Although these code will not affect the function of NCCL, I think it should be deleted.