### PR TITLE
net_ib: return ncclSuccess if read roceTypePath failed and errno is E…

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -248,6 +248,10 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
   close(fd);
 
   if (ret == -1) {
+    WARN("NET/IB: read failed: %s, roceTypePath: %s", strerror(errno), roceTypePath);
+    if (errno == EINVAL) {
+      return ncclSuccess;
+    }
     return ncclSystemError;
   }
 


### PR DESCRIPTION
…INVAL.  #890

Please refer to the problem details：https://github.com/NVIDIA/nccl/issues/890