### PR TITLE
Read abortFlag on the first spin in checkAbort

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -54,11 +54,12 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p>:
   uint32_t abort = 0;
 
   inline __device__ int checkAbort(int &spins, int send) {
-    spins++;
-    if (abort == 0 && spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
+    // Check abortFlag on the 0th spin and multiples of NCCL_SPINS_BEFORE_CHECK_ABORT
+    if (abort == 0 && spins % NCCL_SPINS_BEFORE_CHECK_ABORT == 0) {
       abort = *ncclShmem.comm.abortFlag;
       spins = 0;
     }
+    spins++;
     return abort;
   }
 

--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -56,11 +56,12 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p>:
   uint32_t abort = 0;
 
   inline __device__ int checkAbort(int &spins, int i, int send) {
-    spins++;
-    if (abort == 0 && spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
+    // Check abortFlag on the 0th spin and multiples of NCCL_SPINS_BEFORE_CHECK_ABORT
+    if (abort == 0 && spins % NCCL_SPINS_BEFORE_CHECK_ABORT == 0) {
       abort = *ncclShmem.comm.abortFlag;
       spins = 0;
     }
+    spins++;
     return abort;
   }
 

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -92,14 +92,15 @@ class Primitives<
   }
 
   inline __device__ bool checkAbort(int &spins) {
-    spins++;
-    if (!(flags & Aborted) && spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
+    // Check abortFlag on the 0th spin and multiples of NCCL_SPINS_BEFORE_CHECK_ABORT
+    if (!(flags & Aborted) && spins % NCCL_SPINS_BEFORE_CHECK_ABORT == 0) {
       if (*ncclShmem.comm.abortFlag) {
         flags |= Aborted;
         ncclShmem.aborted = 1;
       }
       spins = 0;
     }
+    spins++;
     return flags & Aborted;
   }
 


### PR DESCRIPTION
While trying to abort the PyTorch [process groups](https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group) that are involved in a hybrid-sharded data parallel job, we noticed that it takes a long time (>2 mins) to call `ncclCommAbort()`.

Upon further debugging, we realized that when `ncclCommAbort()` was called, there are already a bunch of queued NCCL AllGather kernels, but strangely these NCCL kernels that run after abort are taking a long time to exit (much longer than nominal AllGathers). Concretely, nominal AllGathers would take around 1ms to complete, but after `ncclCommAbort` is called, the post-abort AllGathers would take 200ms to complete, and there are many of these AllGather kernels stuck in the queue. Because there's a stream synchronize call involved in `ncclCommAbort()`, these queued kernels then also cause `ncclCommAbort()` to get stuck until the stream can be cleared.

We traced it down to this https://github-ap.tesla.com/AI/nccl/blob/master/src/device/prims_ll.h#L55-L62 call which seems to only be examining the `abortFlag` after 1,000,000 spins.

This PR proposes to examine the `abortFlag` in the 0th `spin` so that there's an opportunity for the NCCL kernels to exit early if `abortFlag` is already set to 1, therefore also speeding up `ncclCommAbort()`.

I was wondering if this approach is reasonable and whether it has major downsides? cc @sjeaugey @KaimingOuyang