### PR TITLE
Makefile: Add nccl_common.h and nccl_tuner.h to INCEXPORTS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ include ../makefiles/common.mk
 include ../makefiles/version.mk
 
 ##### src files
-INCEXPORTS  := nccl.h nccl_net.h
+INCEXPORTS  := nccl.h nccl_net.h nccl_common.h nccl_tuner.h
 LIBSRCFILES := \
 	bootstrap.cc channel.cc collectives.cc debug.cc enqueue.cc group.cc \
 	init.cc init_nvtx.cc net.cc proxy.cc transport.cc register.cc \


### PR DESCRIPTION
To build an out-of-tree Tuner plugin, we need to have access to definitions from `nccl_common.h` and `nccl_tuner.h`. These header files will be installed in `/usr/local/include/` by default, which is one of GCC's default search paths for header files.