### PR TITLE
align the peer mem access check with API document

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -2397,7 +2397,7 @@ ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
     /* Now allow RW access to the newly mapped memory */
     for (int i = 0; i < dcnt; ++i) {
       int p2p = 0;
-      if (i == cudaDev || ((cudaDeviceCanAccessPeer(&p2p, cudaDev, i) == cudaSuccess) && p2p)) {
+      if (i == cudaDev || ((cudaDeviceCanAccessPeer(&p2p, i, cudaDev) == cudaSuccess) && p2p)) {
         accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
         accessDesc.location.id = i;
         accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;


### PR DESCRIPTION
In API document, it writes below:
  cudaDeviceCanAccessPeer(int* canAccessPeer, int device, int peerDevice )
  [if device device is capable of directly accessing memory from peerDevice](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__PEER.html#group__CUDART__PEER_1g4db0d04e44995d5c1c34be4ecc863f22)