### PR TITLE
Fix the loop condition in ncclFindInterfaceMatchSubnet as it may not behave as expected when maxIfs > 1

### DIFF
--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -231,7 +231,7 @@ int ncclFindInterfaceMatchSubnet(char* ifNames, union ncclSocketAddress* localAd
   int found = 0;
   struct ifaddrs *interfaces, *interface;
   getifaddrs(&interfaces);
-  for (interface = interfaces; interface && !found; interface = interface->ifa_next) {
+  for (interface = interfaces; interface && found < maxIfs; interface = interface->ifa_next) {
     if (interface->ifa_addr == NULL) continue;
 
     /* We only support IPv4 & IPv6 */
@@ -253,7 +253,6 @@ int ncclFindInterfaceMatchSubnet(char* ifNames, union ncclSocketAddress* localAd
 
     TRACE(NCCL_INIT|NCCL_NET,"NET : Found interface %s:%s in the same subnet as remote address %s", interface->ifa_name, ncclSocketToString(localAddrs+found, line), ncclSocketToString(remoteAddr, line_a));
     found++;
-    if (found == maxIfs) break;
   }
 
   if (found == 0) {


### PR DESCRIPTION
I am a newcomer learning NCCL, and I have come across this part of the code that seems potentially unreasonable.

When maxIfs > 1, we will only find the first IF that matches subnet.
