### PR TITLE
Fix node mirroring of the second tree in dtree

### DIFF
--- a/src/graph/trees.cc
+++ b/src/graph/trees.cc
@@ -102,8 +102,8 @@ ncclResult_t ncclGetDtree(int nranks, int rank, int* s0, int* d0_0, int* d0_1, i
     int u, d0, d1;
     ncclGetBtree(nranks, nranks-1-rank, &u, &d0, &d1, parentChildType1);
     *s1 = u == -1 ? -1 : nranks-1-u;
-    *d1_0 = d0 == -1 ? -1 : nranks-1-d0;
-    *d1_1 = d1 == -1 ? -1 : nranks-1-d1;
+    *d1_0 = d1 == -1 ? -1 : nranks-1-d1;
+    *d1_1 = d0 == -1 ? -1 : nranks-1-d0;
   }
   return ncclSuccess;
 }


### PR DESCRIPTION
### In src/graph/trees.cc file:
```txt
/* Build a double binary tree. Take the previous tree for the first tree.
 * For the second tree, we use a mirror tree (if nranks is even)
 *
 * 0---------------8                   3----------------11
 *          ______/ \                 / \______
 *         4         \               /         7
 *       /   \        \             /        /   \
 *     2       6       10         1        5      9
 *    / \     / \     /  \       / \      / \    / \
 *   1   3   5   7   9   11     0   2    4   6  8   10
 *
```
When using **mirror** to build the second tree, the two child nodes need to be swapped.
```c++
// original
*d1_0 = d0 == -1 ? -1 : nranks-1-d0;
*d1_1 = d1 == -1 ? -1 : nranks-1-d1;
```
Without the swap, the second tree would look like this:
```txt
 * 0---------------8           11----------------3
 *          ______/ \                     ______/ \
 *         4         \                   7         \
 *       /   \        \                /   \        \     
 *     2       6       10             9     5        1
 *    / \     / \     /  \           / \   / \      / \
 *   1   3   5   7   9   11        10   8 6   4    2   0
```
It can also be seen from the NCCL log:
```bash
[3] NCCL INFO Tree 0 : 2 -> 3 -> -1/-1/-1
[3] NCCL INFO Tree 1 : 11 -> 3 -> 7/1/-1
# child 0 (7) is greater than rank(3), and child 1 (1) is less than rank(3).
```
This could be a potential problem for any communication algorithm that would rely on this logic. So my fix is:
```c++
// fix: swap d1_0 and d1_1
*d1_0 = d1 == -1 ? -1 : nranks-1-d1;
*d1_1 = d0 == -1 ? -1 : nranks-1-d0;
```
NCCL log after fixing:
```
[3] NCCL INFO Tree 0 : 2 -> 3 -> -1/-1/-1
[3] NCCL INFO Tree 1 : 11 -> 3 -> 1/7/-1
```

Please let me know if this makes sense.