### PR TITLE
Fix for various issues in the graph module

### DIFF
--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -328,8 +328,7 @@ ncclResult_t ncclTopoReplayGetGpu(struct ncclTopoSystem* system, struct ncclTopo
     *g = i;
     return ncclSuccess;
   }
-  if (*g == -1) return ncclInternalError;
-  return ncclSuccess;
+  return ncclInternalError;
 }
 
 ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, struct ncclTopoNode* gpu, int step, int backToNet, int backToFirstRank, int forcedOrder, int *time);

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -246,7 +246,7 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
       pciSwitch->pci.device |= 0xffff;
       free(subSwIds);
       // Restart, as system->nodes[PCI].nodes has changed.
-      s = 0;
+      s = -1;  // Will be incremented to 0 in the next loop iteration
       continue;
 fail:
       free(subSwIds);

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -65,6 +65,8 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
         // because then all the prefixes before the prefix-less entry would be
         // overwritten.
         WARN("All entries except the first must have a prefix: \"%s\"", str);
+        free(subToken);
+        free(fullStr);
         return ncclInvalidUsage;
       }
       elemList = prefix;
@@ -97,6 +99,9 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
         }
         if (e==nelems) {
           WARN("Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
+          free(tokStr);
+          free(subToken);
+          free(fullStr);
           return ncclInvalidUsage;
         }
         elem = strtok_r(NULL, ",", &tmpStr);
@@ -105,6 +110,8 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
     }
     if (!foundPrefix) {
       WARN("Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
+      free(subToken);
+      free(fullStr);
       return ncclInvalidUsage;
     }
     free(subToken);

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -51,10 +51,11 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
 #endif
   }
   int o = 0;
+  char quote = c;  // Remember which quote type we started with
   do {
     NCCLCHECK(xmlGetChar(file, &c));
     value[o++] = c;
-  } while (c != '"');
+  } while (c != quote);
   value[o-1] = '\0';
   NCCLCHECK(xmlGetChar(file, last));
   return ncclSuccess;


### PR DESCRIPTION
The pr aims to fix some issues in the graph/ module. The details are as follows:

- graph/search.cc: removed an unreachable branch.
- graph/topo.cc: fixed an indexing issue when restarting the search.
- graph/tuning.cc: fixed the memory leakage issues when returning early.
- graph/xml.cc: fixed a bug when the xml value is wrapped in single quotes.