### PR TITLE
Add cross data center communications and network topology awareness to NCCL

### DIFF
--- a/ext-net/example/nccl/net.h
+++ b/ext-net/example/nccl/net.h
@@ -25,6 +25,7 @@
 
 typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* phandle, int64_t pluginId, void* extData);
 
+#include "net_v11.h"
 #include "net_v10.h"
 #include "net_v9.h"
 #include "net_v8.h"
@@ -35,9 +36,10 @@ typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* p
 #include "net_v3.h"
 #include "net_v2.h"
 
-typedef ncclNet_v10_t ncclNet_t;
-typedef ncclNetProperties_v10_t ncclNetProperties_t;
-typedef ncclNetVDeviceProps_v10_t ncclNetVDeviceProps_t;
-typedef ncclNetCommConfig_v10_t ncclNetCommConfig_t;
+typedef ncclNet_v11_t ncclNet_t;
+typedef ncclNetProperties_v11_t ncclNetProperties_t;
+typedef ncclNetVDeviceProps_v11_t ncclNetVDeviceProps_t;
+typedef ncclNetCommConfig_v11_t ncclNetCommConfig_t;
+typedef ncclNetPath_v11_t ncclNetPath_t;
 
 #endif // end include guard

--- a/ext-net/example/nccl/net_device.h
+++ b/ext-net/example/nccl/net_device.h
@@ -27,6 +27,7 @@ typedef struct {
 typedef ncclNetDeviceHandle_v7_t ncclNetDeviceHandle_v8_t;
 typedef ncclNetDeviceHandle_v8_t ncclNetDeviceHandle_v9_t;
 typedef ncclNetDeviceHandle_v9_t ncclNetDeviceHandle_v10_t;
-typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_t;
+typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_v11_t;
+typedef ncclNetDeviceHandle_v11_t ncclNetDeviceHandle_t;
 
 #endif

--- a/ext-net/example/nccl/net_v11.h
+++ b/ext-net/example/nccl/net_v11.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NET_V11_H_
+#define NET_V11_H_
+
+#define NCCL_NET_MAX_DEVS_PER_NIC_V11 4
+
+typedef struct {
+  int ndevs;
+  int devs[NCCL_NET_MAX_DEVS_PER_NIC_V11];
+} ncclNetVDeviceProps_v11_t;
+
+#define NCCL_NET_TRAFFIC_CLASS_UNDEF -1
+
+typedef struct {
+  // Plugin-specific TC value
+  int trafficClass;
+} ncclNetCommConfig_v11_t;
+
+typedef struct {
+  char* name;                      // Used mostly for logging.
+  char* pciPath;                   // Path to the PCI device in /sys.
+  uint64_t guid;                   // Unique identifier for the NIC chip. Important for
+                                   // cards with multiple PCI functions (Physical or virtual).
+  int ptrSupport;                  // [NCCL_PTR_HOST|NCCL_PTR_CUDA|NCCL_PTR_DMABUF]
+  int regIsGlobal;                 // regMr is not tied to a particular comm
+  int forceFlush;                  // Force a flush on receives
+  int speed;                       // Port speed in Mbps.
+  int port;                        // Port number.
+  float latency;                   // Network latency
+  int maxComms;                    // Maximum number of comms we can create
+  int maxRecvs;                    // Maximum number of grouped receives.
+  ncclNetDeviceType netDeviceType; // Network offload type
+  int netDeviceVersion;            // Version number for network offload
+  ncclNetVDeviceProps_v11_t vProps;
+  size_t maxP2pBytes;  // Max transfer size for point-to-point operations
+  size_t maxCollBytes; // Max transfer size for collective operations
+  uint64_t fabricId;   // Fabric handle associated to the current device
+} ncclNetProperties_v11_t;
+
+typedef enum {
+  NET_LOC_DCL0 = 0 /* same DC, hierarchy level 0*/,
+  NET_LOC_DCL1 = 1 /* different DC, hiearchy level 1 */,
+  NET_LOC_DISC = 2 /* disconnected*/
+} ncclNetLoc_v11_t;
+
+typedef struct {
+  ncclNetLoc_v11_t loc;
+} ncclNetPath_v11_t;
+
+typedef struct {
+  // Name of the network (mainly for logs)
+  const char* name;
+  // Initialize the network.
+  ncclResult_t (*init)(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  // Return the number of adapters.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v11_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create a connection.
+  ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+  // Connect to a handle and return a sending comm object for that peer.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with sendComm == NULL with the expectation that
+  // it will be called again until sendComm != NULL.
+  // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*connect)(int dev, ncclNetCommConfig_v11_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v11_t** sendDevComm);
+  // Finalize connection establishment after remote peer has called connect.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with recvComm == NULL with the expectation that
+  // it will be called again until recvComm != NULL.
+  // If *recvDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v11_t** recvDevComm);
+  // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+  // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* comm, void* mhandle);
+  // Asynchronous send to a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
+  // Asynchronous recv from a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* sizes);
+  // Close and free send/recv comm objects
+  ncclResult_t (*closeSend)(void* sendComm);
+  ncclResult_t (*closeRecv)(void* recvComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Copy the given mhandle to a dptr in a format usable by this plugin's device code
+  ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+
+  // Notify the plugin that a recv has completed by the device
+  ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+
+  // Virtual NIC APIs. makeVDevice will create a virtual NIC given the specified properties, and tell the caller
+  // what index this new vNIC exists at
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v11_t* props);
+
+  // topology API. getNetPath returns the path between two fabricIds.
+  ncclResult_t (*getNetPath)(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_v11_t* path);
+} ncclNet_v11_t;
+
+#endif // end include guard

--- a/src/graph/trees.cc
+++ b/src/graph/trees.cc
@@ -107,3 +107,9 @@ ncclResult_t ncclGetDtree(int nranks, int rank, int* s0, int* d0_0, int* d0_1, i
   }
   return ncclSuccess;
 }
+
+ncclResult_t ncclGetDtreeRoots(int nranks, int* r0, int* r1) {
+  if (r0) *r0 = 0; // primal tree root is always 0
+  if (r1) *r1 = (nranks % 2 == 1 && nranks > 1) ? 1 : (nranks - 1);
+  return ncclSuccess;
+}

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -124,6 +124,19 @@ static ncclResult_t xmlGetAttrLong(struct ncclXmlNode* node, const char* attrNam
   return ncclSuccess;
 }
 
+static ncclResult_t xmlGetAttrUint64(struct ncclXmlNode* node, const char* attrName, uint64_t* value) {
+  const char* str;
+  NCCLCHECK(xmlGetAttrStr(node, attrName, &str));
+  *value = strtoull(str, NULL, 0);
+  return ncclSuccess;
+}
+
+static ncclResult_t xmlGetAttrUint64Default(struct ncclXmlNode* node, const char* attrName, uint64_t* value, uint64_t defaultValue) {
+  const char* str;
+  NCCLCHECK(xmlGetAttr(node, attrName, &str));
+  *value = str ? strtoull(str, NULL, 0) : defaultValue;
+  return ncclSuccess;
+}
 
 static ncclResult_t xmlGetAttrFloat(struct ncclXmlNode* node, const char* attrName, float* value) {
   const char* str;
@@ -272,6 +285,19 @@ static ncclResult_t xmlSetAttrFloat(struct ncclXmlNode* node, const char* attrNa
 }
 
 static ncclResult_t xmlSetAttrLong(struct ncclXmlNode* node, const char* attrName, const int64_t value) {
+  int index;
+  NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
+  if (index == -1) {
+    index = node->nAttrs++;
+    strncpy(node->attrs[index].key, attrName, MAX_STR_LEN);
+    node->attrs[index].key[MAX_STR_LEN] = '\0';
+  }
+  snprintf(node->attrs[index].value, MAX_STR_LEN, "%#lx", value);
+  node->attrs[index].value[MAX_STR_LEN] = '\0';
+  return ncclSuccess;
+}
+
+static ncclResult_t xmlSetAttrUint64(struct ncclXmlNode* node, const char* attrName, const uint64_t value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) {

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -85,8 +85,14 @@ struct ncclUserRedOp {
 };
 
 struct ncclNodeRanks {
+  int dcIndex; // index into the DC array
   int localRanks;
   int* localRankToRank;
+};
+
+struct ncclDcNode {
+  int localNodes;
+  int* localNodeToNode;
 };
 
 struct cliqueInfo {
@@ -421,10 +427,14 @@ struct ncclComm {
   struct ncclProxyConnector* gproxyConn;
   struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next> legacyRegCleanupQueue;
 
+  int ncclNetCount;
+  int ncclDcNetIndex;
   int netPluginLoaded;
-  ncclNet_t* ncclNet;
-  int ncclNetVer;
   ncclNetDeviceType netDeviceType;
+  int ncclNetVer[NCCL_NET_MAX_PLUGINS];
+  int ncclNetPluginIdx[NCCL_NET_MAX_PLUGINS];
+  ncclNet_t* ncclNet[NCCL_NET_MAX_PLUGINS];
+  int ncclCollNetPluginIdx;
   ncclCollNet_t* ncclCollNet;
   void* bootstrap;
   // Bitmasks for ncclTransportP2pSetup
@@ -464,13 +474,16 @@ struct ncclComm {
   int* localRankToRank;
   // localRanks and localRanktoRank for all nodes
   struct ncclNodeRanks* nodeRanks;
+  // multi-DC support
+  int dcCount;
+  struct ncclDcNode* dcNode;
   // MNNVL: Multi-Node NVLink
   int MNNVL; // true when MNNVL is available
   struct cliqueInfo clique; // Our MNNVL clique information
   int cliqueRank; // Our rank within the MNNVL clique
 
   bool checkPointers;
-  bool dmaBufSupport;
+  bool dmaBufSupport[NCCL_NET_MAX_PLUGINS];
 
   // Counter for tracking CUDA launches (P2P and collectives included)
   uint64_t opCount;

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -155,7 +155,7 @@ struct ncclRing {
 
 
 // The root of each tree only has one node down (+1 intra-node).
-#define NCCL_MAX_TREE_ARITY_TOP 2
+#define NCCL_MAX_TREE_ARITY_TOP 3
 // Nodes inside the binary tree can have to two nodes down (+1 intra-node).
 #define NCCL_MAX_TREE_ARITY 3
 struct ncclTree {

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -9,6 +9,7 @@
 
 #include "nccl.h"
 #include "device.h"
+#include "nccl_net.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -33,7 +34,8 @@ ncclResult_t ncclTopoPathAllNVLink(struct ncclTopoSystem* system, int* allNvLink
 ncclResult_t ncclTopoComputeCommCPU(struct ncclComm* comm);
 
 // Query topology
-ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoGraph* graph, int channelId, int peerRank, int64_t* id, int* dev, int* proxyRank);
+ncclResult_t ncclTopoGetNetDevFromGraph(struct ncclComm* comm, int rank, int peerRank, struct ncclTopoGraph* graph, int channelId, int64_t* netId, int* netDev, int* netPathType);
+ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoGraph* graph, int channelId, int peerRank, int pxnRank, int64_t* id, int* dev, int* proxyRank);
 ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* system, int rank1, int rank2, int* p2p, int *read, int* intermediateRank);
 ncclResult_t ncclTopoCheckMNNVL(struct ncclTopoSystem* system, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* ret);
 enum ncclTopoGdrMode {
@@ -43,7 +45,7 @@ enum ncclTopoGdrMode {
   ncclTopoGdrModeNum = 3
 };
 ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* topo, int rank, int64_t netId, int read, enum ncclTopoGdrMode* gdrMode);
-ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int netDev, int rank, int* flush);
+ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int netIdx, int netDev, int rank, int* flush);
 ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool *avail);
 ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank2, int* net);
 int ncclPxnDisable(struct ncclComm* comm);
@@ -70,7 +72,7 @@ ncclResult_t ncclTopoCpuType(struct ncclTopoSystem* system, int* arch, int* vend
 ncclResult_t ncclTopoGetGpuCount(struct ncclTopoSystem* system, int* count);
 ncclResult_t ncclTopoGetNetCount(struct ncclTopoSystem* system, int* count);
 ncclResult_t ncclTopoGetNvsCount(struct ncclTopoSystem* system, int* count);
-ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int channelId, int64_t* id, int* dev);
+ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int channelId, int64_t* id, int* dev, int* pathType, int netDevCount, struct ncclNetDev* netDevs);
 ncclResult_t ncclTopoGetLocalGpu(struct ncclTopoSystem* system, int64_t netId, int* gpuIndex);
 ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *count);
 

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -12,6 +12,8 @@
 #include "comm.h"
 #include "checks.h"
 
+static NCCL_PARAM(AllNet,"ALLNET_ENABLE",0);
+
 typedef char ncclNetHandle_t[NCCL_NET_HANDLE_MAXSIZE];
 
 ncclResult_t ncclNetPluginLoad(struct ncclComm* comm);

--- a/src/include/net_device.h
+++ b/src/include/net_device.h
@@ -27,6 +27,7 @@ typedef struct {
 typedef ncclNetDeviceHandle_v7_t ncclNetDeviceHandle_v8_t;
 typedef ncclNetDeviceHandle_v8_t ncclNetDeviceHandle_v9_t;
 typedef ncclNetDeviceHandle_v9_t ncclNetDeviceHandle_v10_t;
-typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_t;
+typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_v11_t;
+typedef ncclNetDeviceHandle_v11_t ncclNetDeviceHandle_t;
 
 #endif

--- a/src/include/plugin/nccl_net.h
+++ b/src/include/plugin/nccl_net.h
@@ -33,22 +33,25 @@
 // NCCL core profiler callback for network defined events instrumentation
 typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* pHandle, int64_t pluginId, void* extData);
 
+#include "net/net_v11.h"
 #include "net/net_v10.h"
 #include "net/net_v9.h"
 #include "net/net_v8.h"
 #include "net/net_v7.h"
 #include "net/net_v6.h"
 
-typedef ncclNet_v10_t ncclNet_t;
-typedef ncclCollNet_v10_t ncclCollNet_t;
-typedef ncclNetSGE_v10_t ncclNetSGE_t;
-typedef ncclNetProperties_v10_t ncclNetProperties_t;
-typedef ncclNetVDeviceProps_v10_t ncclNetVDeviceProps_t;
-typedef ncclNetCommConfig_v10_t ncclNetCommConfig_t;
+typedef ncclNet_v11_t ncclNet_t;
+typedef ncclCollNet_v11_t ncclCollNet_t;
+typedef ncclNetSGE_v11_t ncclNetSGE_t;
+typedef ncclNetProperties_v11_t ncclNetProperties_t;
+typedef ncclNetVDeviceProps_v11_t ncclNetVDeviceProps_t;
+typedef ncclNetCommConfig_v11_t ncclNetCommConfig_t;
+typedef ncclNetPath_v11_t ncclNetPath_t;
 
-#define NCCL_NET_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC_V10
+#define NCCL_NET_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC_V11
 
-#define NCCL_NET_PLUGIN_SYMBOL ncclNetPlugin_v10
-#define NCCL_COLLNET_PLUGIN_SYMBOL ncclCollNetPlugin_v10
+#define NCCL_NET_PLUGIN_VERSION 11
+#define NCCL_NET_PLUGIN_SYMBOL ncclNetPlugin_v11
+#define NCCL_COLLNET_PLUGIN_SYMBOL ncclCollNetPlugin_v11
 
 #endif // end include guard

--- a/src/include/plugin/net/net_v11.h
+++ b/src/include/plugin/net/net_v11.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NET_V11_H_
+#define NET_V11_H_
+
+#include <cstdint>
+#define NCCL_NET_MAX_DEVS_PER_NIC_V11 4
+
+typedef struct {
+  int ndevs;
+  int devs[NCCL_NET_MAX_DEVS_PER_NIC_V11];
+} ncclNetVDeviceProps_v11_t;
+
+#define NCCL_NET_TRAFFIC_CLASS_UNDEF -1
+
+typedef struct {
+  // Plugin-specific TC value
+  int trafficClass;
+} ncclNetCommConfig_v11_t;
+
+typedef struct {
+  char* name;                      // Used mostly for logging.
+  char* pciPath;                   // Path to the PCI device in /sys.
+  uint64_t guid;                   // Unique identifier for the NIC chip. Important for
+                                   // cards with multiple PCI functions (Physical or virtual).
+  int ptrSupport;                  // [NCCL_PTR_HOST|NCCL_PTR_CUDA|NCCL_PTR_DMABUF]
+  int regIsGlobal;                 // regMr is not tied to a particular comm
+  int forceFlush;                  // Force a flush on receives
+  int speed;                       // Port speed in Mbps.
+  int port;                        // Port number.
+  float latency;                   // Network latency
+  int maxComms;                    // Maximum number of comms we can create
+  int maxRecvs;                    // Maximum number of grouped receives.
+  ncclNetDeviceType netDeviceType; // Network offload type
+  int netDeviceVersion;            // Version number for network offload
+  ncclNetVDeviceProps_v11_t vProps;
+  size_t maxP2pBytes;  // Max transfer size for point-to-point operations
+  size_t maxCollBytes; // Max transfer size for collective operations
+  uint64_t fabricId;   // Fabric handle associated to the current device
+} ncclNetProperties_v11_t;
+
+typedef enum {
+  NET_LOC_DCL0 = 0 /* same DC, hierarchy level 0*/,
+  NET_LOC_DCL1 = 1 /* different DC, hiearchy level 1 */,
+  NET_LOC_DISC = 2 /* disconnected*/
+} ncclNetLoc_v11_t;
+static_assert(NET_LOC_DCL0 < NET_LOC_DCL1 && NET_LOC_DCL1 < NET_LOC_DISC, "Locality must go in increasing order");
+
+typedef struct {
+  ncclNetLoc_v11_t loc;
+} ncclNetPath_v11_t;
+
+typedef struct {
+  // Name of the network (mainly for logs)
+  const char* name;
+  // Initialize the network.
+  ncclResult_t (*init)(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  // Return the number of adapters.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v11_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create a connection.
+  ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+  // Connect to a handle and return a sending comm object for that peer.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with sendComm == NULL with the expectation that
+  // it will be called again until sendComm != NULL.
+  // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*connect)(int dev, ncclNetCommConfig_v11_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v11_t** sendDevComm);
+  // Finalize connection establishment after remote peer has called connect.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with recvComm == NULL with the expectation that
+  // it will be called again until recvComm != NULL.
+  // If *recvDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v11_t** recvDevComm);
+  // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+  // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+  // DMA-BUF support
+  ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* comm, void* mhandle);
+  // Asynchronous send to a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
+  // Asynchronous recv from a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* sizes);
+  // Close and free send/recv comm objects
+  ncclResult_t (*closeSend)(void* sendComm);
+  ncclResult_t (*closeRecv)(void* recvComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Copy the given mhandle to a dptr in a format usable by this plugin's device code
+  ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+
+  // Notify the plugin that a recv has completed by the device
+  ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+
+  // Virtual NIC APIs. makeVDevice will create a virtual NIC given the specified properties, and tell the caller
+  // what index this new vNIC exists at
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v11_t* props);
+
+  // topology API. getNetPath returns the path between two fabricIds.
+  ncclResult_t (*getNetPath)(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_v11_t* path);
+} ncclNet_v11_t;
+
+typedef struct {
+  void* mhandle;
+  void* address;
+  size_t size;
+} ncclNetSGE_v11_t;
+
+typedef struct {
+  // Name of the collective network (mainly for logs)
+  const char* name;
+  // Initialize the collective network.
+  ncclResult_t (*init)(ncclDebugLogger_t logFunction);
+  // Return the number of adapters capable of doing collective operations.
+  // If ndev returns 0, all other functions might be set to NULL.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v11_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create connections.
+  ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+  // Create a group for collective operations. handles have been created
+  // using listen() above. rank indicates caller's rank in the collective network.
+  ncclResult_t (*connect)(void* handles[], int nranks, int rank, void* listenComm, void** collComm);
+  // Returns whether a reduction operation on a data type is supported.
+  // 1 for supported, 0 otherwise.
+  ncclResult_t (*reduceSupport)(ncclDataType_t dataType, ncclRedOp_t redOp, int* supported);
+  // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
+  // DMA-BUF support
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* collComm, void* mhandle);
+  // Performs an asynchronous allreduce operation on the collective group.
+  // May return request == NULL if the call cannot be performed (or would block).
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count, ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle,
+                             void** request);
+  ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v11_t* recvParts, size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                             void* sendMhandle, void** request);
+  ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v11_t* sendParts, void* recvData, size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                 ncclDataType_t dataType, ncclRedOp_t redOp, void* recvMhandle, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* size);
+  // Close and free collective comm objects
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Create a virtual NIC given the specified properties, which can be accessed at device index d
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v11_t* props);
+
+  // topology API. getNetPath returns the path between two fabricIds.
+  ncclResult_t (*getNetPath)(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_v11_t* path);
+} ncclCollNet_v11_t;
+
+#endif // end include guard

--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -299,8 +299,8 @@ struct ncclProxyState {
   int nChannels;
   int buffSizes[NCCL_NUM_PROTOCOLS];
   bool allocP2pNetLLBuffers;
-  bool dmaBufSupport;
-  ncclNet_t* ncclNet;
+  bool dmaBufSupport[NCCL_NET_MAX_PLUGINS];
+  ncclNet_t* ncclNet[NCCL_NET_MAX_PLUGINS];
   ncclCollNet_t* ncclCollNet;
   uint32_t* abortFlag;
   bool directMode;

--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -35,6 +35,13 @@ struct ncclRing;
 struct ncclConnector;
 struct ncclComm;
 
+#define PEERINFO_NETDEV_MAXCOUNT (MAXCHANNELS + 2)
+
+struct ncclNetDev {
+  int netIdx;
+  uint64_t fabricId;
+};
+
 struct ncclPeerInfo {
   int rank;
   int cudaDev;
@@ -50,6 +57,9 @@ struct ncclPeerInfo {
   nvmlGpuFabricInfoV_t fabricInfo;
   int cuMemSupport;
   int version;
+  // multi-DC support
+  int netDevCount;
+  ncclNetDev netDevs[PEERINFO_NETDEV_MAXCOUNT];
 };
 
 #define CONNECT_SIZE 256

--- a/src/include/trees.h
+++ b/src/include/trees.h
@@ -9,5 +9,6 @@
 
 ncclResult_t ncclGetBtree(int nranks, int rank, int* u0, int* d1, int* d0, int* parentChildType);
 ncclResult_t ncclGetDtree(int nranks, int rank, int* u0, int* d0_0, int* d0_1, int* parentChildType0, int* u1, int* d1_0, int* d1_1, int* parentChildType1);
+ncclResult_t ncclGetDtreeRoots(int nranks, int* r0, int* r1);
 
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -34,9 +34,13 @@ ncclResult_t getRandomData(void* buffer, size_t bytes);
 struct netIf {
   char prefix[64];
   int port;
+  int64_t fabricId; // -1 is undefined
 };
 
-int parseStringList(const char* string, struct netIf* ifList, int maxList);
+#define NCCL_IF_MAX_FABRICID (1L<<48)
+
+ncclResult_t parseIfList(const char* string, struct netIf* ifList, int maxList, int *ifCount);
+bool indexIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact, int* index);
 bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact);
 
 static long log2i(long n) {

--- a/src/plugin/net/net_v10.cc
+++ b/src/plugin/net/net_v10.cc
@@ -8,25 +8,162 @@
 #include "net_device.h"
 #include "proxy.h"
 
+static ncclNet_t ncclNet;
+static ncclCollNet_t ncclCollNet;
 static ncclNet_v10_t* ncclNet_v10;
 static ncclCollNet_v10_t* ncclCollNet_v10;
 
+static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
+  ncclNetProperties_v10_t p10;
+  ncclResult_t ans = ncclNet_v10->getProperties(dev, &p10);
+  if (ans != ncclSuccess) return ans;
+  props->name = p10.name;
+  props->pciPath = p10.pciPath;
+  props->guid = p10.guid;
+  props->ptrSupport = p10.ptrSupport;
+  props->regIsGlobal = p10.regIsGlobal;
+  props->forceFlush = p10.forceFlush;
+  props->speed = p10.speed;
+  props->port = p10.port;
+  props->maxComms = p10.maxComms;
+  props->maxRecvs = p10.maxRecvs;
+  props->latency = p10.latency;
+  props->netDeviceType = p10.netDeviceType;
+  props->netDeviceVersion = p10.netDeviceVersion;
+  props->vProps.ndevs = p10.vProps.ndevs;
+  memcpy(props->vProps.devs, p10.vProps.devs, sizeof(p10.vProps.devs));
+  props->maxP2pBytes = p10.maxP2pBytes;
+  props->maxCollBytes = p10.maxCollBytes;
+  props->fabricId = 0; // all devs are on the same rail if v10
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
+}
+
+
+static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* props) {
+  ncclNetProperties_v10_t p10;
+  ncclResult_t ans = ncclCollNet_v10->getProperties(dev, &p10);
+  if (ans != ncclSuccess) return ans;
+  props->name = p10.name;
+  props->pciPath = p10.pciPath;
+  props->guid = p10.guid;
+  props->ptrSupport = p10.ptrSupport;
+  props->regIsGlobal = p10.regIsGlobal;
+  props->forceFlush = p10.forceFlush;
+  props->speed = p10.speed;
+  props->port = p10.port;
+  props->maxComms = p10.maxComms;
+  props->maxRecvs = p10.maxRecvs;
+  props->latency = p10.latency;
+  props->netDeviceType = p10.netDeviceType;
+  props->netDeviceVersion = p10.netDeviceVersion;
+  props->vProps.ndevs = p10.vProps.ndevs;
+  memcpy(props->vProps.devs, p10.vProps.devs, sizeof(p10.vProps.devs));
+  props->maxP2pBytes = p10.maxP2pBytes;
+  props->maxCollBytes = p10.maxCollBytes;
+  props->fabricId = 0; // all devs are on the same rail if v10
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclCollNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclNet_connect(int dev, ncclNetCommConfig_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+  return ncclNet_v10->connect(dev, (ncclNetCommConfig_v10_t*)config, handle, sendComm, sendDevComm);
+}
+
+static ncclResult_t ncclNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
+  return ncclNet_v10->makeVDevice(d, (ncclNetVDeviceProps_v10_t*)props);
+}
+
+static ncclResult_t ncclNet_init(ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
+  NCCLCHECK(ncclNet_v10->init(logfn, proffn));
+  ncclNet.devices = ncclNet_v10->devices;
+  ncclNet.getProperties = ncclNet_getProperties;
+  ncclNet.listen = ncclNet_v10->listen;
+  ncclNet.connect = ncclNet_connect;
+  ncclNet.accept = ncclNet_v10->accept;
+  ncclNet.regMr = ncclNet_v10->regMr;
+  ncclNet.regMrDmaBuf = ncclNet_v10->regMrDmaBuf;
+  ncclNet.deregMr = ncclNet_v10->deregMr;
+  ncclNet.isend = ncclNet_v10->isend;
+  ncclNet.irecv = ncclNet_v10->irecv;
+  ncclNet.iflush = ncclNet_v10->iflush;
+  ncclNet.test = ncclNet_v10->test;
+  ncclNet.closeSend = ncclNet_v10->closeSend;
+  ncclNet.closeRecv = ncclNet_v10->closeRecv;
+  ncclNet.closeListen = ncclNet_v10->closeListen;
+  ncclNet.getDeviceMr = ncclNet_v10->getDeviceMr;
+  ncclNet.irecvConsumed = ncclNet_v10->irecvConsumed;
+  ncclNet.makeVDevice = ncclNet_v10->makeVDevice ? ncclNet_makeVDevice : nullptr;
+  ncclNet.getNetPath = ncclNet_getNetPath;
+  return ncclSuccess;
+}
+
 ncclNet_t* getNcclNet_v10(void* lib) {
-  ncclNet_v10 = (ncclNet_v10_t*)dlsym(lib, "ncclNetPlugin_v10");
+  ncclNet_v10 = (ncclNet_v10_t*)dlsym(lib, "ncclNetPlugin_v9");
   if (ncclNet_v10) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v10)", ncclNet_v10->name);
-    return ncclNet_v10;
+    ncclNet.name = ncclNet_v10->name;
+    ncclNet.init = ncclNet_init;
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v10)", ncclNet_v10->name);
+    return &ncclNet;
   }
-  INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Failed to find ncclNetPlugin_v10 symbol.");
+  INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Failed to find ncclNetPlugin_v9 symbol.");
   return nullptr;
+}
+
+static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
+  size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+  void* sendMhandle, void** request) {
+return ncclCollNet_v10->iallgather(collComm, sendData, nRecvParts, (ncclNetSGE_v10_t*)recvParts, bytesPerRank,
+  windowOffset, windowBytes, sendMhandle, request);
+}
+
+static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
+      size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+      ncclDataType_t dataType, ncclRedOp_t redOp,
+      void* recvMhandle, void** request) {
+return ncclCollNet_v10->ireducescatter(collComm, nSendParts, (ncclNetSGE_v10_t*)sendParts, recvData, bytesPerRank,
+      windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
+}
+
+static ncclResult_t ncclCollNet_init(ncclDebugLogger_t logfn) {
+  NCCLCHECK(ncclCollNet_v10->init(logfn));
+  ncclCollNet.devices = ncclCollNet_v10->devices;
+  ncclCollNet.getProperties = ncclCollNet_getProperties;
+  ncclCollNet.listen = ncclCollNet_v10->listen;
+  ncclCollNet.connect = ncclCollNet_v10->connect;
+  ncclCollNet.reduceSupport = ncclCollNet_v10->reduceSupport;
+  ncclCollNet.regMr = ncclCollNet_v10->regMr;
+  ncclCollNet.regMrDmaBuf = ncclCollNet_v10->regMrDmaBuf;
+  ncclCollNet.deregMr = ncclCollNet_v10->deregMr;
+  ncclCollNet.iallreduce = ncclCollNet_v10->iallreduce;
+  ncclCollNet.iallgather = ncclCollNet_iallgather;
+  ncclCollNet.ireducescatter = ncclCollNet_ireducescatter;
+  ncclCollNet.iflush = ncclCollNet_v10->iflush;
+  ncclCollNet.test = ncclCollNet_v10->test;
+  ncclCollNet.closeColl = ncclCollNet_v10->closeColl;
+  ncclCollNet.closeListen = ncclCollNet_v10->closeListen;
+  ncclCollNet.getNetPath = ncclCollNet_getNetPath;
+  return ncclSuccess;
 }
 
 ncclCollNet_t* getNcclCollNet_v10(void* lib) {
   ncclCollNet_v10 = (ncclCollNet_v10_t*)dlsym(lib, "ncclCollNetPlugin_v10");
   if (ncclCollNet_v10) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v10)", ncclNet_v10->name);
-    return ncclCollNet_v10;
+    ncclCollNet.name = ncclCollNet_v10->name;
+    ncclCollNet.init = ncclCollNet_init;
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v10)", ncclCollNet_v10->name);
+    return &ncclCollNet;
   }
-  INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Failed to find ncclCollNetPlugin_v10 symbol.");
+  INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Failed to find ncclCollNetPlugin_v10 symbol.");
   return nullptr;
 }

--- a/src/plugin/net/net_v11.cc
+++ b/src/plugin/net/net_v11.cc
@@ -1,0 +1,32 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "nccl_net.h"
+#include "net_device.h"
+#include "proxy.h"
+
+static ncclNet_v11_t* ncclNet_v11;
+static ncclCollNet_v11_t* ncclCollNet_v11;
+
+ncclNet_t* getNcclNet_v11(void* lib) {
+  ncclNet_v11 = (ncclNet_v11_t*)dlsym(lib, "ncclNetPlugin_v11");
+  if (ncclNet_v11) {
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v11)", ncclNet_v11->name);
+    return ncclNet_v11;
+  }
+  INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Failed to find ncclNetPlugin_v11 symbol.");
+  return nullptr;
+}
+
+ncclCollNet_t* getNcclCollNet_v11(void* lib) {
+  ncclCollNet_v11 = (ncclCollNet_v11_t*)dlsym(lib, "ncclCollNetPlugin_v11");
+  if (ncclCollNet_v11) {
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v11)", ncclCollNet_v11->name);
+    return ncclCollNet_v11;
+  }
+  INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Failed to find ncclCollNetPlugin_v11 symbol.");
+  return nullptr;
+}

--- a/src/plugin/net/net_v6.cc
+++ b/src/plugin/net/net_v6.cc
@@ -35,6 +35,7 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
   props->vProps.devs[0] = dev;
   props->maxP2pBytes = MAX_NET_SIZE;
   props->maxCollBytes = MAX_COLLNET_SIZE;
+  props->fabricId = 0;
   return ncclSuccess;
 }
 
@@ -71,6 +72,12 @@ static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* si
   return ans;
 }
 
+static ncclResult_t ncclNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
+}
+
 static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* props) {
   ncclNetProperties_v6_t p6;
   ncclResult_t ans = ncclCollNet_v6->getProperties(dev, &p6);
@@ -92,6 +99,7 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   props->vProps.devs[0] = dev;
   props->maxP2pBytes = MAX_NET_SIZE;
   props->maxCollBytes = MAX_COLLNET_SIZE;
+  props->fabricId = 0;
   return ncclSuccess;
 }
 
@@ -108,6 +116,12 @@ static ncclResult_t ncclCollNet_iallreduce(void* collComm, void* sendData, void*
   ncclResult_t ans = ncclCollNet_v6->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp,
                  sendMhandle, recvMhandle, request);
   return ans;
+}
+
+static ncclResult_t ncclCollNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
 }
 
 static ncclResult_t ncclNet_init(ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {

--- a/src/plugin/net/net_v7.cc
+++ b/src/plugin/net/net_v7.cc
@@ -35,6 +35,7 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
   props->vProps.devs[0] = dev;
   props->maxP2pBytes = MAX_NET_SIZE;
   props->maxCollBytes = MAX_COLLNET_SIZE;
+  props->fabricId = 0;
   return ncclSuccess;
 }
 
@@ -67,6 +68,12 @@ static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* si
   return ans;
 }
 
+static ncclResult_t ncclNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
+}
+
 static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* props) {
   ncclNetProperties_v7_t p7;
   ncclResult_t ans = ncclCollNet_v7->getProperties(dev, &p7);
@@ -88,6 +95,7 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   props->vProps.devs[0] = dev;
   props->maxP2pBytes = MAX_NET_SIZE;
   props->maxCollBytes = MAX_COLLNET_SIZE;
+  props->fabricId = 0;
   return ncclSuccess;
 }
 
@@ -104,6 +112,12 @@ static ncclResult_t ncclCollNet_iallreduce(void* collComm, void* sendData, void*
   ncclResult_t ans = ncclCollNet_v7->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp,
                  sendMhandle, recvMhandle, request);
   return ans;
+}
+
+static ncclResult_t ncclCollNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
 }
 
 static ncclResult_t ncclNet_init(ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {

--- a/src/plugin/net/net_v9.cc
+++ b/src/plugin/net/net_v9.cc
@@ -4,10 +4,11 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
+#include "debug.h"
 #include "nccl_net.h"
 #include "net_device.h"
-#include "proxy.h"
 #include "checks.h"
+#include <dlfcn.h>
 
 static ncclNet_t ncclNet;
 static ncclCollNet_t ncclCollNet;
@@ -15,7 +16,28 @@ static ncclNet_v9_t* ncclNet_v9;
 static ncclCollNet_v9_t* ncclCollNet_v9;
 
 static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
-  return ncclNet_v9->getProperties(dev, (ncclNetProperties_v9_t *)props);
+  ncclNetProperties_v9_t p9;
+  ncclResult_t ans = ncclNet_v9->getProperties(dev, &p9);
+  if (ans != ncclSuccess) return ans;
+  props->name = p9.name;
+  props->pciPath = p9.pciPath;
+  props->guid = p9.guid;
+  props->ptrSupport = p9.ptrSupport;
+  props->regIsGlobal = p9.regIsGlobal;
+  props->forceFlush = p9.forceFlush;
+  props->speed = p9.speed;
+  props->port = p9.port;
+  props->maxComms = p9.maxComms;
+  props->maxRecvs = p9.maxRecvs;
+  props->latency = p9.latency;
+  props->netDeviceType = p9.netDeviceType;
+  props->netDeviceVersion = p9.netDeviceVersion;
+  props->vProps.ndevs = p9.vProps.ndevs;
+  memcpy(props->vProps.devs, p9.vProps.devs, sizeof(p9.vProps.devs));
+  props->maxP2pBytes = p9.maxP2pBytes;
+  props->maxCollBytes = p9.maxCollBytes;
+  props->fabricId= 0; // all devs are on the same rail if v9
+  return ncclSuccess;
 }
 
 static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* pHandle, void** request) {
@@ -34,8 +56,35 @@ static ncclResult_t ncclNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   return ncclNet_v9->makeVDevice(d, (ncclNetVDeviceProps_v9_t*)props);
 }
 
+static ncclResult_t ncclNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
+}
+
 static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* props) {
-  return ncclCollNet_v9->getProperties(dev, (ncclNetProperties_v9_t *)props);
+  ncclNetProperties_v9_t p9;
+  ncclResult_t ans = ncclCollNet_v9->getProperties(dev, &p9);
+  if (ans != ncclSuccess) return ans;
+  props->name = p9.name;
+  props->pciPath = p9.pciPath;
+  props->guid = p9.guid;
+  props->ptrSupport = p9.ptrSupport;
+  props->regIsGlobal = p9.regIsGlobal;
+  props->forceFlush = p9.forceFlush;
+  props->speed = p9.speed;
+  props->port = p9.port;
+  props->maxComms = p9.maxComms;
+  props->maxRecvs = p9.maxRecvs;
+  props->latency = p9.latency;
+  props->netDeviceType = p9.netDeviceType;
+  props->netDeviceVersion = p9.netDeviceVersion;
+  props->vProps.ndevs = p9.vProps.ndevs;
+  memcpy(props->vProps.devs, p9.vProps.devs, sizeof(p9.vProps.devs));
+  props->maxP2pBytes = p9.maxP2pBytes;
+  props->maxCollBytes = p9.maxCollBytes;
+  props->fabricId= 0; // all devs are on the same rail if v9
+  return ncclSuccess;
 }
 
 static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
@@ -51,6 +100,11 @@ static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, n
                                  void* recvMhandle, void** request) {
   return ncclCollNet_v9->ireducescatter(collComm, nSendParts, (ncclNetSGE_v9_t*)sendParts, recvData, bytesPerRank,
                                  windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
+}
+static ncclResult_t ncclCollNet_getNetPath(uint64_t fabricId0, uint64_t fabricId1, ncclNetPath_t* path) {
+  if (!path) return ncclInvalidArgument;
+  path->loc = (fabricId0 == fabricId1) ? NET_LOC_DCL0 : NET_LOC_DISC;
+  return ncclSuccess;
 }
 
 static ncclResult_t ncclNet_init(ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
@@ -73,6 +127,7 @@ static ncclResult_t ncclNet_init(ncclDebugLogger_t logfn, ncclProfilerCallback_t
   ncclNet.getDeviceMr = ncclNet_v9->getDeviceMr;
   ncclNet.irecvConsumed = ncclNet_v9->irecvConsumed;
   ncclNet.makeVDevice = (ncclNet_v9->makeVDevice) ? ncclNet_makeVDevice : nullptr;
+  ncclNet.getNetPath = ncclNet_getNetPath;
   return ncclSuccess;
 }
 
@@ -105,6 +160,7 @@ static ncclResult_t ncclCollNet_init(ncclDebugLogger_t logfn) {
   ncclCollNet.test = ncclCollNet_v9->test;
   ncclCollNet.closeColl = ncclCollNet_v9->closeColl;
   ncclCollNet.closeListen = ncclCollNet_v9->closeListen;
+  ncclCollNet.getNetPath = ncclCollNet_getNetPath;
   return ncclSuccess;
 }
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1821,8 +1821,10 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
     proxyState->p2pChunkSize = comm->p2pChunkSize;
     proxyState->nChannels = comm->nChannels;
     proxyState->allocP2pNetLLBuffers = comm->allocP2pNetLLBuffers;
-    proxyState->dmaBufSupport = comm->dmaBufSupport;
-    proxyState->ncclNet = comm->ncclNet;
+    for (int n = 0; n < comm->ncclNetCount; ++n) {
+      proxyState->dmaBufSupport[n] = comm->dmaBufSupport[n];
+      proxyState->ncclNet[n] = comm->ncclNet[n];
+    }
     proxyState->ncclCollNet = comm->ncclCollNet;
     proxyState->profilerContext = comm->profilerContext;
     proxyState->directMode = comm->directMode;


### PR DESCRIPTION
# Cross Data Center Communication and network topology awareness

**Goal: Enable NCCL to perform multi-DC communication with minimum modification to the AI training workloads.**

This feature supports two use-cases for multi-DC communication:
- Within the same communicator, different data centers are connected through different networks (typically IB, RoCE for the intra-DC network, and TCP for the inter-DC network).
- Within the same communicator, different data centers are connected through the same network (typically IB or RoCE for both intra-DC and inter-DC network).

Prior NCCL releases already provide support for using different communication backends in separate communicators.

## Enable the Usage of Multiple Networks

For NCCL to use multiple networks, one has to set `NCCL_ALLNET_ENABLE=1`. This will consequently disable the usage of `collNet`.
Further, we advise the user to set `NCCL_ALLNET_FASTNET="IB"` to make sure that NCCL knows which network will be used to detect the DC topology.

## The Fabric ID

The feature relies on the concept of `fabricId`. It is used by NCCL to capture the topology information and ensure connectivity between the devices.
The `fabricId` is provided by the user, and the way to do so depends on the network plugin in use.
Below we detail the usage of our internal IB plugin.

In the internal IB plugin, the fabric Id is set through the environment variable `NCCL_IB_HCA`: `NCCL_IB_HCA="=device:port:fabricID"`.
We encourage the user to use the `=` prefix to guarantee an exact match with the device name.
Further, the value of the `fabricID` should be a positive integer, up to `(1<<48)`. It will be interpreted as `DC_ID * MAX_RAILS + RAIL_ID`, where `MAX_RAILS` can be set with `NCCL_IB_FABRICID_MAXRAIL`. If unset, each of the fabricId values will be interpreted as a railId (i.e. `fabricId = railId` and `dcId = 0`).

For example:

- By default, `fabricId=0` and `fabricId=64` will represent two devices that are disconnected from each other.
- Setting `NCCL_IB_FABRICID_MAXRAIL=64` and again using `fabricId=0` and `fabricId=64` will represent two devices that are connected to each other, but in different data centers, respectively `0` and `1`.
- Still with `NCCL_IB_FABRICID_MAXRAIL=64`, `fabricId=0` and `fabricId=16` will be interpreted as devices belonging to the same data center but with no direct rail connectivity.
- Two devices from different networks are always disconnected.
- IB and RoCE devices receive different fabricIds by default, which guarantees that they are not connected to each other. This can be overridden by the user if needed.

## Job Script

For `mpirun` based jobs, we recommend using a bash script to assign different fabricIds to each of the MPI Processes.

For example, the following script will divide the MPI processes into different DCs, each of them of size `DC_SIZE`. If unset, `DC_SIZE` will be set to the number of processes on the node. In our example, we assume 8 dual ports NICs (seen as 16 devices by `ibv_devinfo`).

```bash
#!/bin/bash
if [ -z "$OMPI_COMM_WORLD_SIZE" ] || [ -z "$OMPI_COMM_WORLD_RANK" ]; then
  # we don't have OMPI, try MPICH
  if [ -z "$PMI_SIZE" ] || [ -z "$PMI_RANK" ]; then
    # we don't have MPICH
    mpiName="NONE"
    worldSize=1
    worldRank=0
    localSize=1
  else
    mpiName="MPICH"
    worldSize=${PMI_SIZE:=1}
    worldRank=${PMI_RANK:=0}
    localSize=${MPI_LOCALNRANKS:=1}
  fi
else
  mpiName="OMPI"
  worldSize=${OMPI_COMM_WORLD_SIZE:=1}
  worldRank=${OMPI_COMM_WORLD_RANK:=0}
  localSize=${OMPI_COMM_WORLD_LOCAL_SIZE:=1}
fi

# decide on how many MPI ranks are part of the DC
dcSize=${DC_SIZE:=$localSize}

# gather the list of HCA
nrails=8
uid=$((nrails * (worldRank / dcSize)))
# get the HCA list
hca_list="="\
"mlx5_1::$(( uid+0 )),mlx5_2::$(( uid+0 )),"\
"mlx5_3::$(( uid+1 )),mlx5_4::$(( uid+1 )),"\
"mlx5_5::$(( uid+2 )),mlx5_6::$(( uid+2 )),"\
"mlx5_7::$(( uid+3 )),mlx5_8::$(( uid+3 )),"\
"mlx5_9::$(( uid+4 )),mlx5_10::$(( uid+4 )),"\
"mlx5_11::$(( uid+5 )),mlx5_12::$(( uid+5 )),"\
"mlx5_13::$(( uid+6 )),mlx5_14::$(( uid+6 )),"\
"mlx5_15::$(( uid+7 )),mlx5_16::$(( uid+7 ))"

echo "$(hostname) world rank ${worldRank}, world size ${worldSize}, dcSize ${dcSize}, uid ${uid} with using NCCL_IB_HCA=\"${hca_list}\""
# if DCs are connected through TCP:
NCCL_IB_HCA="${hca_list}" $@
# if DCs are connected through IB:
# NCCL_IB_FABRICID_MAXRAIL=${nrails} NCCL_IB_HCA="${hca_list}" $@
```

The internal tuning model of NCCL hasn't been adapted yet to the cross-DC communication.
Therefore, we recommend setting the desired algorithm to either `RING` or `TREE`.

## Performance Considerations

The connection between DCs is very likely to drive the overall performance. We recommend testing a few values for various parameters in order to find the most suited parameter set. Here are some of the parameters we expect to drive the performance:

- `NCCL_IB_QPS_PER_CONNECTION` to improve performance for higher latency IB connections.
- `NCCL_NSOCKS_PERTHREAD` and `NCCL_SOCKET_NTHREADS` to improve performance for higher latency TCP connections.
- (new in this branch) `NCCL_SOCKET_INLINE` and `NCCL_SOCKET_MIN_TASKSIZE` to control the size of the TCP messages and the size of the inlined data.
- `NCCL_BUFFSIZE`, together with changing the value of `NCCL_STEPS`.
- (new in this branch) `NCCL_SCATTER_XDC`: allows the scattering of the channels onto different NICs for the cross-DC connection. This will lead to channels following a different rank ordering within a single collective. For IB inter-DC network, we recommend setting the value to `0`. For TCP inter-DC network, we recommend setting the value to `1`.
- `NCCL_MIN_CTAS` (with `NCCL_SCATTER_XDC=1`): for TCP connections, increasing the number of CTAs will increase the number of channels and therefore the number of TCP NICs that NCCL will use. If allowed to (see above), NCCL maps each channel to a different node. Therefore, the total number of NICs used within a single collective then depends on the number of channels used.