### PR TITLE
[nccl-profiling] fix bug on calling wrong id for proxy step in recvProxyProgress

### DIFF
--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1479,7 +1479,6 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
       struct ncclProxySubArgs* subGroup = args->subs+s;
       for (int i=0; i<subGroup->groupSize; i++) {
         struct ncclProxySubArgs* sub = subGroup + i;
-        int doneStepId = sub->done;
         if (sub->done == sub->nsteps) continue;
         if (sub->transmitted > sub->done) {
           struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
@@ -1494,6 +1493,7 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
                 NCCLCHECK(proxyState->ncclNet->irecvConsumed(resources->netRecvComm, subGroup->recvRequestsSubCount, subGroup->recvRequestsCache[sub->done%NCCL_STEPS]));
               subGroup->recvRequestsCache[sub->done%NCCL_STEPS] = NULL;
             }
+            int doneStepId = sub->done;
             sub->done += args->sliceSteps;
             ncclProfilerStopProxyStepEvent(s+i, args, doneStepId);
             ncclProfilerRecordProxyOpEventState(s+i, args, sub->done, sub->transSize, ncclProfilerProxyOpRecvDone);


### PR DESCRIPTION
This bug seems to be the root cause of #1658

Our team profiler implementation started to have some proxyStep events without a recorded end timestamp with nccl v2.24.3 (working fine in nccl v2.23.4). 

I looked through the source code and narrowed down the issue to be because of this logical error in `recvProxyProgress`, since`doneStepId` is created outside of the while loop, but is used for all the steps inside the while loop --> we have proxy step events which are not updated properly. 


Let me know if more context is needed for verifying this fix