### PR TITLE
makefiles: common.mk: update c++ standard to c++14

### DIFF
--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -76,7 +76,7 @@ $(info NVCC_GENCODE is ${NVCC_GENCODE})
 ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 13; echo $$?),0)
   CXXSTD ?= -std=c++17
 else
-  CXXSTD ?= -std=c++11
+  CXXSTD ?= -std=c++14
 endif
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \


### PR DESCRIPTION
Compilation fails using newer versions of gcc (gcc-14 specifically) due to the c++11 standard default set by the build system:

```
/usr/include/c++/14/type_traits(1610): error: "__is_nothrow_new_constructible" is not a function or static data member
      constexpr bool __is_nothrow_new_constructible
                     ^

/usr/include/c++/14/type_traits(1610): error: "constexpr" is not valid here
      constexpr bool __is_nothrow_new_constructible
      ^

/usr/include/c++/14/type_traits(1610): error: "__is_nothrow_new_constructible" is not a function or static data member
      constexpr bool __is_nothrow_new_constructible
                     ^

/usr/include/c++/14/type_traits(1610): error: "constexpr" is not valid here
      constexpr bool __is_nothrow_new_constructible
      ^

/usr/include/c++/14/type_traits(1610): error: "__is_nothrow_new_constructible" is not a function or static data member
      constexpr bool __is_nothrow_new_constructible
                     ^

/usr/include/c++/14/type_traits(1610): error: "constexpr" is not valid here
      constexpr bool __is_nothrow_new_constructible
      ^

/usr/include/c++/14/type_traits(1610): error: "__is_nothrow_new_constructible" is not a function or static data member
      constexpr bool __is_nothrow_new_constructible
                     ^

/usr/include/c++/14/type_traits(1610): error: "constexpr" is not valid here
      constexpr bool __is_nothrow_new_constructible
```

Update the standard to c++14 to allow compilation with modern toolchain versions.

Closes: https://github.com/NVIDIA/nccl/issues/1743