### PR TITLE
[NVCC] Modify template for FP8 type casting to be compilable in C++20

### DIFF
--- a/src/device/reduce_kernel.h
+++ b/src/device/reduce_kernel.h
@@ -256,38 +256,28 @@ struct Apply_Cast<float ,__nv_bfloat16, /*EltPerPack=*/2> {
 };
 #endif
 
-#if defined(__CUDA_FP8_TYPES_EXIST__)
-#define FP8_CAST(FP8_T, VEC2_T, VEC4_T) \
-template<> struct Apply_Cast<FP8_T, float, 2> { \
-  __device__ __forceinline__ static BytePack<8> cast(BytePack<2> a) { \
-    VEC2_T va = fromPack<VEC2_T>(a); FP8_T* p = reinterpret_cast<FP8_T*>(&va); \
-    return toPack(make_float2(float(__half(p[0])), float(__half(p[1])))); \
-  } \
-}; \
-template<> struct Apply_Cast<float, FP8_T, 2> { \
-  __device__ __forceinline__ static BytePack<2> cast(BytePack<8> b) { \
-    float2 vb = fromPack<float2>(b); VEC2_T va; FP8_T* p = reinterpret_cast<FP8_T*>(&va); \
-    p[0] = FP8_T(__half(vb.x)); p[1] = FP8_T(__half(vb.y)); return toPack(va); \
-  } \
-}; \
-template<> struct Apply_Cast<FP8_T, float, 4> { \
-  __device__ __forceinline__ static BytePack<16> cast(BytePack<4> a) { \
-    VEC4_T va = fromPack<VEC4_T>(a); FP8_T* p = reinterpret_cast<FP8_T*>(&va); \
-    return toPack(make_float4(float(__half(p[0])), float(__half(p[1])), float(__half(p[2])), float(__half(p[3])))); \
-  } \
-}; \
-template<> struct Apply_Cast<float, FP8_T, 4> { \
-  __device__ __forceinline__ static BytePack<4> cast(BytePack<16> b) { \
-    float4 vb = fromPack<float4>(b); VEC4_T va; FP8_T* p = reinterpret_cast<FP8_T*>(&va); \
-    p[0] = FP8_T(__half(vb.x)); p[1] = FP8_T(__half(vb.y)); p[2] = FP8_T(__half(vb.z)); p[3] = FP8_T(__half(vb.w)); \
-    return toPack(va); \
-  } \
-};
+#define EASY_CAST(A, B, EltPerPack, VecA, VecB) \
+  template<> \
+  struct Apply_Cast<A, B, EltPerPack> { \
+    __device__ __forceinline__ static BytePack<sizeof(B)*EltPerPack> cast(BytePack<sizeof(A)*EltPerPack> a) { \
+      return toPack(static_cast<VecB>(fromPack<VecA>(a))); \
+    } \
+  }; \
+  template<> \
+  struct Apply_Cast<B, A, EltPerPack> { \
+    __device__ __forceinline__ static BytePack<sizeof(A)*EltPerPack> cast(BytePack<sizeof(B)*EltPerPack> b) { \
+      return toPack(VecA(fromPack<VecB>(b))); \
+    } \
+  };
 
-FP8_CAST(__nv_fp8_e5m2, __nv_fp8x2_e5m2, __nv_fp8x4_e5m2)
-FP8_CAST(__nv_fp8_e4m3, __nv_fp8x2_e4m3, __nv_fp8x4_e4m3)
-#undef FP8_CAST
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+EASY_CAST(__nv_fp8_e5m2, float, 2, __nv_fp8x2_e5m2, float2)
+EASY_CAST(__nv_fp8_e5m2, float, 4, __nv_fp8x4_e5m2, float4)
+
+EASY_CAST(__nv_fp8_e4m3, float, 2, __nv_fp8x2_e4m3, float2)
+EASY_CAST(__nv_fp8_e4m3, float, 4, __nv_fp8x4_e4m3, float4)
 #endif
+#undef EASY_CAST
 
 ////////////////////////////////////////////////////////////////////////////////
 // Apply_Reduce


### PR DESCRIPTION
### Context

As mentioned by #1770 , we are having some issue with compiling NCCL v2.27.5 using C++20 (it's compilable on C++11 --> 17). We figured out the root-cause is because of this section of device code in `reduce_kernel.h`, which does not work in C++20. My understanding is that in C++20, the rules for aggregate initialization and implicit conversions have become stricter.

In other words, this line `return toPack(VecB(fromPack<VecA>(a)));` relies on the ability to construct VecB from a VecA (or vice versa) via an implicit or aggregate conversion. In C++20, this is not allowed unless there is an explicit constructor or conversion operator.

### Fix Detail

I attempted to create a localized fix for this particular `reduce_kernel.h` code snippet here by doing explicit and manual element-wise conversion between the types. 

Update: 

Seems like I was being a bit too manual, just need some pushing for compiler to use the correct operator, alternatively can just do `return toPack((VecB)(fromPack<VecA>(a))); \` as well --> would similarly invoke the explicit operator https://docs.nvidia.com/cuda/cuda-math-api/cuda_math_api/struct____nv__fp8x2__e5m2.html#_CPPv4NK15__nv_fp8x2_e5m2cv6float2Ev

Have compiled successfully on C++14, C++17 and C++20.

Would appreciate some help with verifying whether the fix make sense for this particular case, or if not, what would be the correct fix in order to compile with C++20. 


