### PR TITLE
Ignore system headers in include/header processing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -132,7 +132,7 @@ $(OBJDIR)/%.o : %.cc $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
 	$(CXX) -I. -I$(INCDIR) $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -c $< -o $@
-	@$(CXX) -I. -I$(INCDIR) $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -M $< > $(@:%.o=%.d.tmp)
+	@$(CXX) -I. -I$(INCDIR) $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -MM $< > $(@:%.o=%.d.tmp)
 	@sed "0,/^.*:/s//$(subst /,\/,$@):/" $(@:%.o=%.d.tmp) > $(@:%.o=%.d)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:%.o=%.d.tmp) | fmt -1 | \
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)

--- a/src/device/Makefile
+++ b/src/device/Makefile
@@ -50,8 +50,8 @@ define COMPILE_SYM
  $(NVCC) $(NVCUFLAGS_SYM) $3 -dw $2 -o $1
 endef
 
-DEPENDS.cu = $(NVCC) $(NVCUFLAGS) -M -dc $1
-DEPENDS.cc = $(CXX) $(CXXFLAGS) -M -c $1
+DEPENDS.cu = $(NVCC) $(NVCUFLAGS) -MM -dc $1
+DEPENDS.cc = $(CXX) $(CXXFLAGS) -MM -c $1
 define DEPENDS
 @$(SAY) "Dependencies" $2;\
  mkdir -p $(dir $1);\


### PR DESCRIPTION
Use `-MM` instead of `-M` in header/include tracking, so avoid potentially
excessive `realpath` calls in some builds.