### PR TITLE
[profiler example] Add missing "err.h" include in "profiler.h"

### DIFF
--- a/ext-profiler/example/nccl/profiler.h
+++ b/ext-profiler/example/nccl/profiler.h
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 
 #include "common.h"
+#include "err.h"
 
 enum {
   ncclProfileGroup          = (1 << 0),  // group event type


### PR DESCRIPTION
Several profiler_v*.h files uses ncclResult_t defined in err.h but the header is not #included-ed in "profiler.h"

Currently the .c files in example does include it before including "profiler.h" and therefore does not trigger compilation error. But this commit should make the "profiler.h" header self-contained (as it was in previous versions).