### PR TITLE
fix missing header on examples

### DIFF
--- a/ext-profiler/example/nccl/profiler.h
+++ b/ext-profiler/example/nccl/profiler.h
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 
 #include "common.h"
+#include "err.h"
 
 enum {
   ncclProfileGroup          = (1 << 0),  // group event type

--- a/ext-profiler/google-CoMMA/Makefile
+++ b/ext-profiler/google-CoMMA/Makefile
@@ -3,7 +3,7 @@
 all: build-CoMMA
 
 build-CoMMA: clone-CoMMA
-	cd CoMMA && cargo build
+	cd CoMMA && cargo build --release
 
 clone-CoMMA:
 	@if [ ! -d CoMMA ] ; then \


### PR DESCRIPTION
 The profiler headers reference ncclResult_t which is declared in err.h

 Errors building CoMMA example:
  Unable to generate bindings for third_party/nccl/ext-profiler/example/nccl/profiler.h: clang diagnosed error: third_party/nccl/ext-profiler/example/nccl/profiler_v5.h:124:3: error: type name requires a specifier or qualifier
  third_party/nccl/ext-profiler/example/nccl/profiler_v5.h:132:3: error: type name requires a specifier or qualifier
  third_party/nccl/ext-profiler/example/nccl/profiler_v5.h:132:18: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  third_party/nccl/ext-profiler/example/nccl/profiler_v5.h:132:3: error: duplicate member 'ncclResult_t'
  
 All 3 examples build and run fine with this tiny change.
 
 Also use release version of CoMMA following its intructions https://cloud.google.com/ai-hypercomputer/docs/nccl/configure-comma#build-from-source
 
 Thank you!
 