### PR TITLE
Drain error code when kernel is not found

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -41,7 +41,10 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
       if (fn == nullptr) continue;
 
       cudaError_t errcode = cudaFuncGetAttributes(&attr, fn);
-      if (errcode != cudaSuccess) continue; // Silently ignore failures
+      if (errcode != cudaSuccess) {
+		  errorcode = cudaGetLastError(); // Drain error code
+		  continue; // Silently ignore failures
+	  }
       if (maxStackSize) {
         if (attr.localSizeBytes > *maxStackSize) *maxStackSize = attr.localSizeBytes;
       }


### PR DESCRIPTION
Fixes spurious failures when PyTorch is linked statically with NCCL-2.28.3 because error is not drained, but rather gets propagated into a next CUDA kernel invocation

Fixes https://github.com/pytorch/pytorch/issues/164402