### PR TITLE
Fix potential hang issues when encountering illegal external connections

### DIFF
--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -39,7 +39,8 @@ enum ncclSocketState {
   ncclSocketStateTerminating = 8,
   ncclSocketStateClosed = 9,
   ncclSocketStateError = 10,
-  ncclSocketStateNum = 11
+  ncclSocketStateInvalidMagic = 11,
+  ncclSocketStateNum = 12
 };
 
 enum ncclSocketType {


### PR DESCRIPTION
We have addressed the issue raised in #1808 by introducing a new socket state specifically to handle invalid magic values, preventing the program from entering an infinite loop. The PR is based on #1834, and we extend it to cover a key edge case (successful external connection but no magic value or invalid magic field length). Details of the state transitions and handling mechanism are visualized in the diagram below:
<img width="1500" height="823" alt="image" src="https://github.com/user-attachments/assets/66131677-b960-42cf-b507-460786d758d9" />
Test Method as Follows:
Write a shell script that executes nccl-tests alltoall_perf in a loop. During the program runtime, use `naabu` to simulate external connections. When the port used by the proxy thread is connected, it will generate logs and prevent program hangs.
<img width="1500" height="191" alt="image" src="https://github.com/user-attachments/assets/b8d3523e-e819-474e-8d54-f73f615424be" />

Additionally, we have extended the solution to cover an important edge case:
When an external connection is successfully established but either:

1. No magic value is transmitted, or
2. The sent data does not meet the required length for the magic field

A timeout mechanism has been implemented to prevent the program from hanging indefinitely in such cases. This ensures the system can gracefully handle incomplete or malformed connection handshakes, improving overall stability and fault tolerance.
The timeout duration is set to a reasonable default that balances responsiveness with allowance for legitimate network delays, while still preventing permanent hangs in failure scenarios.