### PR TITLE
plugin/net.cc: Fix segfault in ncclGin initialization

### DIFF
--- a/src/plugin/net.cc
+++ b/src/plugin/net.cc
@@ -206,6 +206,8 @@ static ncclResult_t ncclNetPluginInit(struct ncclComm* comm, netPluginLib_t* plu
       if (ncclGinIbGdaki.init(&throwAwayContext, comm->commHash, ncclDebugLog) == ncclSuccess) {
         if (ncclGinIbGdaki.devices(&ndev) == ncclSuccess && ndev > 0) {
           pluginLib->ncclGin = &ncclGinIbGdaki;
+        } else {
+          pluginLib->ncclGin = &ncclGinIbProxy;
         }
         ncclGinIbGdaki.finalize(throwAwayContext);
       }


### PR DESCRIPTION
If ncclGinIbGdaki.devices() fails after init() succeeds, pluginLib->ncclGin is left at -1, leading to a segfault when calling pluginLib->ncclGin->init().