### PR TITLE
[Feature Preview] Introduce Python bindings for NCCL with nccl4py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ default: src.build
 install: src.install
 BUILDDIR ?= $(abspath ./build)
 ABSBUILDDIR := $(abspath $(BUILDDIR))
-TARGETS := src pkg
+TARGETS := src pkg nccl4py
 clean: ${TARGETS:%=%.clean}
 examples.build: src.build
 LICENSE_FILES := LICENSE.txt
@@ -29,6 +29,9 @@ examples: src.build
 
 pkg.%:
 	${MAKE} -C pkg $* BUILDDIR=${ABSBUILDDIR}
+
+nccl4py.%:
+	${MAKE} -C nccl4py $* BUILDDIR=${ABSBUILDDIR}
 
 pkg.debian.prep: lic
 pkg.txz.prep: lic

--- a/nccl4py/.gitignore
+++ b/nccl4py/.gitignore
@@ -1,0 +1,21 @@
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Cython compiled outputs
+nccl/bindings/**/*.cpp
+nccl/bindings/**/*.so
+
+# Generated package files
+nccl/_version.py
+
+# Stamps
+**/.stamp
+
+__pycache__
+
+# Tool caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/

--- a/nccl4py/MANIFEST.in
+++ b/nccl4py/MANIFEST.in
@@ -1,0 +1,16 @@
+include pyproject.toml
+include setup.py
+include README.md
+
+# Include Cython sources and headers for sdist only
+include nccl/bindings/_internal/*.pyx
+include nccl/bindings/_internal/*.pxd
+include nccl/bindings/*.pxd
+include nccl/bindings/*.pyx
+
+# Typing markers and stubs
+include nccl/bindings/*.pyi
+
+# Exclude build artifacts and cache
+prune nccl/__pycache__
+global-exclude __pycache__/* *.pyc *.pyo *.stamp *.cpp *.c

--- a/nccl4py/Makefile
+++ b/nccl4py/Makefile
@@ -1,0 +1,70 @@
+UV            ?= uv
+
+# Root Makefile passes BUILDDIR; default to ../build if not set
+MKFILE_DIR           := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+BUILDDIR             ?= $(abspath $(MKFILE_DIR)/../build)
+NCCL_DIR             := $(abspath $(MKFILE_DIR)/../src)
+NCCL4PY_DIR          := $(abspath $(MKFILE_DIR))
+NCCL4PY_BINDINGS_DIR := $(NCCL4PY_DIR)/nccl/bindings
+
+EXTERNALS_DIR      := $(BUILDDIR)/externals
+EXTERNALS_VENV_DIR := $(EXTERNALS_DIR)/venvs
+DIST_DIR           := $(BUILDDIR)/dist
+
+# CUDA home is only used to provide headers for cython
+CUDA_HOME       ?= /usr/local/cuda
+CUDA_VARIANTS   := 12 13
+PYTHON_VERSIONS := 3.10 3.11 3.12 3.13 3.14
+
+# manylinux repair configuration
+AUDITWHEEL_PLAT ?= manylinux_2_34_$(shell uname -m)
+
+.DEFAULT_GOAL := build
+.PHONY: all build dev clean
+
+all: build
+
+dev:
+	@cd $(NCCL4PY_DIR) && $(UV) sync --extra dev && $(UV) pip install -e .[dev]
+
+
+NCCL4PY_FILES := \
+	nccl/__init__.py \
+	nccl/core/*.py \
+	nccl/core/interop/*.py \
+	nccl/bindings/*.pyx \
+	nccl/bindings/*.pxd \
+	nccl/bindings/*.py \
+	nccl/bindings/_internal/*.pyx \
+	nccl/bindings/_internal/*.pxd \
+	nccl/bindings/_internal/*.py
+
+BUILD_DIR = $(BUILDDIR)/nccl4py_cu$*
+OUT_DIR = $(DIST_DIR)/nccl4py_cu$*
+
+$(CUDA_VARIANTS:%=$(DIST_DIR)/nccl4py_cu%/makefile.stamp): $(DIST_DIR)/nccl4py_cu%/makefile.stamp : $(wildcard $(NCCL4PY_DIR)/nccl/core/*.py)
+	mkdir -p "$(BUILD_DIR)"
+	cp "$(NCCL4PY_DIR)/nccl4py_cu$*/pyproject.toml" "$(NCCL4PY_DIR)/nccl4py_cu$*/setup.py" "$(NCCL4PY_DIR)/MANIFEST.in" "$(NCCL4PY_DIR)/README.md" "$(BUILD_DIR)/"
+	cd "$(NCCL4PY_DIR)"; cp --parents $(NCCL4PY_FILES) "$(BUILD_DIR)/"
+	CUDA_HOME="$(CUDA_HOME)" $(UV) build --sdist -p "cpython@3.13" --out-dir "$(OUT_DIR)" "$(BUILD_DIR)"
+	for v in $(PYTHON_VERSIONS); do \
+	  	CUDA_HOME="$(CUDA_HOME)" $(UV) build --wheel -p "cpython@$${v}" --out-dir "$(OUT_DIR)" "$(OUT_DIR)"/nccl4py_cu$*-*.tar.gz; \
+	done;
+	find "$(OUT_DIR)" -maxdepth 1 -type f -name '*.whl' ! -name '*manylinux*' -print0 | \
+		xargs -0 -r $(UV) run --isolated --no-project -p "cpython@3.13" --with auditwheel --with patchelf \
+		-m auditwheel repair --plat "$(AUDITWHEEL_PLAT)" -w "$(OUT_DIR)"; \
+	touch "$@"
+
+$(CUDA_VARIANTS:%=nccl4py_cu%): nccl4py_cu%: $(DIST_DIR)/nccl4py_cu%/makefile.stamp
+
+build: $(CUDA_VARIANTS:%=nccl4py_cu%)
+
+clean:
+	@rm -rf $(DIST_DIR) \
+			$(BUILDDIR)/nccl4py_cu* \
+			$(NCCL4PY_DIR)/*.egg-info \
+			$(NCCL4PY_DIR)/build \
+			$(NCCL4PY_DIR)/nccl/_version.py
+	@find $(NCCL4PY_DIR) -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	@find $(NCCL4PY_DIR) -type f -name "*.pyc" -delete 2>/dev/null || true
+	@find $(NCCL4PY_BINDINGS_DIR) -type f \( -name "*.so" -o -name "*.cpp" -o -name "*.c" \) -delete 2>/dev/null || true

--- a/nccl4py/README.md
+++ b/nccl4py/README.md
@@ -1,0 +1,3 @@
+# NCCL4Py Overview
+
+NCCL4Py is a Python package that provides a Pythonic interface to NCCL

--- a/nccl4py/examples/01_basic/01_allreduce.py
+++ b/nccl4py/examples/01_basic/01_allreduce.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+NCCL4Py Basic Example: AllReduce
+==================================
+
+The simplest possible example showing how to use NCCL4Py with AllReduce.
+Each rank contributes its rank number, and all ranks receive the sum.
+
+USAGE:
+mpirun -np 4 python 01_allreduce.py
+"""
+
+import sys
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    print("ERROR: mpi4py required. Install with: pip install mpi4py")
+    sys.exit(1)
+
+try:
+    import torch
+except ImportError:
+    print("ERROR: PyTorch required. Install with: pip install torch")
+    sys.exit(1)
+
+import nccl.core as nccl
+
+
+def main():
+    # Initialize MPI
+    comm_mpi = MPI.COMM_WORLD
+    rank = comm_mpi.Get_rank()
+    nranks = comm_mpi.Get_size()
+
+    # Set rank 0 as the root
+    root = 0
+
+    # Assign GPU to each process
+    device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
+    torch.cuda.set_device(device)
+
+    # [NCCL4Py] Generate unique ID on the root rank
+    unique_id = nccl.get_unique_id() if rank == root else None
+
+    # Broadcast unique ID to all ranks
+    unique_id = comm_mpi.bcast(unique_id, root=root)
+
+    # [NCCL4Py] Initialize NCCL communicator
+    nccl_comm = nccl.Communicator.init(nranks=nranks, rank=rank, unique_id=unique_id)
+
+    if rank == root:
+        print(f"Running AllReduce with {nranks} ranks...")
+
+    # Create PyTorch tensor with rank value
+    data = torch.tensor([float(rank)], dtype=torch.float32, device=device)
+
+    # [NCCL4Py] AllReduce: Sum all rank values
+    nccl_comm.all_reduce(data, data, nccl.SUM)
+
+    torch.cuda.synchronize()
+
+    # Verify result
+    expected = float(nranks * (nranks - 1) // 2)
+    actual = float(data[0].item())
+
+    print(f"Rank {rank}: AllReduce result = {actual:.0f} (expected {expected:.0f})")
+
+    # [NCCL4Py] Destroy NCCL communicator (collective call)
+    nccl_comm.destroy()
+
+    if rank == root:
+        if actual == expected:
+            print("SUCCESS!")
+        else:
+            print("FAILED!")
+
+    return 0 if actual == expected else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nccl4py/examples/01_basic/02_send_recv.py
+++ b/nccl4py/examples/01_basic/02_send_recv.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+NCCL4Py Basic Example: Send/Recv
+==================================
+
+Simple point-to-point communication example showing two ranks exchanging data.
+Demonstrates the use of group() to avoid deadlocks.
+
+USAGE:
+mpirun -np 2 python 02_send_recv.py
+"""
+
+import sys
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    print("ERROR: mpi4py required. Install with: pip install mpi4py")
+    sys.exit(1)
+
+try:
+    import torch
+except ImportError:
+    print("ERROR: PyTorch required. Install with: pip install torch")
+    sys.exit(1)
+
+import nccl.core as nccl
+
+
+def main():
+    # Initialize MPI
+    comm_mpi = MPI.COMM_WORLD
+    rank = comm_mpi.Get_rank()
+    nranks = comm_mpi.Get_size()
+
+    # Set rank 0 as the root
+    root = 0
+
+    if nranks != 2:
+        if rank == root:
+            print("ERROR: This example requires exactly 2 ranks")
+            print("Usage: mpirun -np 2 python 02_send_recv.py")
+        sys.exit(1)
+
+    # Assign GPU to each process
+    device = torch.device(f"cuda:{rank % torch.cuda.device_count()}")
+    torch.cuda.set_device(device)
+
+    # [NCCL4Py] Generate unique ID on the root rank
+    unique_id = nccl.get_unique_id() if rank == root else None
+
+    # Broadcast unique ID to all ranks
+    unique_id = comm_mpi.bcast(unique_id, root=root)
+
+    # [NCCL4Py] Initialize NCCL communicator
+    nccl_comm = nccl.Communicator.init(nranks=nranks, rank=rank, unique_id=unique_id)
+
+    if rank == root:
+        print("Running Send/Recv between 2 ranks...")
+
+    # Create tensors
+    send_data = torch.tensor([float(100 + rank)], dtype=torch.float32, device=device)
+    recv_data = torch.zeros(1, dtype=torch.float32, device=device)
+
+    other_rank = 1 - rank  # Rank 0 <-> Rank 1
+
+    # Exchange data using group() to avoid deadlock
+    # IMPORTANT: Using group() allows send() and recv() to be called in any order.
+    # Without group(), you must ensure send() and recv() are ordered carefully to avoid deadlock.
+    # For example:
+    #   - All ranks call send() first, then all call recv(), OR
+    #   - Even ranks send then recv, odd ranks recv then send
+
+    # [NCCL4Py] Use group() to avoid deadlock
+    with nccl.group():
+        # [NCCL4Py] Send data to the other rank
+        nccl_comm.send(send_data, peer=other_rank)
+        # [NCCL4Py] Receive data from the other rank
+        nccl_comm.recv(recv_data, peer=other_rank)
+
+    torch.cuda.synchronize()
+
+    # Verify result
+    expected = float(100 + (1 - rank))
+    actual = float(recv_data[0].item())
+
+    print(f"Rank {rank}: Sent {100 + rank:.0f}, Received {actual:.0f} (expected {expected:.0f})")
+
+    # [NCCL4Py] Destroy NCCL communicator (collective call)
+    nccl_comm.destroy()
+
+    if rank == root:
+        if actual == expected:
+            print("SUCCESS!")
+        else:
+            print("FAILED!")
+
+    return 0 if actual == expected else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nccl4py/nccl/__init__.py
+++ b/nccl4py/nccl/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL4Py: Python bindings for NVIDIA Collective Communications Library (NCCL).
+
+NCCL4Py provides Pythonic access to NCCL for efficient multi-GPU and multi-node
+communication. It supports all NCCL collective operations, point-to-point
+communication, and advanced features like buffer registration and custom reduction
+operators.
+"""
+
+from nccl._version import __version__, __version_tuple__
+
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+]

--- a/nccl4py/nccl/bindings/__init__.py
+++ b/nccl4py/nccl/bindings/__init__.py
@@ -1,0 +1,1 @@
+from .nccl import *

--- a/nccl4py/nccl/bindings/_internal/__init__.py
+++ b/nccl4py/nccl/bindings/_internal/__init__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+Internal bindings implementation.
+
+This module preloads the NCCL library using cuda-pathfinder if available,
+which provides better library discovery across different environments
+(conda, system installs, custom CUDA paths, etc.).
+
+If cuda-pathfinder is not available or fails to find NCCL, the Cython
+bindings will fall back to direct dlopen("libnccl.so.2") which works
+if the library is in standard system paths.
+
+See documentation for cuda-pathfinder including the search order at:
+https://nvidia.github.io/cuda-python/cuda-pathfinder/latest/generated/cuda.pathfinder.load_nvidia_dynamic_lib.html#cuda.pathfinder.load_nvidia_dynamic_lib
+"""
+
+# Optional: Preload NCCL library for better discovery
+# This runs before the Cython extensions are loaded, allowing
+# dlsym(RTLD_DEFAULT, ...) to find the already-loaded library
+try:
+    from cuda.pathfinder import load_nvidia_dynamic_lib
+
+    load_nvidia_dynamic_lib("nccl")
+except ImportError:
+    # cuda-python not installed, fall back to Cython's dlopen
+    pass
+except Exception:
+    # Library not found by pathfinder or other error
+    # Fall back to Cython's dlopen - it will provide the error message if needed
+    pass

--- a/nccl4py/nccl/bindings/_internal/nccl.pxd
+++ b/nccl4py/nccl/bindings/_internal/nccl.pxd
@@ -1,0 +1,52 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code was automatically generated with version 2.28.0. Do not modify it directly.
+
+from ..cynccl cimport *
+
+
+###############################################################################
+# Wrapper functions
+###############################################################################
+
+cdef ncclResult_t _ncclMemAlloc(void** ptr, size_t size) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclMemFree(void* ptr) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclGetVersion(int* version) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclGetUniqueId(ncclUniqueId* uniqueId) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommFinalize(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommDestroy(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommAbort(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommShrink(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commIds, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef const char* _ncclGetErrorString(ncclResult_t result) except?NULL nogil
+cdef const char* _ncclGetLastError(ncclComm_t comm) except?NULL nogil
+cdef ncclResult_t _ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommCount(const ncclComm_t comm, int* count) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommCuDevice(const ncclComm_t comm, int* device) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommUserRank(const ncclComm_t comm, int* rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommDeregister(const ncclComm_t comm, void* handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclGather(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclScatter(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclGroupStart() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclGroupEnd() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t _ncclGroupSimulateEnd(ncclSimInfo_t* simInfo) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil

--- a/nccl4py/nccl/bindings/_internal/nccl_linux.pyx
+++ b/nccl4py/nccl/bindings/_internal/nccl_linux.pyx
@@ -1,0 +1,902 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code was automatically generated with version 2.28.0. Do not modify it directly.
+
+from libc.stdint cimport intptr_t
+
+from .utils import FunctionNotFoundError, NotSupportedError
+
+
+###############################################################################
+# Extern
+###############################################################################
+
+cdef extern from "<dlfcn.h>" nogil:
+    void* dlopen(const char*, int)
+    char* dlerror()
+    void* dlsym(void*, const char*)
+    int dlclose(void*)
+
+    enum:
+        RTLD_LAZY
+        RTLD_NOW
+        RTLD_GLOBAL
+        RTLD_LOCAL
+
+    const void* RTLD_DEFAULT 'RTLD_DEFAULT'
+
+
+###############################################################################
+# Wrapper init
+###############################################################################
+
+cdef bint __py_nccl_init = False
+
+cdef void* __ncclMemAlloc = NULL
+cdef void* __ncclMemFree = NULL
+cdef void* __ncclGetVersion = NULL
+cdef void* __ncclGetUniqueId = NULL
+cdef void* __ncclCommInitRankConfig = NULL
+cdef void* __ncclCommInitRank = NULL
+cdef void* __ncclCommInitAll = NULL
+cdef void* __ncclCommFinalize = NULL
+cdef void* __ncclCommDestroy = NULL
+cdef void* __ncclCommAbort = NULL
+cdef void* __ncclCommSplit = NULL
+cdef void* __ncclCommShrink = NULL
+cdef void* __ncclCommInitRankScalable = NULL
+cdef void* __ncclGetErrorString = NULL
+cdef void* __ncclGetLastError = NULL
+cdef void* __ncclCommGetAsyncError = NULL
+cdef void* __ncclCommCount = NULL
+cdef void* __ncclCommCuDevice = NULL
+cdef void* __ncclCommUserRank = NULL
+cdef void* __ncclCommRegister = NULL
+cdef void* __ncclCommDeregister = NULL
+cdef void* __ncclCommWindowRegister = NULL
+cdef void* __ncclCommWindowDeregister = NULL
+cdef void* __ncclRedOpCreatePreMulSum = NULL
+cdef void* __ncclRedOpDestroy = NULL
+cdef void* __ncclReduce = NULL
+cdef void* __ncclBcast = NULL
+cdef void* __ncclBroadcast = NULL
+cdef void* __ncclAllReduce = NULL
+cdef void* __ncclReduceScatter = NULL
+cdef void* __ncclAllGather = NULL
+cdef void* __ncclAlltoAll = NULL
+cdef void* __ncclGather = NULL
+cdef void* __ncclScatter = NULL
+cdef void* __ncclSend = NULL
+cdef void* __ncclRecv = NULL
+cdef void* __ncclGroupStart = NULL
+cdef void* __ncclGroupEnd = NULL
+cdef void* __ncclGroupSimulateEnd = NULL
+
+
+cdef void* load_library() except* nogil:
+    cdef void* handle
+    handle = dlopen("libnccl.so.2", RTLD_NOW | RTLD_GLOBAL)
+    if handle == NULL:
+        with gil:
+            err_msg = dlerror()
+            raise RuntimeError(f'Failed to dlopen libnccl ({err_msg.decode()})')
+    return handle
+
+
+cdef int _check_or_init_nccl() except -1 nogil:
+    global __py_nccl_init
+    if __py_nccl_init:
+        return 0
+
+    # Load function
+    cdef void* handle = NULL
+    global __ncclMemAlloc
+    __ncclMemAlloc = dlsym(RTLD_DEFAULT, 'ncclMemAlloc')
+    if __ncclMemAlloc == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclMemAlloc = dlsym(handle, 'ncclMemAlloc')
+
+    global __ncclMemFree
+    __ncclMemFree = dlsym(RTLD_DEFAULT, 'ncclMemFree')
+    if __ncclMemFree == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclMemFree = dlsym(handle, 'ncclMemFree')
+
+    global __ncclGetVersion
+    __ncclGetVersion = dlsym(RTLD_DEFAULT, 'ncclGetVersion')
+    if __ncclGetVersion == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGetVersion = dlsym(handle, 'ncclGetVersion')
+
+    global __ncclGetUniqueId
+    __ncclGetUniqueId = dlsym(RTLD_DEFAULT, 'ncclGetUniqueId')
+    if __ncclGetUniqueId == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGetUniqueId = dlsym(handle, 'ncclGetUniqueId')
+
+    global __ncclCommInitRankConfig
+    __ncclCommInitRankConfig = dlsym(RTLD_DEFAULT, 'ncclCommInitRankConfig')
+    if __ncclCommInitRankConfig == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommInitRankConfig = dlsym(handle, 'ncclCommInitRankConfig')
+
+    global __ncclCommInitRank
+    __ncclCommInitRank = dlsym(RTLD_DEFAULT, 'ncclCommInitRank')
+    if __ncclCommInitRank == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommInitRank = dlsym(handle, 'ncclCommInitRank')
+
+    global __ncclCommInitAll
+    __ncclCommInitAll = dlsym(RTLD_DEFAULT, 'ncclCommInitAll')
+    if __ncclCommInitAll == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommInitAll = dlsym(handle, 'ncclCommInitAll')
+
+    global __ncclCommFinalize
+    __ncclCommFinalize = dlsym(RTLD_DEFAULT, 'ncclCommFinalize')
+    if __ncclCommFinalize == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommFinalize = dlsym(handle, 'ncclCommFinalize')
+
+    global __ncclCommDestroy
+    __ncclCommDestroy = dlsym(RTLD_DEFAULT, 'ncclCommDestroy')
+    if __ncclCommDestroy == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommDestroy = dlsym(handle, 'ncclCommDestroy')
+
+    global __ncclCommAbort
+    __ncclCommAbort = dlsym(RTLD_DEFAULT, 'ncclCommAbort')
+    if __ncclCommAbort == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommAbort = dlsym(handle, 'ncclCommAbort')
+
+    global __ncclCommSplit
+    __ncclCommSplit = dlsym(RTLD_DEFAULT, 'ncclCommSplit')
+    if __ncclCommSplit == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommSplit = dlsym(handle, 'ncclCommSplit')
+
+    global __ncclCommShrink
+    __ncclCommShrink = dlsym(RTLD_DEFAULT, 'ncclCommShrink')
+    if __ncclCommShrink == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommShrink = dlsym(handle, 'ncclCommShrink')
+
+    global __ncclCommInitRankScalable
+    __ncclCommInitRankScalable = dlsym(RTLD_DEFAULT, 'ncclCommInitRankScalable')
+    if __ncclCommInitRankScalable == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommInitRankScalable = dlsym(handle, 'ncclCommInitRankScalable')
+
+    global __ncclGetErrorString
+    __ncclGetErrorString = dlsym(RTLD_DEFAULT, 'ncclGetErrorString')
+    if __ncclGetErrorString == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGetErrorString = dlsym(handle, 'ncclGetErrorString')
+
+    global __ncclGetLastError
+    __ncclGetLastError = dlsym(RTLD_DEFAULT, 'ncclGetLastError')
+    if __ncclGetLastError == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGetLastError = dlsym(handle, 'ncclGetLastError')
+
+    global __ncclCommGetAsyncError
+    __ncclCommGetAsyncError = dlsym(RTLD_DEFAULT, 'ncclCommGetAsyncError')
+    if __ncclCommGetAsyncError == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommGetAsyncError = dlsym(handle, 'ncclCommGetAsyncError')
+
+    global __ncclCommCount
+    __ncclCommCount = dlsym(RTLD_DEFAULT, 'ncclCommCount')
+    if __ncclCommCount == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommCount = dlsym(handle, 'ncclCommCount')
+
+    global __ncclCommCuDevice
+    __ncclCommCuDevice = dlsym(RTLD_DEFAULT, 'ncclCommCuDevice')
+    if __ncclCommCuDevice == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommCuDevice = dlsym(handle, 'ncclCommCuDevice')
+
+    global __ncclCommUserRank
+    __ncclCommUserRank = dlsym(RTLD_DEFAULT, 'ncclCommUserRank')
+    if __ncclCommUserRank == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommUserRank = dlsym(handle, 'ncclCommUserRank')
+
+    global __ncclCommRegister
+    __ncclCommRegister = dlsym(RTLD_DEFAULT, 'ncclCommRegister')
+    if __ncclCommRegister == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommRegister = dlsym(handle, 'ncclCommRegister')
+
+    global __ncclCommDeregister
+    __ncclCommDeregister = dlsym(RTLD_DEFAULT, 'ncclCommDeregister')
+    if __ncclCommDeregister == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommDeregister = dlsym(handle, 'ncclCommDeregister')
+
+    global __ncclCommWindowRegister
+    __ncclCommWindowRegister = dlsym(RTLD_DEFAULT, 'ncclCommWindowRegister')
+    if __ncclCommWindowRegister == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommWindowRegister = dlsym(handle, 'ncclCommWindowRegister')
+
+    global __ncclCommWindowDeregister
+    __ncclCommWindowDeregister = dlsym(RTLD_DEFAULT, 'ncclCommWindowDeregister')
+    if __ncclCommWindowDeregister == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclCommWindowDeregister = dlsym(handle, 'ncclCommWindowDeregister')
+
+    global __ncclRedOpCreatePreMulSum
+    __ncclRedOpCreatePreMulSum = dlsym(RTLD_DEFAULT, 'ncclRedOpCreatePreMulSum')
+    if __ncclRedOpCreatePreMulSum == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclRedOpCreatePreMulSum = dlsym(handle, 'ncclRedOpCreatePreMulSum')
+
+    global __ncclRedOpDestroy
+    __ncclRedOpDestroy = dlsym(RTLD_DEFAULT, 'ncclRedOpDestroy')
+    if __ncclRedOpDestroy == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclRedOpDestroy = dlsym(handle, 'ncclRedOpDestroy')
+
+    global __ncclReduce
+    __ncclReduce = dlsym(RTLD_DEFAULT, 'ncclReduce')
+    if __ncclReduce == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclReduce = dlsym(handle, 'ncclReduce')
+
+    global __ncclBcast
+    __ncclBcast = dlsym(RTLD_DEFAULT, 'ncclBcast')
+    if __ncclBcast == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclBcast = dlsym(handle, 'ncclBcast')
+
+    global __ncclBroadcast
+    __ncclBroadcast = dlsym(RTLD_DEFAULT, 'ncclBroadcast')
+    if __ncclBroadcast == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclBroadcast = dlsym(handle, 'ncclBroadcast')
+
+    global __ncclAllReduce
+    __ncclAllReduce = dlsym(RTLD_DEFAULT, 'ncclAllReduce')
+    if __ncclAllReduce == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclAllReduce = dlsym(handle, 'ncclAllReduce')
+
+    global __ncclReduceScatter
+    __ncclReduceScatter = dlsym(RTLD_DEFAULT, 'ncclReduceScatter')
+    if __ncclReduceScatter == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclReduceScatter = dlsym(handle, 'ncclReduceScatter')
+
+    global __ncclAllGather
+    __ncclAllGather = dlsym(RTLD_DEFAULT, 'ncclAllGather')
+    if __ncclAllGather == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclAllGather = dlsym(handle, 'ncclAllGather')
+
+    global __ncclAlltoAll
+    __ncclAlltoAll = dlsym(RTLD_DEFAULT, 'ncclAlltoAll')
+    if __ncclAlltoAll == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclAlltoAll = dlsym(handle, 'ncclAlltoAll')
+
+    global __ncclGather
+    __ncclGather = dlsym(RTLD_DEFAULT, 'ncclGather')
+    if __ncclGather == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGather = dlsym(handle, 'ncclGather')
+
+    global __ncclScatter
+    __ncclScatter = dlsym(RTLD_DEFAULT, 'ncclScatter')
+    if __ncclScatter == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclScatter = dlsym(handle, 'ncclScatter')
+
+    global __ncclSend
+    __ncclSend = dlsym(RTLD_DEFAULT, 'ncclSend')
+    if __ncclSend == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclSend = dlsym(handle, 'ncclSend')
+
+    global __ncclRecv
+    __ncclRecv = dlsym(RTLD_DEFAULT, 'ncclRecv')
+    if __ncclRecv == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclRecv = dlsym(handle, 'ncclRecv')
+
+    global __ncclGroupStart
+    __ncclGroupStart = dlsym(RTLD_DEFAULT, 'ncclGroupStart')
+    if __ncclGroupStart == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGroupStart = dlsym(handle, 'ncclGroupStart')
+
+    global __ncclGroupEnd
+    __ncclGroupEnd = dlsym(RTLD_DEFAULT, 'ncclGroupEnd')
+    if __ncclGroupEnd == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGroupEnd = dlsym(handle, 'ncclGroupEnd')
+
+    global __ncclGroupSimulateEnd
+    __ncclGroupSimulateEnd = dlsym(RTLD_DEFAULT, 'ncclGroupSimulateEnd')
+    if __ncclGroupSimulateEnd == NULL:
+        if handle == NULL:
+            handle = load_library()
+        __ncclGroupSimulateEnd = dlsym(handle, 'ncclGroupSimulateEnd')
+
+    __py_nccl_init = True
+    return 0
+
+
+cdef dict func_ptrs = None
+
+
+cpdef dict _inspect_function_pointers():
+    global func_ptrs
+    if func_ptrs is not None:
+        return func_ptrs
+
+    _check_or_init_nccl()
+    cdef dict data = {}
+
+    global __ncclMemAlloc
+    data["__ncclMemAlloc"] = <intptr_t>__ncclMemAlloc
+
+    global __ncclMemFree
+    data["__ncclMemFree"] = <intptr_t>__ncclMemFree
+
+    global __ncclGetVersion
+    data["__ncclGetVersion"] = <intptr_t>__ncclGetVersion
+
+    global __ncclGetUniqueId
+    data["__ncclGetUniqueId"] = <intptr_t>__ncclGetUniqueId
+
+    global __ncclCommInitRankConfig
+    data["__ncclCommInitRankConfig"] = <intptr_t>__ncclCommInitRankConfig
+
+    global __ncclCommInitRank
+    data["__ncclCommInitRank"] = <intptr_t>__ncclCommInitRank
+
+    global __ncclCommInitAll
+    data["__ncclCommInitAll"] = <intptr_t>__ncclCommInitAll
+
+    global __ncclCommFinalize
+    data["__ncclCommFinalize"] = <intptr_t>__ncclCommFinalize
+
+    global __ncclCommDestroy
+    data["__ncclCommDestroy"] = <intptr_t>__ncclCommDestroy
+
+    global __ncclCommAbort
+    data["__ncclCommAbort"] = <intptr_t>__ncclCommAbort
+
+    global __ncclCommSplit
+    data["__ncclCommSplit"] = <intptr_t>__ncclCommSplit
+
+    global __ncclCommShrink
+    data["__ncclCommShrink"] = <intptr_t>__ncclCommShrink
+
+    global __ncclCommInitRankScalable
+    data["__ncclCommInitRankScalable"] = <intptr_t>__ncclCommInitRankScalable
+
+    global __ncclGetErrorString
+    data["__ncclGetErrorString"] = <intptr_t>__ncclGetErrorString
+
+    global __ncclGetLastError
+    data["__ncclGetLastError"] = <intptr_t>__ncclGetLastError
+
+    global __ncclCommGetAsyncError
+    data["__ncclCommGetAsyncError"] = <intptr_t>__ncclCommGetAsyncError
+
+    global __ncclCommCount
+    data["__ncclCommCount"] = <intptr_t>__ncclCommCount
+
+    global __ncclCommCuDevice
+    data["__ncclCommCuDevice"] = <intptr_t>__ncclCommCuDevice
+
+    global __ncclCommUserRank
+    data["__ncclCommUserRank"] = <intptr_t>__ncclCommUserRank
+
+    global __ncclCommRegister
+    data["__ncclCommRegister"] = <intptr_t>__ncclCommRegister
+
+    global __ncclCommDeregister
+    data["__ncclCommDeregister"] = <intptr_t>__ncclCommDeregister
+
+    global __ncclCommWindowRegister
+    data["__ncclCommWindowRegister"] = <intptr_t>__ncclCommWindowRegister
+
+    global __ncclCommWindowDeregister
+    data["__ncclCommWindowDeregister"] = <intptr_t>__ncclCommWindowDeregister
+
+    global __ncclRedOpCreatePreMulSum
+    data["__ncclRedOpCreatePreMulSum"] = <intptr_t>__ncclRedOpCreatePreMulSum
+
+    global __ncclRedOpDestroy
+    data["__ncclRedOpDestroy"] = <intptr_t>__ncclRedOpDestroy
+
+    global __ncclReduce
+    data["__ncclReduce"] = <intptr_t>__ncclReduce
+
+    global __ncclBcast
+    data["__ncclBcast"] = <intptr_t>__ncclBcast
+
+    global __ncclBroadcast
+    data["__ncclBroadcast"] = <intptr_t>__ncclBroadcast
+
+    global __ncclAllReduce
+    data["__ncclAllReduce"] = <intptr_t>__ncclAllReduce
+
+    global __ncclReduceScatter
+    data["__ncclReduceScatter"] = <intptr_t>__ncclReduceScatter
+
+    global __ncclAllGather
+    data["__ncclAllGather"] = <intptr_t>__ncclAllGather
+
+    global __ncclAlltoAll
+    data["__ncclAlltoAll"] = <intptr_t>__ncclAlltoAll
+
+    global __ncclGather
+    data["__ncclGather"] = <intptr_t>__ncclGather
+
+    global __ncclScatter
+    data["__ncclScatter"] = <intptr_t>__ncclScatter
+
+    global __ncclSend
+    data["__ncclSend"] = <intptr_t>__ncclSend
+
+    global __ncclRecv
+    data["__ncclRecv"] = <intptr_t>__ncclRecv
+
+    global __ncclGroupStart
+    data["__ncclGroupStart"] = <intptr_t>__ncclGroupStart
+
+    global __ncclGroupEnd
+    data["__ncclGroupEnd"] = <intptr_t>__ncclGroupEnd
+
+    global __ncclGroupSimulateEnd
+    data["__ncclGroupSimulateEnd"] = <intptr_t>__ncclGroupSimulateEnd
+
+    func_ptrs = data
+    return data
+
+
+cpdef _inspect_function_pointer(str name):
+    global func_ptrs
+    if func_ptrs is None:
+        func_ptrs = _inspect_function_pointers()
+    return func_ptrs[name]
+
+
+###############################################################################
+# Wrapper functions
+###############################################################################
+
+cdef ncclResult_t _ncclMemAlloc(void** ptr, size_t size) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclMemAlloc
+    _check_or_init_nccl()
+    if __ncclMemAlloc == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclMemAlloc is not found")
+    return (<ncclResult_t (*)(void**, size_t) noexcept nogil>__ncclMemAlloc)(
+        ptr, size)
+
+
+cdef ncclResult_t _ncclMemFree(void* ptr) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclMemFree
+    _check_or_init_nccl()
+    if __ncclMemFree == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclMemFree is not found")
+    return (<ncclResult_t (*)(void*) noexcept nogil>__ncclMemFree)(
+        ptr)
+
+
+cdef ncclResult_t _ncclGetVersion(int* version) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclGetVersion
+    _check_or_init_nccl()
+    if __ncclGetVersion == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGetVersion is not found")
+    return (<ncclResult_t (*)(int*) noexcept nogil>__ncclGetVersion)(
+        version)
+
+
+cdef ncclResult_t _ncclGetUniqueId(ncclUniqueId* uniqueId) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclGetUniqueId
+    _check_or_init_nccl()
+    if __ncclGetUniqueId == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGetUniqueId is not found")
+    return (<ncclResult_t (*)(ncclUniqueId*) noexcept nogil>__ncclGetUniqueId)(
+        uniqueId)
+
+
+cdef ncclResult_t _ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommInitRankConfig
+    _check_or_init_nccl()
+    if __ncclCommInitRankConfig == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommInitRankConfig is not found")
+    return (<ncclResult_t (*)(ncclComm_t*, int, ncclUniqueId, int, ncclConfig_t*) noexcept nogil>__ncclCommInitRankConfig)(
+        comm, nranks, commId, rank, config)
+
+
+cdef ncclResult_t _ncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommInitRank
+    _check_or_init_nccl()
+    if __ncclCommInitRank == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommInitRank is not found")
+    return (<ncclResult_t (*)(ncclComm_t*, int, ncclUniqueId, int) noexcept nogil>__ncclCommInitRank)(
+        comm, nranks, commId, rank)
+
+
+cdef ncclResult_t _ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommInitAll
+    _check_or_init_nccl()
+    if __ncclCommInitAll == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommInitAll is not found")
+    return (<ncclResult_t (*)(ncclComm_t*, int, const int*) noexcept nogil>__ncclCommInitAll)(
+        comm, ndev, devlist)
+
+
+cdef ncclResult_t _ncclCommFinalize(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommFinalize
+    _check_or_init_nccl()
+    if __ncclCommFinalize == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommFinalize is not found")
+    return (<ncclResult_t (*)(ncclComm_t) noexcept nogil>__ncclCommFinalize)(
+        comm)
+
+
+cdef ncclResult_t _ncclCommDestroy(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommDestroy
+    _check_or_init_nccl()
+    if __ncclCommDestroy == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommDestroy is not found")
+    return (<ncclResult_t (*)(ncclComm_t) noexcept nogil>__ncclCommDestroy)(
+        comm)
+
+
+cdef ncclResult_t _ncclCommAbort(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommAbort
+    _check_or_init_nccl()
+    if __ncclCommAbort == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommAbort is not found")
+    return (<ncclResult_t (*)(ncclComm_t) noexcept nogil>__ncclCommAbort)(
+        comm)
+
+
+cdef ncclResult_t _ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommSplit
+    _check_or_init_nccl()
+    if __ncclCommSplit == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommSplit is not found")
+    return (<ncclResult_t (*)(ncclComm_t, int, int, ncclComm_t*, ncclConfig_t*) noexcept nogil>__ncclCommSplit)(
+        comm, color, key, newcomm, config)
+
+
+cdef ncclResult_t _ncclCommShrink(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommShrink
+    _check_or_init_nccl()
+    if __ncclCommShrink == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommShrink is not found")
+    return (<ncclResult_t (*)(ncclComm_t, int*, int, ncclComm_t*, ncclConfig_t*, int) noexcept nogil>__ncclCommShrink)(
+        comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags)
+
+
+cdef ncclResult_t _ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commIds, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommInitRankScalable
+    _check_or_init_nccl()
+    if __ncclCommInitRankScalable == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommInitRankScalable is not found")
+    return (<ncclResult_t (*)(ncclComm_t*, int, int, int, ncclUniqueId*, ncclConfig_t*) noexcept nogil>__ncclCommInitRankScalable)(
+        newcomm, nranks, myrank, nId, commIds, config)
+
+
+cdef const char* _ncclGetErrorString(ncclResult_t result) except?NULL nogil:
+    global __ncclGetErrorString
+    _check_or_init_nccl()
+    if __ncclGetErrorString == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGetErrorString is not found")
+    return (<const char* (*)(ncclResult_t) noexcept nogil>__ncclGetErrorString)(
+        result)
+
+
+cdef const char* _ncclGetLastError(ncclComm_t comm) except?NULL nogil:
+    global __ncclGetLastError
+    _check_or_init_nccl()
+    if __ncclGetLastError == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGetLastError is not found")
+    return (<const char* (*)(ncclComm_t) noexcept nogil>__ncclGetLastError)(
+        comm)
+
+
+cdef ncclResult_t _ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommGetAsyncError
+    _check_or_init_nccl()
+    if __ncclCommGetAsyncError == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommGetAsyncError is not found")
+    return (<ncclResult_t (*)(ncclComm_t, ncclResult_t*) noexcept nogil>__ncclCommGetAsyncError)(
+        comm, asyncError)
+
+
+cdef ncclResult_t _ncclCommCount(const ncclComm_t comm, int* count) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommCount
+    _check_or_init_nccl()
+    if __ncclCommCount == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommCount is not found")
+    return (<ncclResult_t (*)(const ncclComm_t, int*) noexcept nogil>__ncclCommCount)(
+        comm, count)
+
+
+cdef ncclResult_t _ncclCommCuDevice(const ncclComm_t comm, int* device) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommCuDevice
+    _check_or_init_nccl()
+    if __ncclCommCuDevice == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommCuDevice is not found")
+    return (<ncclResult_t (*)(const ncclComm_t, int*) noexcept nogil>__ncclCommCuDevice)(
+        comm, device)
+
+
+cdef ncclResult_t _ncclCommUserRank(const ncclComm_t comm, int* rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommUserRank
+    _check_or_init_nccl()
+    if __ncclCommUserRank == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommUserRank is not found")
+    return (<ncclResult_t (*)(const ncclComm_t, int*) noexcept nogil>__ncclCommUserRank)(
+        comm, rank)
+
+
+cdef ncclResult_t _ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommRegister
+    _check_or_init_nccl()
+    if __ncclCommRegister == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommRegister is not found")
+    return (<ncclResult_t (*)(const ncclComm_t, void*, size_t, void**) noexcept nogil>__ncclCommRegister)(
+        comm, buff, size, handle)
+
+
+cdef ncclResult_t _ncclCommDeregister(const ncclComm_t comm, void* handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommDeregister
+    _check_or_init_nccl()
+    if __ncclCommDeregister == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommDeregister is not found")
+    return (<ncclResult_t (*)(const ncclComm_t, void*) noexcept nogil>__ncclCommDeregister)(
+        comm, handle)
+
+
+cdef ncclResult_t _ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommWindowRegister
+    _check_or_init_nccl()
+    if __ncclCommWindowRegister == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommWindowRegister is not found")
+    return (<ncclResult_t (*)(ncclComm_t, void*, size_t, ncclWindow_t*, int) noexcept nogil>__ncclCommWindowRegister)(
+        comm, buff, size, win, winFlags)
+
+
+cdef ncclResult_t _ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclCommWindowDeregister
+    _check_or_init_nccl()
+    if __ncclCommWindowDeregister == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclCommWindowDeregister is not found")
+    return (<ncclResult_t (*)(ncclComm_t, ncclWindow_t) noexcept nogil>__ncclCommWindowDeregister)(
+        comm, win)
+
+
+cdef ncclResult_t _ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclRedOpCreatePreMulSum
+    _check_or_init_nccl()
+    if __ncclRedOpCreatePreMulSum == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclRedOpCreatePreMulSum is not found")
+    return (<ncclResult_t (*)(ncclRedOp_t*, void*, ncclDataType_t, ncclScalarResidence_t, ncclComm_t) noexcept nogil>__ncclRedOpCreatePreMulSum)(
+        op, scalar, datatype, residence, comm)
+
+
+cdef ncclResult_t _ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclRedOpDestroy
+    _check_or_init_nccl()
+    if __ncclRedOpDestroy == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclRedOpDestroy is not found")
+    return (<ncclResult_t (*)(ncclRedOp_t, ncclComm_t) noexcept nogil>__ncclRedOpDestroy)(
+        op, comm)
+
+
+cdef ncclResult_t _ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclReduce
+    _check_or_init_nccl()
+    if __ncclReduce == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclReduce is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, ncclRedOp_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclReduce)(
+        sendbuff, recvbuff, count, datatype, op, root, comm, stream)
+
+
+cdef ncclResult_t _ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclBcast
+    _check_or_init_nccl()
+    if __ncclBcast == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclBcast is not found")
+    return (<ncclResult_t (*)(void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclBcast)(
+        buff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t _ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclBroadcast
+    _check_or_init_nccl()
+    if __ncclBroadcast == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclBroadcast is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclBroadcast)(
+        sendbuff, recvbuff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t _ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclAllReduce
+    _check_or_init_nccl()
+    if __ncclAllReduce == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclAllReduce is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, ncclRedOp_t, ncclComm_t, cudaStream_t) noexcept nogil>__ncclAllReduce)(
+        sendbuff, recvbuff, count, datatype, op, comm, stream)
+
+
+cdef ncclResult_t _ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclReduceScatter
+    _check_or_init_nccl()
+    if __ncclReduceScatter == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclReduceScatter is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, ncclRedOp_t, ncclComm_t, cudaStream_t) noexcept nogil>__ncclReduceScatter)(
+        sendbuff, recvbuff, recvcount, datatype, op, comm, stream)
+
+
+cdef ncclResult_t _ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclAllGather
+    _check_or_init_nccl()
+    if __ncclAllGather == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclAllGather is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, ncclComm_t, cudaStream_t) noexcept nogil>__ncclAllGather)(
+        sendbuff, recvbuff, sendcount, datatype, comm, stream)
+
+
+cdef ncclResult_t _ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclAlltoAll
+    _check_or_init_nccl()
+    if __ncclAlltoAll == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclAlltoAll is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, ncclComm_t, cudaStream_t) noexcept nogil>__ncclAlltoAll)(
+        sendbuff, recvbuff, count, datatype, comm, stream)
+
+
+cdef ncclResult_t _ncclGather(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclGather
+    _check_or_init_nccl()
+    if __ncclGather == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGather is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclGather)(
+        sendbuff, recvbuff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t _ncclScatter(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclScatter
+    _check_or_init_nccl()
+    if __ncclScatter == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclScatter is not found")
+    return (<ncclResult_t (*)(const void*, void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclScatter)(
+        sendbuff, recvbuff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t _ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclSend
+    _check_or_init_nccl()
+    if __ncclSend == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclSend is not found")
+    return (<ncclResult_t (*)(const void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclSend)(
+        sendbuff, count, datatype, peer, comm, stream)
+
+
+cdef ncclResult_t _ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclRecv
+    _check_or_init_nccl()
+    if __ncclRecv == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclRecv is not found")
+    return (<ncclResult_t (*)(void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) noexcept nogil>__ncclRecv)(
+        recvbuff, count, datatype, peer, comm, stream)
+
+
+cdef ncclResult_t _ncclGroupStart() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclGroupStart
+    _check_or_init_nccl()
+    if __ncclGroupStart == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGroupStart is not found")
+    return (<ncclResult_t (*)() noexcept nogil>__ncclGroupStart)(
+        )
+
+
+cdef ncclResult_t _ncclGroupEnd() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclGroupEnd
+    _check_or_init_nccl()
+    if __ncclGroupEnd == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGroupEnd is not found")
+    return (<ncclResult_t (*)() noexcept nogil>__ncclGroupEnd)(
+        )
+
+
+cdef ncclResult_t _ncclGroupSimulateEnd(ncclSimInfo_t* simInfo) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    global __ncclGroupSimulateEnd
+    _check_or_init_nccl()
+    if __ncclGroupSimulateEnd == NULL:
+        with gil:
+            raise FunctionNotFoundError("function ncclGroupSimulateEnd is not found")
+    return (<ncclResult_t (*)(ncclSimInfo_t*) noexcept nogil>__ncclGroupSimulateEnd)(
+        simInfo)

--- a/nccl4py/nccl/bindings/_internal/utils.pxd
+++ b/nccl4py/nccl/bindings/_internal/utils.pxd
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+from libc.stdint cimport int32_t, int64_t, intptr_t
+from libcpp.vector cimport vector
+from libcpp cimport bool as cppbool
+from libcpp cimport nullptr_t, nullptr
+from libcpp.memory cimport unique_ptr
+
+from ..cynccl cimport ncclUniqueId
+
+
+cdef extern from * nogil:
+    """
+    template<typename T>
+    class nullable_unique_ptr {
+      public:
+        nullable_unique_ptr() noexcept = default;
+
+        nullable_unique_ptr(std::nullptr_t) noexcept = delete;
+
+        explicit nullable_unique_ptr(T* data, bool own_data):
+            own_data_(own_data)
+        {
+            if (own_data)
+                manager_.reset(data);
+            else
+                raw_data_ = data;
+        }
+
+        nullable_unique_ptr(const nullable_unique_ptr&) = delete;
+
+        nullable_unique_ptr& operator=(const nullable_unique_ptr&) = delete;
+
+        nullable_unique_ptr(nullable_unique_ptr&& other) noexcept
+        {
+            own_data_ = other.own_data_;
+            other.own_data_ = false;  // ownership is transferred
+            if (own_data_)
+            {
+                manager_ = std::move(other.manager_);
+                raw_data_ = nullptr;  // just in case
+            }
+            else
+            {
+                manager_.reset(nullptr);  // just in case
+                raw_data_ = other.raw_data_;
+            }
+        }
+
+        nullable_unique_ptr& operator=(nullable_unique_ptr&& other) noexcept
+        {
+            own_data_ = other.own_data_;
+            other.own_data_ = false;  // ownership is transferred
+            if (own_data_)
+            {
+                manager_ = std::move(other.manager_);
+                raw_data_ = nullptr;  // just in case
+            }
+            else
+            {
+                manager_.reset(nullptr);  // just in case
+                raw_data_ = other.raw_data_;
+            }
+            return *this;
+        }
+
+        ~nullable_unique_ptr() = default;
+
+        void reset(T* data, bool own_data)
+        {
+            own_data_ = own_data;
+            if (own_data_)
+            {
+                manager_.reset(data);
+                raw_data_ = nullptr;
+            }
+            else
+            {
+                manager_.reset(nullptr);
+                raw_data_ = data;
+            }
+        }
+
+        void swap(nullable_unique_ptr& other) noexcept
+        {
+            std::swap(manager_, other.manager_);
+            std::swap(raw_data_, other.raw_data_);
+            std::swap(own_data_, other.own_data_);
+        }
+
+        /*
+         * Get the pointer to the underlying object (this is different from data()!).
+         */
+        T* get() const noexcept
+        {
+            if (own_data_)
+                return manager_.get();
+            else
+                return raw_data_;
+        }
+
+        /*
+         * Get the pointer to the underlying buffer (this is different from get()!).
+         */
+        void* data() noexcept
+        {
+            if (own_data_)
+                return manager_.get()->data();
+            else
+                return raw_data_;
+        }
+
+        T& operator*()
+        {
+            if (own_data_)
+                return *manager_;
+            else
+                return *raw_data_;
+        }
+
+      private:
+        std::unique_ptr<T> manager_{};
+        T* raw_data_{nullptr};
+        bool own_data_{false};
+    };
+    """
+    # xref: cython/Cython/Includes/libcpp/memory.pxd
+    cdef cppclass nullable_unique_ptr[T]:
+        nullable_unique_ptr()
+        nullable_unique_ptr(T*, cppbool)
+        nullable_unique_ptr(nullable_unique_ptr[T]&)
+
+        # Modifiers
+        void reset(T*, cppbool)
+        void swap(nullable_unique_ptr&)
+
+        # Observers
+        T* get()
+        T& operator*()
+        void* data()
+
+
+ctypedef fused ResT:
+    int
+    int32_t
+    int64_t
+    char
+    float
+    double
+    ncclUniqueId
+
+
+ctypedef fused PtrT:
+    void
+
+
+cdef cppclass nested_resource[T]:
+    nullable_unique_ptr[ vector[intptr_t] ] ptrs
+    nullable_unique_ptr[ vector[vector[T]] ] nested_resource_ptr
+
+
+# accepts the output pointer as input to use the return value for exception propagation
+cdef int get_resource_ptr(nullable_unique_ptr[vector[ResT]] &in_out_ptr, object obj, ResT* __unused) except 1
+cdef int get_resource_ptrs(nullable_unique_ptr[ vector[PtrT*] ] &in_out_ptr, object obj, PtrT* __unused) except 1
+cdef int get_nested_resource_ptr(nested_resource[ResT] &in_out_ptr, object obj, ResT* __unused) except 1
+
+cdef bint is_nested_sequence(data)
+cdef void* get_buffer_pointer(buf, Py_ssize_t size, readonly=*) except*

--- a/nccl4py/nccl/bindings/_internal/utils.pyx
+++ b/nccl4py/nccl/bindings/_internal/utils.pyx
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: LicenseRef-NVIDIA-SOFTWARE-LICENSE
+
+cimport cpython
+from libc.stdint cimport intptr_t
+from libcpp.utility cimport move
+from cython.operator cimport dereference as deref
+
+
+cdef bint is_nested_sequence(data):
+    if not cpython.PySequence_Check(data):
+        return False
+    else:
+        for i in data:
+            if not cpython.PySequence_Check(i):
+                return False
+        else:
+            return True
+
+
+cdef void* get_buffer_pointer(buf, Py_ssize_t size, readonly=True) except*:
+    """The caller must ensure ``buf`` is alive when the returned pointer is in use."""
+    cdef void* bufPtr
+    cdef int flags = cpython.PyBUF_ANY_CONTIGUOUS
+    if not readonly:
+        flags |= cpython.PyBUF_WRITABLE
+    cdef int status = -1
+    cdef cpython.Py_buffer view
+
+    if isinstance(buf, int):
+        bufPtr = <void*><intptr_t>buf
+    else:  # try buffer protocol
+        try:
+            status = cpython.PyObject_GetBuffer(buf, &view, flags)
+            # when the caller does not provide a size, it is set to -1 at generate-time by cybind
+            if size != -1:
+                assert view.len == size
+            assert view.ndim == 1
+        except Exception as e:
+            adj = "writable " if not readonly else ""
+            raise ValueError(
+                 "buf must be either a Python int representing the pointer "
+                f"address to a valid buffer, or a 1D contiguous {adj}"
+                 "buffer, of size bytes") from e
+        else:
+            bufPtr = view.buf
+        finally:
+            if status == 0:
+                cpython.PyBuffer_Release(&view)
+
+    return bufPtr
+
+
+# Cython can't infer the ResT overload when it is wrapped in nullable_unique_ptr,
+# so we need a dummy (__unused) input argument to help it
+cdef int get_resource_ptr(nullable_unique_ptr[vector[ResT]] &in_out_ptr, object obj, ResT* __unused) except 1:
+    if cpython.PySequence_Check(obj):
+        vec = new vector[ResT](len(obj))
+        # set the ownership immediately to avoid leaking the `vec` memory in
+        # case of exception in the following loop
+        in_out_ptr.reset(vec, True)
+        for i in range(len(obj)):
+            deref(vec)[i] = obj[i]
+    else:
+        in_out_ptr.reset(<vector[ResT]*><intptr_t>obj, False)
+    return 0
+
+
+cdef int get_resource_ptrs(nullable_unique_ptr[ vector[PtrT*] ] &in_out_ptr, object obj, PtrT* __unused) except 1:
+    if cpython.PySequence_Check(obj):
+        vec = new vector[PtrT*](len(obj))
+        # set the ownership immediately to avoid leaking the `vec` memory in
+        # case of exception in the following loop
+        in_out_ptr.reset(vec, True)
+        for i in range(len(obj)):
+            deref(vec)[i] = <PtrT*><intptr_t>(obj[i])
+    else:
+        in_out_ptr.reset(<vector[PtrT*]*><intptr_t>obj, False)
+    return 0
+
+
+cdef int get_nested_resource_ptr(nested_resource[ResT] &in_out_ptr, object obj, ResT* __unused) except 1:
+    cdef nullable_unique_ptr[ vector[intptr_t] ] nested_ptr
+    cdef nullable_unique_ptr[ vector[vector[ResT]] ] nested_res_ptr
+    cdef vector[intptr_t]* nested_vec = NULL
+    cdef vector[vector[ResT]]* nested_res_vec = NULL
+    cdef size_t i = 0, length = 0
+    cdef intptr_t addr
+
+    if is_nested_sequence(obj):
+        length = len(obj)
+        nested_res_vec = new vector[vector[ResT]](length)
+        nested_vec = new vector[intptr_t](length)
+        # set the ownership immediately to avoid leaking memory in case of
+        # exception in the following loop
+        nested_res_ptr.reset(nested_res_vec, True)
+        nested_ptr.reset(nested_vec, True)
+        for i, obj_i in enumerate(obj):
+            if ResT is char:
+                obj_i_bytes = (<str?>(obj_i)).encode()
+                str_len = <size_t>(len(obj_i_bytes)) + 1  # including null termination
+                deref(nested_res_vec)[i].resize(str_len)
+                obj_i_ptr = <char*>(obj_i_bytes)
+                # cast to size_t explicitly to work around a potentially Cython bug
+                deref(nested_res_vec)[i].assign(obj_i_ptr, obj_i_ptr + <size_t>str_len)
+            else:
+                deref(nested_res_vec)[i] = obj_i
+            deref(nested_vec)[i] = <intptr_t>(deref(nested_res_vec)[i].data())
+    elif cpython.PySequence_Check(obj):
+        length = len(obj)
+        nested_vec = new vector[intptr_t](length)
+        nested_ptr.reset(nested_vec, True)
+        for i, addr in enumerate(obj):
+            deref(nested_vec)[i] = addr
+        nested_res_ptr.reset(NULL, False)
+    else:
+        # obj is an int (ResT**)
+        nested_res_ptr.reset(NULL, False)
+        nested_ptr.reset(<vector[intptr_t]*><intptr_t>obj, False)
+
+    in_out_ptr.ptrs = move(nested_ptr)
+    in_out_ptr.nested_resource_ptr = move(nested_res_ptr)
+    return 0
+
+
+class FunctionNotFoundError(RuntimeError): pass
+
+class NotSupportedError(RuntimeError): pass

--- a/nccl4py/nccl/bindings/cynccl.pxd
+++ b/nccl4py/nccl/bindings/cynccl.pxd
@@ -1,0 +1,146 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code was automatically generated with version 2.28.0. Do not modify it directly.
+
+
+from libc.stdint cimport int64_t
+
+
+###############################################################################
+# Types (structs, enums, ...)
+###############################################################################
+
+# enums
+ctypedef enum ncclResult_t "ncclResult_t":
+    ncclSuccess "ncclSuccess" = 0
+    ncclUnhandledCudaError "ncclUnhandledCudaError" = 1
+    ncclSystemError "ncclSystemError" = 2
+    ncclInternalError "ncclInternalError" = 3
+    ncclInvalidArgument "ncclInvalidArgument" = 4
+    ncclInvalidUsage "ncclInvalidUsage" = 5
+    ncclRemoteError "ncclRemoteError" = 6
+    ncclInProgress "ncclInProgress" = 7
+    ncclNumResults "ncclNumResults" = 8
+    _NCCLRESULT_T_INTERNAL_LOADING_ERROR "_NCCLRESULT_T_INTERNAL_LOADING_ERROR" = -42
+
+ctypedef enum ncclRedOp_dummy_t "ncclRedOp_dummy_t":
+    ncclNumOps_dummy "ncclNumOps_dummy" = 5
+
+ctypedef enum ncclRedOp_t "ncclRedOp_t":
+    ncclSum "ncclSum" = 0
+    ncclProd "ncclProd" = 1
+    ncclMax "ncclMax" = 2
+    ncclMin "ncclMin" = 3
+    ncclAvg "ncclAvg" = 4
+    ncclNumOps "ncclNumOps" = 5
+    ncclMaxRedOp "ncclMaxRedOp" = (0x7fffffff >> (32 - (8 * sizeof(ncclRedOp_dummy_t))))
+
+ctypedef enum ncclDataType_t "ncclDataType_t":
+    ncclInt8 "ncclInt8" = 0
+    ncclChar "ncclChar" = 0
+    ncclUint8 "ncclUint8" = 1
+    ncclInt32 "ncclInt32" = 2
+    ncclInt "ncclInt" = 2
+    ncclUint32 "ncclUint32" = 3
+    ncclInt64 "ncclInt64" = 4
+    ncclUint64 "ncclUint64" = 5
+    ncclFloat16 "ncclFloat16" = 6
+    ncclHalf "ncclHalf" = 6
+    ncclFloat32 "ncclFloat32" = 7
+    ncclFloat "ncclFloat" = 7
+    ncclFloat64 "ncclFloat64" = 8
+    ncclDouble "ncclDouble" = 8
+    ncclBfloat16 "ncclBfloat16" = 9
+    ncclFloat8e4m3 "ncclFloat8e4m3" = 10
+    ncclFloat8e5m2 "ncclFloat8e5m2" = 11
+    ncclNumTypes "ncclNumTypes" = 12
+
+ctypedef enum ncclScalarResidence_t "ncclScalarResidence_t":
+    ncclScalarDevice "ncclScalarDevice" = 0
+    ncclScalarHostImmediate "ncclScalarHostImmediate" = 1
+
+
+# types
+cdef extern from *:
+    """
+    #include <driver_types.h>
+    #include <library_types.h>
+    #include <cuComplex.h>
+    """
+    ctypedef void* cudaStream_t 'cudaStream_t'
+
+
+ctypedef void* ncclComm_t 'ncclComm_t'
+ctypedef void* ncclWindow_t 'ncclWindow_t'
+ctypedef struct ncclUniqueId 'ncclUniqueId':
+    char internal[128]
+ctypedef struct ncclConfig_t 'ncclConfig_t':
+    size_t size
+    unsigned int magic
+    unsigned int version
+    int blocking
+    int cgaClusterSize
+    int minCTAs
+    int maxCTAs
+    char* netName
+    int splitShare
+    int trafficClass
+    char* commName
+    int collnetEnable
+    int CTAPolicy
+    int shrinkShare
+    int nvlsCTAs
+    int nChannelsPerNetPeer
+    int nvlinkCentricSched
+ctypedef struct ncclSimInfo_t 'ncclSimInfo_t':
+    size_t size
+    unsigned int magic
+    unsigned int version
+    float estimatedTime
+
+
+###############################################################################
+# Functions
+###############################################################################
+
+cdef ncclResult_t ncclMemAlloc(void** ptr, size_t size) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclMemFree(void* ptr) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclGetVersion(int* version) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclGetUniqueId(ncclUniqueId* uniqueId) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommFinalize(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommDestroy(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommAbort(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommShrink(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commIds, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef const char* ncclGetErrorString(ncclResult_t result) except?NULL nogil
+cdef const char* ncclGetLastError(ncclComm_t comm) except?NULL nogil
+cdef ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommCount(const ncclComm_t comm, int* count) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommCuDevice(const ncclComm_t comm, int* device) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommDeregister(const ncclComm_t comm, void* handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclGather(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclScatter(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclGroupStart() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclGroupEnd() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil
+cdef ncclResult_t ncclGroupSimulateEnd(ncclSimInfo_t* simInfo) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil

--- a/nccl4py/nccl/bindings/cynccl.pyx
+++ b/nccl4py/nccl/bindings/cynccl.pyx
@@ -1,0 +1,167 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code was automatically generated with version 2.28.0. Do not modify it directly.
+
+from ._internal cimport nccl as _nccl
+
+
+###############################################################################
+# Wrapper functions
+###############################################################################
+
+cdef ncclResult_t ncclMemAlloc(void** ptr, size_t size) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclMemAlloc(ptr, size)
+
+
+cdef ncclResult_t ncclMemFree(void* ptr) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclMemFree(ptr)
+
+
+cdef ncclResult_t ncclGetVersion(int* version) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclGetVersion(version)
+
+
+cdef ncclResult_t ncclGetUniqueId(ncclUniqueId* uniqueId) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclGetUniqueId(uniqueId)
+
+
+cdef ncclResult_t ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommInitRankConfig(comm, nranks, commId, rank, config)
+
+
+cdef ncclResult_t ncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommInitRank(comm, nranks, commId, rank)
+
+
+cdef ncclResult_t ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommInitAll(comm, ndev, devlist)
+
+
+cdef ncclResult_t ncclCommFinalize(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommFinalize(comm)
+
+
+cdef ncclResult_t ncclCommDestroy(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommDestroy(comm)
+
+
+cdef ncclResult_t ncclCommAbort(ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommAbort(comm)
+
+
+cdef ncclResult_t ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommSplit(comm, color, key, newcomm, config)
+
+
+cdef ncclResult_t ncclCommShrink(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommShrink(comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags)
+
+
+cdef ncclResult_t ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commIds, ncclConfig_t* config) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommInitRankScalable(newcomm, nranks, myrank, nId, commIds, config)
+
+
+cdef const char* ncclGetErrorString(ncclResult_t result) except?NULL nogil:
+    return _nccl._ncclGetErrorString(result)
+
+
+cdef const char* ncclGetLastError(ncclComm_t comm) except?NULL nogil:
+    return _nccl._ncclGetLastError(comm)
+
+
+cdef ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommGetAsyncError(comm, asyncError)
+
+
+cdef ncclResult_t ncclCommCount(const ncclComm_t comm, int* count) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommCount(comm, count)
+
+
+cdef ncclResult_t ncclCommCuDevice(const ncclComm_t comm, int* device) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommCuDevice(comm, device)
+
+
+cdef ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommUserRank(comm, rank)
+
+
+cdef ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommRegister(comm, buff, size, handle)
+
+
+cdef ncclResult_t ncclCommDeregister(const ncclComm_t comm, void* handle) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommDeregister(comm, handle)
+
+
+cdef ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommWindowRegister(comm, buff, size, win, winFlags)
+
+
+cdef ncclResult_t ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclCommWindowDeregister(comm, win)
+
+
+cdef ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclRedOpCreatePreMulSum(op, scalar, datatype, residence, comm)
+
+
+cdef ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclRedOpDestroy(op, comm)
+
+
+cdef ncclResult_t ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclReduce(sendbuff, recvbuff, count, datatype, op, root, comm, stream)
+
+
+cdef ncclResult_t ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclBcast(buff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclBroadcast(sendbuff, recvbuff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclAllReduce(sendbuff, recvbuff, count, datatype, op, comm, stream)
+
+
+cdef ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclReduceScatter(sendbuff, recvbuff, recvcount, datatype, op, comm, stream)
+
+
+cdef ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclAllGather(sendbuff, recvbuff, sendcount, datatype, comm, stream)
+
+
+cdef ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclAlltoAll(sendbuff, recvbuff, count, datatype, comm, stream)
+
+
+cdef ncclResult_t ncclGather(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclGather(sendbuff, recvbuff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t ncclScatter(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclScatter(sendbuff, recvbuff, count, datatype, root, comm, stream)
+
+
+cdef ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclSend(sendbuff, count, datatype, peer, comm, stream)
+
+
+cdef ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm, cudaStream_t stream) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclRecv(recvbuff, count, datatype, peer, comm, stream)
+
+
+cdef ncclResult_t ncclGroupStart() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclGroupStart()
+
+
+cdef ncclResult_t ncclGroupEnd() except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclGroupEnd()
+
+
+cdef ncclResult_t ncclGroupSimulateEnd(ncclSimInfo_t* simInfo) except?_NCCLRESULT_T_INTERNAL_LOADING_ERROR nogil:
+    return _nccl._ncclGroupSimulateEnd(simInfo)

--- a/nccl4py/nccl/bindings/nccl.pxd
+++ b/nccl4py/nccl/bindings/nccl.pxd
@@ -1,0 +1,75 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code was automatically generated with version 2.28.0. Do not modify it directly.
+
+from libc.stdint cimport intptr_t
+
+from .cynccl cimport *
+
+
+###############################################################################
+# Types
+###############################################################################
+
+ctypedef ncclComm_t Comm
+ctypedef ncclWindow_t Window
+
+ctypedef cudaStream_t Stream
+
+
+###############################################################################
+# Enum
+###############################################################################
+
+ctypedef ncclResult_t _Result
+ctypedef ncclRedOp_dummy_t _RedOp_dummy
+ctypedef ncclRedOp_t _RedOp
+ctypedef ncclDataType_t _DataType
+ctypedef ncclScalarResidence_t _ScalarResidence
+
+
+###############################################################################
+# Functions
+###############################################################################
+
+cpdef intptr_t mem_alloc(size_t size) except? 0
+cpdef mem_free(intptr_t ptr)
+cpdef int get_version() except? -1
+cpdef get_unique_id(intptr_t unique_id)
+cpdef intptr_t comm_init_rank_config(int nranks, comm_id, int rank, intptr_t config) except? 0
+cpdef intptr_t comm_init_rank(int nranks, comm_id, int rank) except? 0
+cpdef comm_init_all(intptr_t comm, int ndev, devlist)
+cpdef comm_finalize(intptr_t comm)
+cpdef comm_destroy(intptr_t comm)
+cpdef comm_abort(intptr_t comm)
+cpdef intptr_t comm_split(intptr_t comm, int color, int key, intptr_t config) except? 0
+cpdef intptr_t comm_shrink(intptr_t comm, exclude_ranks_list, int exclude_ranks_count, intptr_t config, int shrink_flags) except? 0
+cpdef intptr_t comm_init_rank_scalable(int nranks, int myrank, int n_id, comm_ids, intptr_t config) except? 0
+cpdef str get_error_string(int result)
+cpdef str get_last_error(intptr_t comm)
+cpdef int comm_get_async_error(intptr_t comm) except? -1
+cpdef int comm_count(intptr_t comm) except? -1
+cpdef int comm_cu_device(intptr_t comm) except? -1
+cpdef int comm_user_rank(intptr_t comm) except? -1
+cpdef intptr_t comm_register(intptr_t comm, intptr_t buff, size_t size) except? 0
+cpdef comm_deregister(intptr_t comm, intptr_t handle)
+cpdef intptr_t comm_window_register(intptr_t comm, intptr_t buff, size_t size, int win_flags) except? 0
+cpdef comm_window_deregister(intptr_t comm, intptr_t win)
+cpdef int red_op_create_pre_mul_sum(intptr_t scalar, int datatype, int residence, intptr_t comm) except? -1
+cpdef red_op_destroy(int op, intptr_t comm)
+cpdef reduce(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int op, int root, intptr_t comm, intptr_t stream)
+cpdef bcast(intptr_t buff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream)
+cpdef broadcast(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream)
+cpdef all_reduce(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int op, intptr_t comm, intptr_t stream)
+cpdef reduce_scatter(intptr_t sendbuff, intptr_t recvbuff, size_t recvcount, int datatype, int op, intptr_t comm, intptr_t stream)
+cpdef all_gather(intptr_t sendbuff, intptr_t recvbuff, size_t sendcount, int datatype, intptr_t comm, intptr_t stream)
+cpdef allto_all(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, intptr_t comm, intptr_t stream)
+cpdef gather(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream)
+cpdef scatter(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream)
+cpdef send(intptr_t sendbuff, size_t count, int datatype, int peer, intptr_t comm, intptr_t stream)
+cpdef recv(intptr_t recvbuff, size_t count, int datatype, int peer, intptr_t comm, intptr_t stream)
+cpdef group_start()
+cpdef group_end()
+cpdef group_simulate_end(intptr_t sim_info)

--- a/nccl4py/nccl/bindings/nccl.pyx
+++ b/nccl4py/nccl/bindings/nccl.pyx
@@ -1,0 +1,988 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This code was automatically generated with version 2.28.0. Do not modify it directly.
+
+cimport cython  # NOQA
+from cpython cimport buffer as _buffer
+from cpython.memoryview cimport PyMemoryView_FromMemory
+from libcpp.vector cimport vector
+
+from ._internal.utils cimport (nested_resource, nullable_unique_ptr, get_buffer_pointer,
+                              get_resource_ptr, get_nested_resource_ptr)
+
+from enum import IntEnum as _IntEnum
+
+import numpy as _numpy
+
+
+###############################################################################
+# POD
+###############################################################################
+
+unique_id_dtype = _numpy.dtype([
+    ("internal", _numpy.int8, (128,)),
+    ], align=True)
+
+
+cdef class UniqueId:
+    """Empty-initialize an array of `ncclUniqueId`.
+
+    The resulting object is of length `size` and of dtype `unique_id_dtype`.
+    If default-constructed, the instance represents a single struct.
+
+    Args:
+        size (int): number of structs, default=1.
+
+
+    .. seealso:: `ncclUniqueId`
+    """
+    cdef:
+        readonly object _data
+
+    def __init__(self, size=1):
+        arr = _numpy.empty(size, dtype=unique_id_dtype)
+        self._data = arr.view(_numpy.recarray)
+        assert self._data.itemsize == sizeof(ncclUniqueId), \
+            f"itemsize {self._data.itemsize} mismatches struct size {sizeof(ncclUniqueId)}"
+
+    def __repr__(self):
+        if self._data.size > 1:
+            return f"<{__name__}.UniqueId_Array_{self._data.size} object at {hex(id(self))}>"
+        else:
+            return f"<{__name__}.UniqueId object at {hex(id(self))}>"
+
+    @property
+    def ptr(self):
+        """Get the pointer address to the data as Python :class:`int`."""
+        return self._data.ctypes.data
+
+    def __int__(self):
+        if self._data.size > 1:
+            raise TypeError("int() argument must be a bytes-like object of size 1. "
+                            "To get the pointer address of an array, use .ptr")
+        return self._data.ctypes.data
+
+    def __len__(self):
+        return self._data.size
+
+    def __eq__(self, other):
+        if not isinstance(other, UniqueId):
+            return False
+        if self._data.size != other._data.size:
+            return False
+        if self._data.dtype != other._data.dtype:
+            return False
+        return bool((self._data == other._data).all())
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            size = self._data.size
+            if key >= size or key <= -(size+1):
+                raise IndexError("index is out of bounds")
+            if key < 0:
+                key += size
+            return UniqueId.from_data(self._data[key:key+1])
+        out = self._data[key]
+        if isinstance(out, _numpy.recarray) and out.dtype == unique_id_dtype:
+            return UniqueId.from_data(out)
+        return out
+
+    def __setitem__(self, key, val):
+        self._data[key] = val
+
+    @staticmethod
+    def from_data(data):
+        """Create an UniqueId instance wrapping the given NumPy array.
+
+        Args:
+            data (_numpy.ndarray): a 1D array of dtype `unique_id_dtype` holding the data.
+        """
+        cdef UniqueId obj = UniqueId.__new__(UniqueId)
+        if not isinstance(data, (_numpy.ndarray, _numpy.recarray)):
+            raise TypeError("data argument must be a NumPy ndarray")
+        if data.ndim != 1:
+            raise ValueError("data array must be 1D")
+        if data.dtype != unique_id_dtype:
+            raise ValueError("data array must be of dtype unique_id_dtype")
+        obj._data = data.view(_numpy.recarray)
+
+        return obj
+
+    @staticmethod
+    def from_ptr(intptr_t ptr, size_t size=1, bint readonly=False):
+        """Create an UniqueId instance wrapping the given pointer.
+
+        Args:
+            ptr (intptr_t): pointer address as Python :class:`int` to the data.
+            size (int): number of structs, default=1.
+            readonly (bool): whether the data is read-only (to the user). default is `False`.
+        """
+        if ptr == 0:
+            raise ValueError("ptr must not be null (0)")
+        cdef UniqueId obj = UniqueId.__new__(UniqueId)
+        cdef flag = _buffer.PyBUF_READ if readonly else _buffer.PyBUF_WRITE
+        cdef object buf = PyMemoryView_FromMemory(
+            <char*>ptr, sizeof(ncclUniqueId) * size, flag)
+        data = _numpy.ndarray((size,), buffer=buf,
+                              dtype=unique_id_dtype)
+        obj._data = data.view(_numpy.recarray)
+
+        return obj
+
+
+config_dtype = _numpy.dtype([
+    ("size_", _numpy.uint64, ),
+    ("magic", _numpy.uint32, ),
+    ("version", _numpy.uint32, ),
+    ("blocking", _numpy.int32, ),
+    ("cga_cluster_size", _numpy.int32, ),
+    ("min_ctas", _numpy.int32, ),
+    ("max_ctas", _numpy.int32, ),
+    ("net_name", _numpy.intp, ),
+    ("split_share", _numpy.int32, ),
+    ("traffic_class", _numpy.int32, ),
+    ("comm_name", _numpy.intp, ),
+    ("collnet_enable", _numpy.int32, ),
+    ("cta_policy", _numpy.int32, ),
+    ("shrink_share", _numpy.int32, ),
+    ("nvls_ctas", _numpy.int32, ),
+    ("n_channels_per_net_peer", _numpy.int32, ),
+    ("nvlink_centric_sched", _numpy.int32, ),
+    ], align=True)
+
+
+cdef class Config:
+    """Empty-initialize an array of `ncclConfig_t`.
+
+    The resulting object is of length `size` and of dtype `config_dtype`.
+    If default-constructed, the instance represents a single struct.
+
+    Args:
+        size (int): number of structs, default=1.
+
+
+    .. seealso:: `ncclConfig_t`
+    """
+    cdef:
+        readonly object _data
+        dict _holder
+
+    def __init__(self, size=1):
+        arr = _numpy.empty(size, dtype=config_dtype)
+        self._data = arr.view(_numpy.recarray)
+        assert self._data.itemsize == sizeof(ncclConfig_t), \
+            f"itemsize {self._data.itemsize} mismatches struct size {sizeof(ncclConfig_t)}"
+        self._holder = {}
+
+    def __repr__(self):
+        if self._data.size > 1:
+            return f"<{__name__}.Config_Array_{self._data.size} object at {hex(id(self))}>"
+        else:
+            return f"<{__name__}.Config object at {hex(id(self))}>"
+
+    @property
+    def ptr(self):
+        """Get the pointer address to the data as Python :class:`int`."""
+        return self._data.ctypes.data
+
+    def __int__(self):
+        if self._data.size > 1:
+            raise TypeError("int() argument must be a bytes-like object of size 1. "
+                            "To get the pointer address of an array, use .ptr")
+        return self._data.ctypes.data
+
+    def __len__(self):
+        return self._data.size
+
+    def __eq__(self, other):
+        if not isinstance(other, Config):
+            return False
+        if self._data.size != other._data.size:
+            return False
+        if self._data.dtype != other._data.dtype:
+            return False
+        return bool((self._data == other._data).all())
+
+    @property
+    def size_(self):
+        """Union[~_numpy.uint64, int]: """
+        if self._data.size == 1:
+            return int(self._data.size_[0])
+        return self._data.size_
+
+    @size_.setter
+    def size_(self, val):
+        self._data.size_ = val
+
+    @property
+    def magic(self):
+        """Union[~_numpy.uint32, int]: """
+        if self._data.size == 1:
+            return int(self._data.magic[0])
+        return self._data.magic
+
+    @magic.setter
+    def magic(self, val):
+        self._data.magic = val
+
+    @property
+    def version(self):
+        """Union[~_numpy.uint32, int]: """
+        if self._data.size == 1:
+            return int(self._data.version[0])
+        return self._data.version
+
+    @version.setter
+    def version(self, val):
+        self._data.version = val
+
+    @property
+    def blocking(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.blocking[0])
+        return self._data.blocking
+
+    @blocking.setter
+    def blocking(self, val):
+        self._data.blocking = val
+
+    @property
+    def cga_cluster_size(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.cga_cluster_size[0])
+        return self._data.cga_cluster_size
+
+    @cga_cluster_size.setter
+    def cga_cluster_size(self, val):
+        self._data.cga_cluster_size = val
+
+    @property
+    def min_ctas(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.min_ctas[0])
+        return self._data.min_ctas
+
+    @min_ctas.setter
+    def min_ctas(self, val):
+        self._data.min_ctas = val
+
+    @property
+    def max_ctas(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.max_ctas[0])
+        return self._data.max_ctas
+
+    @max_ctas.setter
+    def max_ctas(self, val):
+        self._data.max_ctas = val
+
+    @property
+    def net_name(self):
+        """Union[~_numpy.intp, str]: """
+        cdef char* ptr
+        cdef bytes buf
+        if self._data.size == 1:
+            ptr = <char*><intptr_t>(int(self._data.net_name[0]))
+            if ptr:
+                buf = ptr
+                return buf.decode()
+            return ""
+        return self._data.net_name
+
+    @net_name.setter
+    def net_name(self, val):
+        cdef char* ptr
+        cdef bytes buf
+        if self._data.size == 1:
+            buf = val.encode()
+            ptr = buf
+            self._holder["net_name"] = buf
+            self._data.net_name = <intptr_t>ptr
+            return
+        self._data.net_name = val
+
+    @property
+    def split_share(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.split_share[0])
+        return self._data.split_share
+
+    @split_share.setter
+    def split_share(self, val):
+        self._data.split_share = val
+
+    @property
+    def traffic_class(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.traffic_class[0])
+        return self._data.traffic_class
+
+    @traffic_class.setter
+    def traffic_class(self, val):
+        self._data.traffic_class = val
+
+    @property
+    def comm_name(self):
+        """Union[~_numpy.intp, str]: """
+        cdef char* ptr
+        cdef bytes buf
+        if self._data.size == 1:
+            ptr = <char*><intptr_t>(int(self._data.comm_name[0]))
+            if ptr:
+                buf = ptr
+                return buf.decode()
+            return ""
+        return self._data.comm_name
+
+    @comm_name.setter
+    def comm_name(self, val):
+        cdef char* ptr
+        cdef bytes buf
+        if self._data.size == 1:
+            buf = val.encode()
+            ptr = buf
+            self._holder["comm_name"] = buf
+            self._data.comm_name = <intptr_t>ptr
+            return
+        self._data.comm_name = val
+
+    @property
+    def collnet_enable(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.collnet_enable[0])
+        return self._data.collnet_enable
+
+    @collnet_enable.setter
+    def collnet_enable(self, val):
+        self._data.collnet_enable = val
+
+    @property
+    def cta_policy(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.cta_policy[0])
+        return self._data.cta_policy
+
+    @cta_policy.setter
+    def cta_policy(self, val):
+        self._data.cta_policy = val
+
+    @property
+    def shrink_share(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.shrink_share[0])
+        return self._data.shrink_share
+
+    @shrink_share.setter
+    def shrink_share(self, val):
+        self._data.shrink_share = val
+
+    @property
+    def nvls_ctas(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.nvls_ctas[0])
+        return self._data.nvls_ctas
+
+    @nvls_ctas.setter
+    def nvls_ctas(self, val):
+        self._data.nvls_ctas = val
+
+    @property
+    def n_channels_per_net_peer(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.n_channels_per_net_peer[0])
+        return self._data.n_channels_per_net_peer
+
+    @n_channels_per_net_peer.setter
+    def n_channels_per_net_peer(self, val):
+        self._data.n_channels_per_net_peer = val
+
+    @property
+    def nvlink_centric_sched(self):
+        """Union[~_numpy.int32, int]: """
+        if self._data.size == 1:
+            return int(self._data.nvlink_centric_sched[0])
+        return self._data.nvlink_centric_sched
+
+    @nvlink_centric_sched.setter
+    def nvlink_centric_sched(self, val):
+        self._data.nvlink_centric_sched = val
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            size = self._data.size
+            if key >= size or key <= -(size+1):
+                raise IndexError("index is out of bounds")
+            if key < 0:
+                key += size
+            return Config.from_data(self._data[key:key+1])
+        out = self._data[key]
+        if isinstance(out, _numpy.recarray) and out.dtype == config_dtype:
+            return Config.from_data(out)
+        return out
+
+    def __setitem__(self, key, val):
+        self._data[key] = val
+
+    @staticmethod
+    def from_data(data):
+        """Create an Config instance wrapping the given NumPy array.
+
+        Args:
+            data (_numpy.ndarray): a 1D array of dtype `config_dtype` holding the data.
+        """
+        cdef Config obj = Config.__new__(Config)
+        if not isinstance(data, (_numpy.ndarray, _numpy.recarray)):
+            raise TypeError("data argument must be a NumPy ndarray")
+        if data.ndim != 1:
+            raise ValueError("data array must be 1D")
+        if data.dtype != config_dtype:
+            raise ValueError("data array must be of dtype config_dtype")
+        obj._data = data.view(_numpy.recarray)
+
+        return obj
+
+    @staticmethod
+    def from_ptr(intptr_t ptr, size_t size=1, bint readonly=False):
+        """Create an Config instance wrapping the given pointer.
+
+        Args:
+            ptr (intptr_t): pointer address as Python :class:`int` to the data.
+            size (int): number of structs, default=1.
+            readonly (bool): whether the data is read-only (to the user). default is `False`.
+        """
+        if ptr == 0:
+            raise ValueError("ptr must not be null (0)")
+        cdef Config obj = Config.__new__(Config)
+        cdef flag = _buffer.PyBUF_READ if readonly else _buffer.PyBUF_WRITE
+        cdef object buf = PyMemoryView_FromMemory(
+            <char*>ptr, sizeof(ncclConfig_t) * size, flag)
+        data = _numpy.ndarray((size,), buffer=buf,
+                              dtype=config_dtype)
+        obj._data = data.view(_numpy.recarray)
+
+        return obj
+
+
+sim_info_dtype = _numpy.dtype([
+    ("size_", _numpy.uint64, ),
+    ("magic", _numpy.uint32, ),
+    ("version", _numpy.uint32, ),
+    ("estimated_time", _numpy.float32, ),
+    ], align=True)
+
+
+cdef class SimInfo:
+    """Empty-initialize an array of `ncclSimInfo_t`.
+
+    The resulting object is of length `size` and of dtype `sim_info_dtype`.
+    If default-constructed, the instance represents a single struct.
+
+    Args:
+        size (int): number of structs, default=1.
+
+
+    .. seealso:: `ncclSimInfo_t`
+    """
+    cdef:
+        readonly object _data
+
+    def __init__(self, size=1):
+        arr = _numpy.empty(size, dtype=sim_info_dtype)
+        self._data = arr.view(_numpy.recarray)
+        assert self._data.itemsize == sizeof(ncclSimInfo_t), \
+            f"itemsize {self._data.itemsize} mismatches struct size {sizeof(ncclSimInfo_t)}"
+
+    def __repr__(self):
+        if self._data.size > 1:
+            return f"<{__name__}.SimInfo_Array_{self._data.size} object at {hex(id(self))}>"
+        else:
+            return f"<{__name__}.SimInfo object at {hex(id(self))}>"
+
+    @property
+    def ptr(self):
+        """Get the pointer address to the data as Python :class:`int`."""
+        return self._data.ctypes.data
+
+    def __int__(self):
+        if self._data.size > 1:
+            raise TypeError("int() argument must be a bytes-like object of size 1. "
+                            "To get the pointer address of an array, use .ptr")
+        return self._data.ctypes.data
+
+    def __len__(self):
+        return self._data.size
+
+    def __eq__(self, other):
+        if not isinstance(other, SimInfo):
+            return False
+        if self._data.size != other._data.size:
+            return False
+        if self._data.dtype != other._data.dtype:
+            return False
+        return bool((self._data == other._data).all())
+
+    @property
+    def size_(self):
+        """Union[~_numpy.uint64, int]: """
+        if self._data.size == 1:
+            return int(self._data.size_[0])
+        return self._data.size_
+
+    @size_.setter
+    def size_(self, val):
+        self._data.size_ = val
+
+    @property
+    def magic(self):
+        """Union[~_numpy.uint32, int]: """
+        if self._data.size == 1:
+            return int(self._data.magic[0])
+        return self._data.magic
+
+    @magic.setter
+    def magic(self, val):
+        self._data.magic = val
+
+    @property
+    def version(self):
+        """Union[~_numpy.uint32, int]: """
+        if self._data.size == 1:
+            return int(self._data.version[0])
+        return self._data.version
+
+    @version.setter
+    def version(self, val):
+        self._data.version = val
+
+    @property
+    def estimated_time(self):
+        """Union[~_numpy.float32, float]: """
+        if self._data.size == 1:
+            return float(self._data.estimated_time[0])
+        return self._data.estimated_time
+
+    @estimated_time.setter
+    def estimated_time(self, val):
+        self._data.estimated_time = val
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            size = self._data.size
+            if key >= size or key <= -(size+1):
+                raise IndexError("index is out of bounds")
+            if key < 0:
+                key += size
+            return SimInfo.from_data(self._data[key:key+1])
+        out = self._data[key]
+        if isinstance(out, _numpy.recarray) and out.dtype == sim_info_dtype:
+            return SimInfo.from_data(out)
+        return out
+
+    def __setitem__(self, key, val):
+        self._data[key] = val
+
+    @staticmethod
+    def from_data(data):
+        """Create an SimInfo instance wrapping the given NumPy array.
+
+        Args:
+            data (_numpy.ndarray): a 1D array of dtype `sim_info_dtype` holding the data.
+        """
+        cdef SimInfo obj = SimInfo.__new__(SimInfo)
+        if not isinstance(data, (_numpy.ndarray, _numpy.recarray)):
+            raise TypeError("data argument must be a NumPy ndarray")
+        if data.ndim != 1:
+            raise ValueError("data array must be 1D")
+        if data.dtype != sim_info_dtype:
+            raise ValueError("data array must be of dtype sim_info_dtype")
+        obj._data = data.view(_numpy.recarray)
+
+        return obj
+
+    @staticmethod
+    def from_ptr(intptr_t ptr, size_t size=1, bint readonly=False):
+        """Create an SimInfo instance wrapping the given pointer.
+
+        Args:
+            ptr (intptr_t): pointer address as Python :class:`int` to the data.
+            size (int): number of structs, default=1.
+            readonly (bool): whether the data is read-only (to the user). default is `False`.
+        """
+        if ptr == 0:
+            raise ValueError("ptr must not be null (0)")
+        cdef SimInfo obj = SimInfo.__new__(SimInfo)
+        cdef flag = _buffer.PyBUF_READ if readonly else _buffer.PyBUF_WRITE
+        cdef object buf = PyMemoryView_FromMemory(
+            <char*>ptr, sizeof(ncclSimInfo_t) * size, flag)
+        data = _numpy.ndarray((size,), buffer=buf,
+                              dtype=sim_info_dtype)
+        obj._data = data.view(_numpy.recarray)
+
+        return obj
+
+
+
+###############################################################################
+# Enum
+###############################################################################
+
+class Result(_IntEnum):
+    """See `ncclResult_t`."""
+    Success = ncclSuccess
+    UnhandledCudaError = ncclUnhandledCudaError
+    SystemError = ncclSystemError
+    InternalError = ncclInternalError
+    InvalidArgument = ncclInvalidArgument
+    InvalidUsage = ncclInvalidUsage
+    RemoteError = ncclRemoteError
+    InProgress = ncclInProgress
+    NumResults = ncclNumResults
+
+class RedOp_dummy(_IntEnum):
+    """See `ncclRedOp_dummy_t`."""
+    NumOps_dummy = ncclNumOps_dummy
+
+class RedOp(_IntEnum):
+    """See `ncclRedOp_t`."""
+    Sum = ncclSum
+    Prod = ncclProd
+    Max = ncclMax
+    Min = ncclMin
+    Avg = ncclAvg
+    NumOps = ncclNumOps
+    MaxRedOp = ncclMaxRedOp
+
+class DataType(_IntEnum):
+    """See `ncclDataType_t`."""
+    Int8 = ncclInt8
+    Char = ncclChar
+    Uint8 = ncclUint8
+    Int32 = ncclInt32
+    Int = ncclInt
+    Uint32 = ncclUint32
+    Int64 = ncclInt64
+    Uint64 = ncclUint64
+    Float16 = ncclFloat16
+    Half = ncclHalf
+    Float32 = ncclFloat32
+    Float = ncclFloat
+    Float64 = ncclFloat64
+    Double = ncclDouble
+    Bfloat16 = ncclBfloat16
+    Float8e4m3 = ncclFloat8e4m3
+    Float8e5m2 = ncclFloat8e5m2
+    NumTypes = ncclNumTypes
+
+class ScalarResidence(_IntEnum):
+    """See `ncclScalarResidence_t`."""
+    Device = ncclScalarDevice
+    HostImmediate = ncclScalarHostImmediate
+
+
+###############################################################################
+# Error handling
+###############################################################################
+
+class NCCLError(Exception):
+
+    def __init__(self, status):
+        self.status = status
+        s = Result(status)
+        cdef str err = f"{s.name} ({s.value}): {get_error_string(status)}"
+        super(NCCLError, self).__init__(err)
+
+    def __reduce__(self):
+        return (type(self), (self.status,))
+
+
+@cython.profile(False)
+cpdef inline check_status(int status):
+    if status != Result.Success and status != Result.InProgress:
+        raise NCCLError(status)
+
+
+###############################################################################
+# Wrapper functions
+###############################################################################
+
+cpdef intptr_t mem_alloc(size_t size) except? 0:
+    cdef void* ptr
+    with nogil:
+        status = ncclMemAlloc(&ptr, size)
+    check_status(status)
+    return <intptr_t>ptr
+
+
+cpdef mem_free(intptr_t ptr):
+    with nogil:
+        status = ncclMemFree(<void*>ptr)
+    check_status(status)
+
+
+cpdef int get_version() except? -1:
+    cdef int version
+    with nogil:
+        status = ncclGetVersion(&version)
+    check_status(status)
+    return version
+
+
+cpdef get_unique_id(intptr_t unique_id):
+    with nogil:
+        status = ncclGetUniqueId(<ncclUniqueId*>unique_id)
+    check_status(status)
+
+
+cpdef intptr_t comm_init_rank_config(int nranks, comm_id, int rank, intptr_t config) except? 0:
+    cdef void* _comm_id_ = get_buffer_pointer(comm_id, -1, readonly=False)
+    cdef Comm comm
+    with nogil:
+        status = ncclCommInitRankConfig(&comm, nranks, (<ncclUniqueId*>(_comm_id_))[0], rank, <ncclConfig_t*>config)
+    check_status(status)
+    return <intptr_t>comm
+
+
+cpdef intptr_t comm_init_rank(int nranks, comm_id, int rank) except? 0:
+    cdef void* _comm_id_ = get_buffer_pointer(comm_id, -1, readonly=False)
+    cdef Comm comm
+    with nogil:
+        status = ncclCommInitRank(&comm, nranks, (<ncclUniqueId*>(_comm_id_))[0], rank)
+    check_status(status)
+    return <intptr_t>comm
+
+
+cpdef comm_init_all(intptr_t comm, int ndev, devlist):
+    cdef nullable_unique_ptr[ vector[int] ] _devlist_
+    get_resource_ptr[int](_devlist_, devlist, <int*>NULL)
+    with nogil:
+        status = ncclCommInitAll(<Comm*>comm, ndev, <const int*>(_devlist_.data()))
+    check_status(status)
+
+
+cpdef comm_finalize(intptr_t comm):
+    with nogil:
+        status = ncclCommFinalize(<Comm>comm)
+    check_status(status)
+
+
+cpdef comm_destroy(intptr_t comm):
+    with nogil:
+        status = ncclCommDestroy(<Comm>comm)
+    check_status(status)
+
+
+cpdef comm_abort(intptr_t comm):
+    with nogil:
+        status = ncclCommAbort(<Comm>comm)
+    check_status(status)
+
+
+cpdef intptr_t comm_split(intptr_t comm, int color, int key, intptr_t config) except? 0:
+    cdef Comm newcomm
+    with nogil:
+        status = ncclCommSplit(<Comm>comm, color, key, &newcomm, <ncclConfig_t*>config)
+    check_status(status)
+    return <intptr_t>newcomm
+
+
+cpdef intptr_t comm_shrink(intptr_t comm, exclude_ranks_list, int exclude_ranks_count, intptr_t config, int shrink_flags) except? 0:
+    cdef nullable_unique_ptr[ vector[int] ] _exclude_ranks_list_
+    get_resource_ptr[int](_exclude_ranks_list_, exclude_ranks_list, <int*>NULL)
+    cdef Comm newcomm
+    with nogil:
+        status = ncclCommShrink(<Comm>comm, <int*>(_exclude_ranks_list_.data()), exclude_ranks_count, &newcomm, <ncclConfig_t*>config, shrink_flags)
+    check_status(status)
+    return <intptr_t>newcomm
+
+
+cpdef intptr_t comm_init_rank_scalable(int nranks, int myrank, int n_id, comm_ids, intptr_t config) except? 0:
+    cdef nested_resource[ ncclUniqueId ] _comm_ids_
+    get_nested_resource_ptr[ncclUniqueId](_comm_ids_, comm_ids, <ncclUniqueId*>NULL)
+    cdef Comm newcomm
+    with nogil:
+        status = ncclCommInitRankScalable(&newcomm, nranks, myrank, n_id, <ncclUniqueId*>(_comm_ids_.ptrs.data()), <ncclConfig_t*>config)
+    check_status(status)
+    return <intptr_t>newcomm
+
+
+cpdef str get_error_string(int result):
+    cdef bytes _output_
+    _output_ = ncclGetErrorString(<_Result>result)
+    return _output_.decode()
+
+
+cpdef str get_last_error(intptr_t comm):
+    cdef bytes _output_
+    _output_ = ncclGetLastError(<Comm>comm)
+    return _output_.decode()
+
+
+cpdef int comm_get_async_error(intptr_t comm) except? -1:
+    cdef _Result async_error
+    with nogil:
+        status = ncclCommGetAsyncError(<Comm>comm, &async_error)
+    check_status(status)
+    return <int>async_error
+
+
+cpdef int comm_count(intptr_t comm) except? -1:
+    cdef int count
+    with nogil:
+        status = ncclCommCount(<const Comm>comm, &count)
+    check_status(status)
+    return count
+
+
+cpdef int comm_cu_device(intptr_t comm) except? -1:
+    cdef int device
+    with nogil:
+        status = ncclCommCuDevice(<const Comm>comm, &device)
+    check_status(status)
+    return device
+
+
+cpdef int comm_user_rank(intptr_t comm) except? -1:
+    cdef int rank
+    with nogil:
+        status = ncclCommUserRank(<const Comm>comm, &rank)
+    check_status(status)
+    return rank
+
+
+cpdef intptr_t comm_register(intptr_t comm, intptr_t buff, size_t size) except? 0:
+    cdef void* handle
+    with nogil:
+        status = ncclCommRegister(<const Comm>comm, <void*>buff, size, &handle)
+    check_status(status)
+    return <intptr_t>handle
+
+
+cpdef comm_deregister(intptr_t comm, intptr_t handle):
+    with nogil:
+        status = ncclCommDeregister(<const Comm>comm, <void*>handle)
+    check_status(status)
+
+
+cpdef intptr_t comm_window_register(intptr_t comm, intptr_t buff, size_t size, int win_flags) except? 0:
+    cdef Window win
+    with nogil:
+        status = ncclCommWindowRegister(<Comm>comm, <void*>buff, size, &win, win_flags)
+    check_status(status)
+    return <intptr_t>win
+
+
+cpdef comm_window_deregister(intptr_t comm, intptr_t win):
+    with nogil:
+        status = ncclCommWindowDeregister(<Comm>comm, <Window>win)
+    check_status(status)
+
+
+cpdef int red_op_create_pre_mul_sum(intptr_t scalar, int datatype, int residence, intptr_t comm) except? -1:
+    cdef _RedOp op
+    with nogil:
+        status = ncclRedOpCreatePreMulSum(&op, <void*>scalar, <_DataType>datatype, <_ScalarResidence>residence, <Comm>comm)
+    check_status(status)
+    return <int>op
+
+
+cpdef red_op_destroy(int op, intptr_t comm):
+    with nogil:
+        status = ncclRedOpDestroy(<_RedOp>op, <Comm>comm)
+    check_status(status)
+
+
+cpdef reduce(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int op, int root, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclReduce(<const void*>sendbuff, <void*>recvbuff, count, <_DataType>datatype, <_RedOp>op, root, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef bcast(intptr_t buff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclBcast(<void*>buff, count, <_DataType>datatype, root, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef broadcast(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclBroadcast(<const void*>sendbuff, <void*>recvbuff, count, <_DataType>datatype, root, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef all_reduce(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int op, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclAllReduce(<const void*>sendbuff, <void*>recvbuff, count, <_DataType>datatype, <_RedOp>op, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef reduce_scatter(intptr_t sendbuff, intptr_t recvbuff, size_t recvcount, int datatype, int op, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclReduceScatter(<const void*>sendbuff, <void*>recvbuff, recvcount, <_DataType>datatype, <_RedOp>op, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef all_gather(intptr_t sendbuff, intptr_t recvbuff, size_t sendcount, int datatype, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclAllGather(<const void*>sendbuff, <void*>recvbuff, sendcount, <_DataType>datatype, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef allto_all(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclAlltoAll(<const void*>sendbuff, <void*>recvbuff, count, <_DataType>datatype, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef gather(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclGather(<const void*>sendbuff, <void*>recvbuff, count, <_DataType>datatype, root, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef scatter(intptr_t sendbuff, intptr_t recvbuff, size_t count, int datatype, int root, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclScatter(<const void*>sendbuff, <void*>recvbuff, count, <_DataType>datatype, root, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef send(intptr_t sendbuff, size_t count, int datatype, int peer, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclSend(<const void*>sendbuff, count, <_DataType>datatype, peer, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef recv(intptr_t recvbuff, size_t count, int datatype, int peer, intptr_t comm, intptr_t stream):
+    with nogil:
+        status = ncclRecv(<void*>recvbuff, count, <_DataType>datatype, peer, <Comm>comm, <Stream>stream)
+    check_status(status)
+
+
+cpdef group_start():
+    with nogil:
+        status = ncclGroupStart()
+    check_status(status)
+
+
+cpdef group_end():
+    with nogil:
+        status = ncclGroupEnd()
+    check_status(status)
+
+
+cpdef group_simulate_end(intptr_t sim_info):
+    with nogil:
+        status = ncclGroupSimulateEnd(<ncclSimInfo_t*>sim_info)
+    check_status(status)

--- a/nccl4py/nccl/core/__init__.py
+++ b/nccl4py/nccl/core/__init__.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL4Py Core API: Pythonic access to NCCL for multi-GPU communication.
+
+This module provides the main public API for NCCL operations.
+"""
+
+# Core types and enums
+from nccl.core.typing import *
+
+# Constants
+from nccl.core.constants import *
+
+# Communicator and configuration
+from nccl.core.communicator import *
+
+# Resource management
+from nccl.core.resources import *
+
+# Group operations
+from nccl.core.group import *
+
+# Utilities
+from nccl.core.utils import *
+
+# Memory management
+from nccl.core.buffer import *
+
+# Interop modules - import as submodules for nccl.core.cupy.array, etc.
+from nccl.core.interop import *
+
+# The following __all__ exports define the stable, public API surface of NCCL4Py.
+# Semantic versioning guarantees apply only to the symbols explicitly listed below.
+# All other modules, functions, and symbols are internal implementation details and are subject to change without notice.
+__all__ = [
+    # Types and specs
+    "NcclDataType",
+    "NcclRedOp",
+    "NcclBufferSpec",
+    "NcclScalarSpec",
+    "NcclDeviceSpec",
+    "NcclStreamSpec",
+    # Exceptions
+    "NcclInvalid",
+    # Data type constants
+    "INT8",
+    "CHAR",
+    "UINT8",
+    "INT32",
+    "INT",
+    "UINT32",
+    "INT64",
+    "UINT64",
+    "FLOAT16",
+    "HALF",
+    "FLOAT32",
+    "FLOAT",
+    "FLOAT64",
+    "DOUBLE",
+    "BFLOAT16",
+    "FLOAT8E4M3",
+    "FLOAT8E5M2",
+    # Reduction op constants
+    "SUM",
+    "PROD",
+    "MAX",
+    "MIN",
+    "AVG",
+    # Constants and enums
+    "NCCL_SPLIT_NOCOLOR",
+    "CTAPolicy",
+    "CommShrinkFlag",
+    "WindowFlag",
+    # Communicator
+    "Communicator",
+    "NCCLConfig",
+    # Resources
+    "RegisteredBufferHandle",
+    "RegisteredWindowHandle",
+    "CustomRedOp",
+    # Group
+    "group",
+    "group_start",
+    "group_end",
+    "group_simulate_end",
+    "GroupSimInfo",
+    # Utilities
+    "Version",
+    "get_version",
+    "UniqueId",
+    "get_unique_id",
+    "get_error_string",
+    # Memory
+    "mem_alloc",
+    "mem_free",
+    # Interop modules
+    "cupy",
+    "torch",
+]

--- a/nccl4py/nccl/core/buffer.py
+++ b/nccl4py/nccl/core/buffer.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+Buffer specification and memory allocation for NCCL operations.
+
+This module provides utilities for allocating NCCL-optimized device memory and
+resolving various buffer specifications (arrays, tensors, tuples) into the raw
+pointers, counts, and dtypes required by NCCL operations.
+"""
+
+from __future__ import annotations
+import math
+
+from cuda.core.experimental import Buffer
+from cuda.core.experimental.utils import StridedMemoryView, args_viewable_as_strided_memory
+
+from nccl.core.cuda import get_device_id, get_stream_ptr
+from nccl.core.memory import get_memory_resource
+from nccl.core.typing import (
+    NcclBufferSpec,
+    NcclDataType,
+    NcclDeviceSpec,
+    NcclInvalid,
+    NcclStreamSpec,
+)
+
+
+__all__ = ["mem_alloc", "mem_free", "NcclBuffer"]
+
+
+def mem_alloc(size: int, device: NcclDeviceSpec | None = None) -> Buffer:
+    """
+    Allocates GPU buffer memory using NCCL's memory allocator.
+
+    The actual allocated size may be larger than requested due to buffer granularity
+    requirements from NCCL optimizations.
+
+    Args:
+        - size (int): Number of bytes to allocate.
+        - device (NcclDeviceSpec, optional): Target CUDA device. Defaults to current device.
+
+    Returns:
+        ``Buffer``: A CUDA buffer object backed by NCCL-managed memory.
+
+    Notes:
+        - The returned buffer size may exceed the requested size due to alignment requirements.
+        - Buffer is allocated on the specified device, if provided; current device is restored after allocation.
+
+    Memory Lifecycle:
+        Memory can be explicitly freed using ``mem_free(buf)`` or automatically freed when
+        the Buffer object is garbage collected.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclmemalloc
+    """
+    device_id = get_device_id(device)
+
+    mr = get_memory_resource(device_id)
+    return mr.allocate(size)
+
+
+def mem_free(buf: Buffer) -> None:
+    """
+    Frees memory allocated by ``mem_alloc()``.
+
+    Args:
+        - buf (Buffer): The buffer to free.
+
+    Notes:
+        Explicit deallocation is optional. Memory is automatically freed when the Buffer
+        object is garbage collected.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclmemfree
+    """
+    buf.close()
+
+
+@args_viewable_as_strided_memory((0,))
+def _resolve_buffer(buffer, stream_ptr: int | None) -> StridedMemoryView:
+    return buffer.view(stream_ptr)
+
+
+class NcclBuffer:
+    """
+    Resolves user-provided buffer specifications to raw pointer, count, dtype, and device.
+
+    This class handles various buffer input formats and extracts the necessary metadata
+    for NCCL operations.
+
+    Buffer specifications can be:
+        - An object supporting DLPack or CUDA Array Interface
+        - A ``Buffer`` object
+        - A tuple: ``(buffer, dtype)``
+
+    Stream Handling:
+        When stream is None, the special sentinel value -1 is used internally.
+        This sentinel value (-1) is required by cuda.core's StridedMemoryView.view()
+        to indicate that no stream synchronization should be performed between the
+        producer stream (where the buffer was created) and the consumer stream
+        (where NCCL operations will use it). This avoids implicit synchronization
+        overhead when the user is managing stream dependencies manually.
+
+        When a stream is provided, its handle (typically 0 for default stream or
+        a valid stream pointer) is used for proper synchronization.
+
+    Notes:
+        - Element count is automatically derived from buffer size and dtype. Use slicing to control element count.
+
+    Attributes:
+        ptr (int): Raw device pointer address.
+        count (int): Number of elements in the buffer.
+        dtype (NcclDataType): Data type of buffer elements.
+        device_id (int): CUDA device ID where buffer resides.
+    """
+
+    def __init__(self, buffer: NcclBufferSpec, stream: NcclStreamSpec | None = None) -> None:
+        """
+        Initializes an NcclBuffer from a buffer specification.
+
+        Args:
+            - buffer (NcclBufferSpec): Buffer specification to resolve.
+            - stream (NcclStreamSpec, optional): CUDA stream for synchronization. Defaults to None.
+
+        Raises:
+            - ``NcclInvalid``: If the buffer specification is invalid or malformed.
+        """
+        self.stream_ptr = -1 if stream is None else get_stream_ptr(stream)
+
+        resolved = None
+
+        try:
+            from nccl.core.interop.torch import resolve_tensor
+
+            resolved = resolve_tensor(buffer)
+        except (ImportError, ModuleNotFoundError, NcclInvalid):
+            pass
+
+        try:
+            from nccl.core.interop.cupy import resolve_array
+
+            resolved = resolve_array(buffer)
+        except (ImportError, ModuleNotFoundError, NcclInvalid):
+            pass
+
+        if resolved is not None:
+            self._ptr = resolved[0]
+            self._count = resolved[1]
+            self._dtype = resolved[2]
+            self._device_id = resolved[3]
+        else:
+            view = _resolve_buffer(buffer, self.stream_ptr)
+            self._ptr = view.ptr
+            self._count = math.prod(view.shape)
+            self._dtype = NcclDataType(view.dtype)
+            self._device_id = view.device_id
+
+    @property
+    def ptr(self) -> int:
+        """
+        Raw device pointer address.
+
+        Returns:
+            ``int``: Device memory pointer.
+        """
+        return self._ptr
+
+    @property
+    def count(self) -> int:
+        """
+        Number of elements in the buffer.
+
+        Returns:
+            ``int``: Element count.
+        """
+        return self._count
+
+    @property
+    def dtype(self) -> NcclDataType:
+        """
+        Data type of buffer elements.
+
+        Returns:
+            ``NcclDataType``: NCCL data type.
+        """
+        return self._dtype
+
+    @property
+    def device_id(self) -> int:
+        """
+        CUDA device ID where buffer resides.
+
+        Returns:
+            ``int``: Device ID.
+        """
+        return self._device_id

--- a/nccl4py/nccl/core/communicator.py
+++ b/nccl4py/nccl/core/communicator.py
@@ -1,0 +1,1602 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL communicator creation, management, and operations.
+
+This module provides the core Communicator class and NCCLConfig for NCCL operations.
+Communicators manage groups of ranks for collective and point-to-point communication,
+with support for buffer registration, custom reduction operators, and resource management.
+"""
+
+from __future__ import annotations
+from typing import Sequence, Any
+
+import numpy as _np
+
+from cuda.core.experimental import Device
+
+from nccl import bindings as _nccl_bindings
+
+from nccl.core.buffer import NcclBuffer
+from nccl.core.constants import (
+    NCCL_SPLIT_NOCOLOR,
+    NCCL_UNDEF_INT,
+    CTAPolicy,
+    CommShrinkFlag,
+    WindowFlag,
+)
+from nccl.core.cuda import get_stream_ptr
+from nccl.core.resources import (
+    CommResource,
+    RegisteredBufferHandle,
+    RegisteredWindowHandle,
+    CustomRedOp,
+)
+from nccl.core.typing import (
+    NcclDataType,
+    NcclBufferSpec,
+    NcclRedOp,
+    NcclStreamSpec,
+    NcclScalarSpec,
+    NcclInvalid,
+)
+from nccl.core.utils import UniqueId
+
+
+__all__ = [
+    "NCCLConfig",
+    "Communicator",
+]
+
+
+class NCCLConfig:
+    """
+    NCCL configuration for communicator initialization.
+
+    This class provides configuration options for NCCL communicators, allowing
+    fine-tuning of performance and behavior characteristics. Based on the official
+    NCCL API documentation.
+    """
+
+    def __init__(
+        self,
+        *,
+        blocking: bool | None = None,
+        cga_cluster_size: int | None = None,
+        min_ctas: int | None = None,
+        max_ctas: int | None = None,
+        net_name: str | None = None,
+        split_share: bool | None = None,
+        traffic_class: int | None = None,
+        comm_name: str | None = None,
+        collnet_enable: bool | None = None,
+        cta_policy: CTAPolicy | None = None,
+        shrink_share: bool | None = None,
+        nvls_ctas: int | None = None,
+        n_channels_per_net_peer: int | None = None,
+        nvlink_centric_sched: bool | None = None,
+    ) -> None:
+        """
+        Initializes NCCL configuration with custom parameters.
+
+        All parameters are optional and default to NCCL's internal defaults (undefined).
+
+        Args:
+            - blocking (bool, optional): Blocking (True) or non-blocking (False) communicator behavior. Defaults to True.
+            - cga_cluster_size (int, optional): Cooperative Group Array (CGA) size for kernels (0-8). Defaults to 4 for sm90+, 0 otherwise.
+            - min_ctas (int, optional): Minimal number of CTAs per kernel. Positive integer up to 32. Defaults to 1.
+            - max_ctas (int, optional): Maximal number of CTAs per kernel. Positive integer up to 32. Defaults to 32.
+            - net_name (str, optional): Network module name (e.g., "IB", "Socket"). Case-insensitive. Defaults to NCCL auto-selection.
+            - split_share (bool, optional): Share resources with child communicator during split. Defaults to False.
+            - traffic_class (int, optional): Traffic class (TC) for network operations (>= 0). Network-specific meaning. Defaults to undefined.
+            - comm_name (str, optional): User-defined communicator name for logging and profiling. Defaults to undefined.
+            - collnet_enable (bool, optional): Enable (True) or disable (False) IB SHARP. Defaults to False.
+            - cta_policy (CTAPolicy, optional): CTA scheduling policy. See CTAPolicy enum (Default, Efficiency, Zero). Defaults to CTAPolicy.Default.
+            - shrink_share (bool, optional): Share resources with child communicator during shrink. Defaults to False.
+            - nvls_ctas (int, optional): Total number of CTAs for NVLS kernels. Positive integer. Defaults to NCCL auto-determined value.
+            - n_channels_per_net_peer (int, optional): Number of network channels for pairwise communication. Positive integer, rounded up to power of 2. Defaults to AlltoAll-optimized value.
+            - nvlink_centric_sched (bool, optional): Enable (True) NVLink-centric scheduling. Defaults to False.
+
+        Notes:
+            Aborting any communicator may affect others in the same family when split_share or shrink_share is enabled.
+        """
+        self._cfg: _nccl_bindings.Config = _nccl_bindings.Config()
+        self._cfg._data.fill(0)
+
+        # Apply NCCL_CONFIG_INITIALIZER defaults
+        self._cfg.size_ = int(_nccl_bindings.config_dtype.itemsize)
+        self._cfg.magic = 0xCAFEBEEF  # NCCL protocol magic number for ncclConfig_t validation
+        self._cfg.version = _nccl_bindings.get_version()
+
+        # Initialize all fields to undef
+        self._cfg.blocking = NCCL_UNDEF_INT
+        self._cfg.cga_cluster_size = NCCL_UNDEF_INT
+        self._cfg.min_ctas = NCCL_UNDEF_INT
+        self._cfg.max_ctas = NCCL_UNDEF_INT
+        self._cfg.split_share = NCCL_UNDEF_INT
+        self._cfg.traffic_class = NCCL_UNDEF_INT
+        self._cfg.collnet_enable = NCCL_UNDEF_INT
+        self._cfg.cta_policy = NCCL_UNDEF_INT
+        self._cfg.shrink_share = NCCL_UNDEF_INT
+        self._cfg.nvls_ctas = NCCL_UNDEF_INT
+        self._cfg.n_channels_per_net_peer = NCCL_UNDEF_INT
+        self._cfg.nvlink_centric_sched = NCCL_UNDEF_INT
+
+        # Use setters for validation - they handle type checking and range validation
+        if blocking is not None:
+            self.blocking = blocking
+        if cga_cluster_size is not None:
+            self.cga_cluster_size = cga_cluster_size
+        if min_ctas is not None:
+            self.min_ctas = min_ctas
+        if max_ctas is not None:
+            self.max_ctas = max_ctas
+        if net_name is not None:
+            self.net_name = net_name
+        if split_share is not None:
+            self.split_share = split_share
+        if traffic_class is not None:
+            self.traffic_class = traffic_class
+        if comm_name is not None:
+            self.comm_name = comm_name
+        if collnet_enable is not None:
+            self.collnet_enable = collnet_enable
+        if cta_policy is not None:
+            self.cta_policy = cta_policy
+        if shrink_share is not None:
+            self.shrink_share = shrink_share
+        if nvls_ctas is not None:
+            self.nvls_ctas = nvls_ctas
+        if n_channels_per_net_peer is not None:
+            self.n_channels_per_net_peer = n_channels_per_net_peer
+        if nvlink_centric_sched is not None:
+            self.nvlink_centric_sched = nvlink_centric_sched
+
+    def __repr__(self) -> str:
+        """
+        Returns string representation showing non-default values.
+
+        Returns:
+            ``str``: String showing configured (non-default) values.
+        """
+        parts = []
+
+        # Check each field and include if not undefined
+        if self._cfg.blocking != NCCL_UNDEF_INT:
+            parts.append(f"blocking={bool(self._cfg.blocking)}")
+        if self._cfg.cga_cluster_size != NCCL_UNDEF_INT:
+            parts.append(f"cga_cluster_size={self._cfg.cga_cluster_size}")
+        if self._cfg.min_ctas != NCCL_UNDEF_INT:
+            parts.append(f"min_ctas={self._cfg.min_ctas}")
+        if self._cfg.max_ctas != NCCL_UNDEF_INT:
+            parts.append(f"max_ctas={self._cfg.max_ctas}")
+        if hasattr(self._cfg, "net_name") and self._cfg.net_name:
+            parts.append(f"net_name='{self._cfg.net_name}'")
+        if self._cfg.split_share != NCCL_UNDEF_INT:
+            parts.append(f"split_share={bool(self._cfg.split_share)}")
+        if self._cfg.traffic_class != NCCL_UNDEF_INT:
+            parts.append(f"traffic_class={self._cfg.traffic_class}")
+        if hasattr(self._cfg, "comm_name") and self._cfg.comm_name:
+            parts.append(f"comm_name='{self._cfg.comm_name}'")
+        if self._cfg.collnet_enable != NCCL_UNDEF_INT:
+            parts.append(f"collnet_enable={bool(self._cfg.collnet_enable)}")
+        if self._cfg.cta_policy != NCCL_UNDEF_INT:
+            parts.append(f"cta_policy={CTAPolicy(self._cfg.cta_policy).name}")
+        if self._cfg.shrink_share != NCCL_UNDEF_INT:
+            parts.append(f"shrink_share={bool(self._cfg.shrink_share)}")
+        if self._cfg.nvls_ctas != NCCL_UNDEF_INT:
+            parts.append(f"nvls_ctas={self._cfg.nvls_ctas}")
+        if self._cfg.n_channels_per_net_peer != NCCL_UNDEF_INT:
+            parts.append(f"n_channels_per_net_peer={self._cfg.n_channels_per_net_peer}")
+        if self._cfg.nvlink_centric_sched != NCCL_UNDEF_INT:
+            parts.append(f"nvlink_centric_sched={bool(self._cfg.nvlink_centric_sched)}")
+
+        if parts:
+            return f"<NCCLConfig: {', '.join(parts)}>"
+        else:
+            return "<NCCLConfig: all defaults>"
+
+    @property
+    def ptr(self) -> int:
+        """
+        Raw NCCL config pointer.
+
+        Returns:
+            ``int``: The configuration pointer.
+        """
+        return int(self._cfg.ptr)
+
+    # Field proxies
+
+    @property
+    def blocking(self) -> bool:
+        """
+        Blocking or non-blocking communicator behavior.
+
+        Returns:
+            ``bool``: True for blocking, False for non-blocking. Default: True.
+        """
+        return bool(self._cfg.blocking)
+
+    @blocking.setter
+    def blocking(self, val: bool) -> None:
+        if not isinstance(val, bool):
+            raise NcclInvalid(f"blocking must be bool, got {type(val).__name__}")
+        self._cfg.blocking = int(val)
+
+    @property
+    def cga_cluster_size(self) -> int:
+        """
+        Cooperative Group Array size (0-8).
+
+        Returns:
+            ``int``: CGA cluster size. Default: 4 for sm90+, 0 for older architectures.
+        """
+        return self._cfg.cga_cluster_size
+
+    @cga_cluster_size.setter
+    def cga_cluster_size(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise NcclInvalid(f"cga_cluster_size must be int, got {type(val).__name__}")
+        if not (0 <= val <= 8):
+            raise NcclInvalid(f"cga_cluster_size must be between 0 and 8, got {val}")
+        self._cfg.cga_cluster_size = val
+
+    @property
+    def min_ctas(self) -> int:
+        """
+        Minimum number of CTAs.
+
+        Returns:
+            ``int``: Positive integer up to 32. Default: 1.
+        """
+        return self._cfg.min_ctas
+
+    @min_ctas.setter
+    def min_ctas(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise NcclInvalid(f"min_ctas must be int, got {type(val).__name__}")
+        if not (0 < val <= 32):
+            raise NcclInvalid(f"min_ctas must be a positive integer up to 32, got {val}")
+        self._cfg.min_ctas = val
+
+    @property
+    def max_ctas(self) -> int:
+        """
+        Maximum number of CTAs.
+
+        Returns:
+            ``int``: Positive integer up to 32. Default: 32.
+        """
+        return self._cfg.max_ctas
+
+    @max_ctas.setter
+    def max_ctas(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise NcclInvalid(f"max_ctas must be int, got {type(val).__name__}")
+        if not (0 < val <= 32):
+            raise NcclInvalid(f"max_ctas must be a positive integer up to 32, got {val}")
+        self._cfg.max_ctas = val
+
+    @property
+    def net_name(self) -> str:
+        """
+        Network module name.
+
+        Returns:
+            ``str``: Network module (e.g., 'IB', 'Socket'). Case-insensitive. Default: auto-selected.
+        """
+        return self._cfg.net_name
+
+    @net_name.setter
+    def net_name(self, val: str) -> None:
+        if not isinstance(val, str):
+            raise NcclInvalid(f"net_name must be str, got {type(val).__name__}")
+        self._cfg.net_name = val
+
+    @property
+    def split_share(self) -> bool:
+        """
+        Share resources with child communicator during split.
+
+        Returns:
+            ``bool``: True to share resources. Default: False.
+        """
+        return bool(self._cfg.split_share)
+
+    @split_share.setter
+    def split_share(self, val: bool) -> None:
+        if not isinstance(val, bool):
+            raise NcclInvalid(f"split_share must be bool, got {type(val).__name__}")
+        self._cfg.split_share = int(val)
+
+    @property
+    def traffic_class(self) -> int:
+        """
+        Traffic class for network operations.
+
+        Returns:
+            ``int``: Traffic class (>= 0). Meaning is network-specific.
+        """
+        return self._cfg.traffic_class
+
+    @traffic_class.setter
+    def traffic_class(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise NcclInvalid(f"traffic_class must be int, got {type(val).__name__}")
+        if val < 0:
+            raise NcclInvalid(f"traffic_class must be >= 0, got {val}")
+        self._cfg.traffic_class = val
+
+    @property
+    def comm_name(self) -> str:
+        """
+        User-defined communicator name for logging and profiling.
+
+        Returns:
+            ``str``: Communicator name.
+        """
+        return self._cfg.comm_name
+
+    @comm_name.setter
+    def comm_name(self, val: str) -> None:
+        if not isinstance(val, str):
+            raise NcclInvalid(f"comm_name must be str, got {type(val).__name__}")
+        self._cfg.comm_name = val
+
+    @property
+    def collnet_enable(self) -> bool:
+        """
+        Enable IB SHARP.
+
+        Returns:
+            ``bool``: True to enable. Default: False.
+        """
+        return bool(self._cfg.collnet_enable)
+
+    @collnet_enable.setter
+    def collnet_enable(self, val: bool) -> None:
+        if not isinstance(val, bool):
+            raise NcclInvalid(f"collnet_enable must be bool, got {type(val).__name__}")
+        self._cfg.collnet_enable = int(val)
+
+    @property
+    def cta_policy(self) -> CTAPolicy:
+        """
+        CTA scheduling policy.
+
+        Returns:
+            ``CTAPolicy``: CTA policy enum. Default: CTAPolicy.Default.
+        """
+        return CTAPolicy(self._cfg.cta_policy)
+
+    @cta_policy.setter
+    def cta_policy(self, val: int | CTAPolicy) -> None:
+        if not isinstance(val, (int, CTAPolicy)):
+            raise NcclInvalid(f"cta_policy must be int or CTAPolicy, got {type(val).__name__}")
+        self._cfg.cta_policy = int(val)
+
+    @property
+    def shrink_share(self) -> bool:
+        """
+        Share resources with child communicator during shrink.
+
+        Returns:
+            ``bool``: True to share resources. Default: False.
+        """
+        return bool(self._cfg.shrink_share)
+
+    @shrink_share.setter
+    def shrink_share(self, val: bool) -> None:
+        if not isinstance(val, bool):
+            raise NcclInvalid(f"shrink_share must be bool, got {type(val).__name__}")
+        self._cfg.shrink_share = int(val)
+
+    @property
+    def nvls_ctas(self) -> int:
+        """
+        Total number of CTAs for NVLS kernels.
+
+        Returns:
+            ``int``: Positive integer. Auto-determined by default.
+        """
+        return self._cfg.nvls_ctas
+
+    @nvls_ctas.setter
+    def nvls_ctas(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise NcclInvalid(f"nvls_ctas must be int, got {type(val).__name__}")
+        if val <= 0:
+            raise NcclInvalid(f"nvls_ctas must be a positive integer, got {val}")
+        self._cfg.nvls_ctas = val
+
+    @property
+    def n_channels_per_net_peer(self) -> int:
+        """
+        Number of network channels for pairwise communication.
+
+        Returns:
+            ``int``: Positive integer, rounded up to power of 2.
+        """
+        return self._cfg.n_channels_per_net_peer
+
+    @n_channels_per_net_peer.setter
+    def n_channels_per_net_peer(self, val: int) -> None:
+        if not isinstance(val, int):
+            raise NcclInvalid(f"n_channels_per_net_peer must be int, got {type(val).__name__}")
+        if val <= 0:
+            raise NcclInvalid(f"n_channels_per_net_peer must be a positive integer, got {val}")
+        self._cfg.n_channels_per_net_peer = val
+
+    @property
+    def nvlink_centric_sched(self) -> bool:
+        """
+        Enable NVLink-centric scheduling.
+
+        Returns:
+            ``bool``: True to enable. Default: False.
+        """
+        return bool(self._cfg.nvlink_centric_sched)
+
+    @nvlink_centric_sched.setter
+    def nvlink_centric_sched(self, val: bool) -> None:
+        if not isinstance(val, bool):
+            raise NcclInvalid(f"nvlink_centric_sched must be bool, got {type(val).__name__}")
+        self._cfg.nvlink_centric_sched = int(val)
+
+
+class Communicator:
+    """
+    NCCL Communicator for collective and point-to-point operations.
+
+    A Communicator represents a group of ranks that can perform collective
+    operations (like all_reduce, broadcast) and point-to-point operations (send/recv).
+    Each rank in the communicator has a unique ID (0 to nranks-1).
+
+    Attributes:
+        ptr (int): Raw NCCL communicator pointer (0 if destroyed)
+        nranks (int): Total number of ranks in this communicator
+        device (Device): CUDA device object associated with this communicator
+        rank (int): This rank's ID within the communicator
+    """
+
+    def __init__(self, ptr: int) -> None:
+        """
+        Initializes communicator with a raw NCCL pointer.
+
+        Args:
+            - ptr (int): Integer representing NCCL communicator pointer (0 for sentinel/invalid).
+
+        Raises:
+            - ``NcclInvalid``: If ptr is not an integer.
+
+        Notes:
+            Unlike the class method ``init()``, this constructor allows ptr=0 for
+            creating sentinel communicators (e.g., when ``split()`` excludes a rank).
+        """
+        if ptr is None or not isinstance(ptr, int):
+            raise NcclInvalid("communicator ptr must be an integer")
+        self._comm: int = int(ptr)
+        self._resources: list[CommResource] = []
+
+        if ptr != 0:
+            self._nranks = int(_nccl_bindings.comm_count(self._comm))
+            self._device = Device(int(_nccl_bindings.comm_cu_device(self._comm)))
+            self._rank = int(_nccl_bindings.comm_user_rank(self._comm))
+
+    def _check_valid(self, operation: str) -> None:
+        """
+        Checks if communicator is valid for the given operation.
+
+        Args:
+            - operation (str): Name of the operation being performed.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized (ptr == 0).
+        """
+        if self._comm == 0:
+            raise NcclInvalid(f"Cannot {operation}: Communicator not initialized")
+
+    def _validate_buffer_device(self, buffer: NcclBuffer, buffer_name: str = "buffer") -> None:
+        """
+        Validates that buffer is on the same device as the communicator.
+
+        Args:
+            - buffer (NcclBuffer): Resolved buffer to validate.
+            - buffer_name (str): Name of the buffer for error messages.
+
+        Raises:
+            - ``NcclInvalid``: If buffer device does not match communicator device.
+        """
+        if buffer.device_id != self.device.device_id:
+            raise NcclInvalid(
+                f"{buffer_name} is on device {buffer.device_id}, but communicator "
+                f"is on device {self.device.device_id}. Buffers must be on the same "
+                f"device as the communicator."
+            )
+
+    def __repr__(self) -> str:
+        """
+        Returns string representation of the communicator.
+
+        Returns:
+            ``str``: String showing rank/count/device info if valid, or invalid status.
+        """
+        if self._comm == 0:
+            return "<Communicator: invalid (ptr=0)>"
+        try:
+            return f"<Communicator: rank={self._rank}/{self._nranks}, device={self._device.device_id}, ptr={self._comm:#x}>"
+        except RuntimeError:
+            # If we can't get properties, just show the pointer
+            return f"<Communicator: ptr={self._comm:#x}>"
+
+    @classmethod
+    def init(
+        cls,
+        nranks: int,
+        rank: int,
+        unique_id: UniqueId | Sequence[UniqueId],
+        config: NCCLConfig | None = None,
+    ) -> Communicator:
+        """
+        Initializes a new NCCL communicator.
+
+        Creates a communicator that connects multiple ranks. All ranks must
+        call this method with the same nranks and unique_id, but with different rank values.
+
+        Args:
+            - nranks (int): Total number of ranks in the communicator.
+            - rank (int): This rank (must be between 0 and nranks-1).
+            - unique_id (UniqueId | Sequence[UniqueId]): Unique identifier(s) shared by all ranks.
+            - config (NCCLConfig, optional): NCCL configuration options. Defaults to None.
+
+        Returns:
+            ``Communicator``: A new communicator instance.
+
+        Raises:
+            - ``NcclInvalid``: If unique_id has an invalid type.
+
+        Notes:
+            - This is a collective operation. All ranks must call this method.
+            - See [ncclCommInitRankScalable](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcomminitrankscalable) for when multiple unique_ids are used.
+        """
+        cfg_ptr = 0 if config is None else config.ptr
+        if isinstance(unique_id, UniqueId):
+            comm_ptr = _nccl_bindings.comm_init_rank_scalable(
+                int(nranks), int(rank), 1, unique_id.ptr, cfg_ptr
+            )
+        elif isinstance(unique_id, Sequence) and all(
+            isinstance(uid, UniqueId) for uid in unique_id
+        ):
+            # Pack a sequence of UniqueId wrappers into a single C-side UniqueId buffer
+            arr = _np.empty(len(unique_id), dtype=_nccl_bindings.unique_id_dtype)
+            for i, uid in enumerate(unique_id):
+                # Defensive copy to protect against internal structure changes
+                arr[i] = uid.as_ndarray[0].copy()
+            packed = _nccl_bindings.UniqueId.from_data(arr)
+            comm_ptr = _nccl_bindings.comm_init_rank_scalable(
+                int(nranks), int(rank), int(len(unique_id)), packed.ptr, cfg_ptr
+            )
+        else:
+            raise NcclInvalid("unique_id must be a UniqueId or a sequence of UniqueIds")
+
+        return cls(comm_ptr)
+
+    # --- Communicator APIs ---
+    def split(self, color: int, key: int, config: NCCLConfig | None = None) -> Communicator:
+        """
+        Splits this communicator into sub-communicators based on color values.
+
+        Ranks which pass the same color value will be part of the same group. If color is
+        NCCL_SPLIT_NOCOLOR, the rank will not be part of any group and receives a communicator with ptr=0.
+        The key value determines rank ordering; smaller key means smaller rank in the new communicator.
+        If keys are equal between ranks, the rank in the original communicator determines ordering.
+
+        Args:
+            - color (int): Non-negative color value for grouping ranks (use NCCL_SPLIT_NOCOLOR to exclude this rank).
+            - key (int): Rank ordering key within each color group (smaller key = smaller rank).
+            - config (NCCLConfig, optional): Configuration for the new communicator. If None, inherits parent's configuration. Defaults to None.
+
+        Returns:
+            ``Communicator``: New sub-communicator, or sentinel communicator (ptr=0) if color is NCCL_SPLIT_NOCOLOR.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized or has outstanding operations.
+
+        Notes:
+            - This is a collective operation. All ranks in the communicator must call this method.
+            - There must not be any outstanding NCCL operations on the communicator to avoid deadlock.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommsplit
+        """
+        self._check_valid("split")
+
+        if color == NCCL_SPLIT_NOCOLOR:
+            # Return a sentinel communicator instead of None for consistent API
+            return Communicator(0)
+
+        cfg_ptr = 0 if config is None else config.ptr
+        comm_ptr = _nccl_bindings.comm_split(self._comm, int(color), int(key), cfg_ptr)
+
+        sub_comm = Communicator(comm_ptr)
+        return sub_comm
+
+    def shrink(
+        self,
+        exclude_ranks: Sequence[int] | None = None,
+        config: NCCLConfig | None = None,
+        flag: CommShrinkFlag = CommShrinkFlag.Default,
+    ) -> Communicator:
+        """
+        Creates a new communicator by removing specified ranks from the existing communicator.
+
+        Ranks listed in exclude_ranks will be excluded from the new communicator, and ranks within
+        the new communicator will be updated to maintain a contiguous set of IDs.
+
+        Args:
+            - exclude_ranks (Sequence[int], optional): Ranks to exclude from the new communicator. Defaults to None (no exclusions).
+            - config (NCCLConfig, optional): Configuration for the new communicator. If None, inherits parent's configuration. Defaults to None.
+            - flag (CommShrinkFlag, optional): Shrink behavior flag. Use CommShrinkFlag.Default for normal operation or CommShrinkFlag.Abort after errors. Defaults to CommShrinkFlag.Default.
+
+        Returns:
+            ``Communicator``: New communicator without the excluded ranks.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized.
+
+        Notes:
+            - This is a collective operation. All non-excluded ranks must call this method.
+            - Excluded ranks must NOT call this function.
+            - With CommShrinkFlag.Default: There must not be outstanding NCCL operations to avoid deadlock.
+            - With CommShrinkFlag.Default + config.shrink_share=True: Parent communicator resources are reused.
+            - With CommShrinkFlag.Abort: Automatically aborts outstanding operations; no resources shared with parent.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommshrink
+        """
+        self._check_valid("shrink")
+        ranks_to_exclude = list(exclude_ranks) if exclude_ranks is not None else []
+        cfg_ptr = 0 if config is None else config.ptr
+        comm_ptr = _nccl_bindings.comm_shrink(
+            self._comm, ranks_to_exclude, len(ranks_to_exclude), cfg_ptr, int(flag)
+        )
+
+        return Communicator(comm_ptr)
+
+    def destroy(self) -> None:
+        """
+        Destroys the communicator and frees local resources allocated to it.
+
+        This function only frees local resources if ``finalize()`` was previously called;
+        otherwise, ``destroy()`` will call ``finalize()`` internally. If ``finalize()``
+        is called explicitly, users must ensure the communicator state becomes ncclSuccess
+        before calling ``destroy()``. The communicator should not be accessed after
+        ``destroy()`` returns.
+
+        Args:
+            None
+
+        Raises:
+            None (errors during cleanup are suppressed for safety)
+
+        Notes:
+            - All resources (registered buffers, windows, custom operators) owned by this
+              communicator are automatically closed before destruction.
+            - This is an intra-node collective call - all ranks on the same node must call it to avoid hanging.
+            - Recommended pattern: Call ``finalize()`` then ``destroy()``.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommdestroy
+        """
+        # Close all resources first (best-effort, ignore errors)
+        self.close_all_resources()
+
+        if self._comm == 0:
+            return
+
+        _nccl_bindings.comm_destroy(self._comm)
+        self._comm = 0
+
+    def abort(self) -> None:
+        """
+        Aborts the communicator and frees resources, terminating all uncompleted operations.
+
+        This should be called when an unrecoverable error occurs. All active ranks are
+        required to call this function in order to abort the NCCL communicator successfully.
+
+        Args:
+            None
+
+        Raises:
+            None (errors during cleanup are suppressed for safety)
+
+        Notes:
+            - All resources (registered buffers, windows, custom operators) owned by this
+              communicator are automatically closed before aborting.
+            - Unlike ``destroy()``, this immediately aborts uncompleted operations.
+            - All active ranks must call this function to abort successfully.
+            - For more details, see the Fault Tolerance section in NCCL documentation.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommabort
+        """
+        # Close all resources first (best-effort, ignore errors)
+        self.close_all_resources()
+
+        if self._comm == 0:
+            return
+
+        _nccl_bindings.comm_abort(self._comm)
+        self._comm = 0
+
+    def finalize(self) -> None:
+        """
+        Finalizes the communicator, flushing all uncompleted operations and network resources.
+
+        When the communicator is nonblocking, this is a nonblocking function. Successful return
+        sets the communicator state to ncclInProgress, indicating finalization is in progress.
+        Once all NCCL operations complete, the communicator transitions to ncclSuccess state.
+        Users can query the state with ``get_async_error()``.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        Notes:
+            - This is typically called before ``destroy()`` to ensure all operations complete.
+            - For nonblocking communicators, check completion status with ``get_async_error()``.
+            - This is a collective operation that must be called by all ranks.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommfinalize
+        """
+        if self._comm == 0:
+            return
+
+        _nccl_bindings.comm_finalize(self._comm)
+
+    # --- Properties ---
+    @property
+    def ptr(self) -> int:
+        """
+        Raw NCCL communicator pointer (0 if destroyed/invalid).
+
+        Returns:
+            ``int``: The communicator raw pointer.
+        """
+        return self._comm
+
+    @property
+    def is_valid(self) -> bool:
+        """
+        Checks if the communicator is valid.
+
+        Returns:
+            ``bool``: True if valid, False if destroyed or invalid.
+        """
+        return self._comm != 0
+
+    @property
+    def nranks(self) -> int:
+        """
+        Total number of ranks in the communicator.
+
+        Returns:
+            ``int``: Number of ranks.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommcount
+        """
+        self._check_valid("get nranks")
+        if not hasattr(self, "_nranks"):
+            raise NcclInvalid("Cannot get nranks: Communicator not properly initialized")
+        return self._nranks
+
+    @property
+    def device(self) -> Device:
+        """
+        CUDA device object associated with this communicator.
+
+        Returns:
+            ``Device``: CUDA device object from cuda.core.experimental.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommcudevice
+        """
+        self._check_valid("get device")
+        if not hasattr(self, "_device"):
+            raise NcclInvalid("Cannot get device: Communicator not properly initialized")
+        return self._device
+
+    @property
+    def rank(self) -> int:
+        """
+        This caller's rank within the communicator.
+
+        Returns:
+            ``int``: This rank's ID (0 to nranks-1).
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommuserrank
+        """
+        self._check_valid("get rank")
+        if not hasattr(self, "_rank"):
+            raise NcclInvalid("Cannot get rank: Communicator not properly initialized")
+        return self._rank
+
+    # --- Point-to-Point Communication ---
+    def send(
+        self, sendbuf: NcclBufferSpec, peer: int, stream: NcclStreamSpec | None = None
+    ) -> None:
+        """
+        Sends a buffer to a peer rank using this communicator.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer to send.
+            - peer (int): Destination rank ID.
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If the buffer specification is invalid, buffer is on wrong device, or communicator is not initialized.
+        """
+        self._check_valid("send")
+        s = NcclBuffer(sendbuf)
+        self._validate_buffer_device(s, "sendbuf")
+
+        _nccl_bindings.send(
+            s.ptr, s.count, int(s.dtype), int(peer), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def recv(
+        self, recvbuf: NcclBufferSpec, peer: int, stream: NcclStreamSpec | None = None
+    ) -> None:
+        """
+        Receives data into a buffer from a peer rank using this communicator.
+
+        Args:
+            - recvbuf (NcclBufferSpec): Destination buffer to receive into.
+            - peer (int): Source rank ID.
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If the buffer specification is invalid, buffer is on wrong device, or communicator is not initialized.
+        """
+        self._check_valid("recv")
+        r = NcclBuffer(recvbuf)
+        self._validate_buffer_device(r, "recvbuf")
+
+        _nccl_bindings.recv(
+            r.ptr, r.count, int(r.dtype), int(peer), int(self._comm), get_stream_ptr(stream)
+        )
+
+    # --- Collective Communication Operations ---
+    def all_reduce(
+        self,
+        sendbuf: NcclBufferSpec,
+        recvbuf: NcclBufferSpec,
+        op: NcclRedOp | CustomRedOp,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Reduces data arrays of length count in sendbuf using the specified operation and leaves identical copies of the result in each recvbuf.
+
+        All ranks receive the same reduced result in their receive buffers after this collective operation completes.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer specification containing data to be reduced.
+            - recvbuf (NcclBufferSpec): Destination buffer specification that will receive the reduced result.
+            - op (NcclRedOp | CustomRedOp): Reduction operator to apply (e.g., SUM, MAX, MIN, AVG, PROD, or custom operator).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, mismatched counts, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - Both send and receive buffers must have matching data types.
+            - Element count is inferred from the sendbuf specification: count = sendcount.
+            - Requires recvcount >= sendcount.
+            - In-place operation occurs when sendbuf and recvbuf resolve to the same device memory address.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclallreduce
+        """
+        self._check_valid("all_reduce")
+
+        s, r = NcclBuffer(sendbuf), NcclBuffer(recvbuf)
+        self._validate_buffer_device(s, "sendbuf")
+        self._validate_buffer_device(r, "recvbuf")
+
+        if s.dtype != r.dtype:
+            raise NcclInvalid(
+                f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+            )
+        if r.count < s.count:
+            raise NcclInvalid(
+                f"Buffer count mismatch: recvbuf must have at least {s.count} elements, got {r.count}"
+            )
+
+        s_ptr = s.ptr
+        r_ptr = r.ptr
+        count = s.count
+        dtype = s.dtype
+
+        _nccl_bindings.all_reduce(
+            s_ptr, r_ptr, count, int(dtype), int(op), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def broadcast(
+        self,
+        sendbuf: NcclBufferSpec | Any,
+        recvbuf: NcclBufferSpec,
+        root: int,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Copies count elements from sendbuf on the root rank to all ranks' recvbuf.
+
+        The sendbuf is only used on the root rank and is ignored for other ranks.
+
+        Args:
+            - sendbuf (NcclBufferSpec | Any): Source buffer specification (only used on root rank, automatically set to recvbuf on other ranks).
+            - recvbuf (NcclBufferSpec): Destination buffer specification that will receive the broadcast data.
+            - root (int): Root rank that broadcasts the data (must be between 0 and nranks-1).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, mismatched counts, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - On root rank, both send and receive buffers must have matching data types.
+            - Element count is inferred from the recvbuf specification: count = recvcount.
+            - On root rank, requires sendcount == recvcount.
+            - In-place operation occurs when sendbuf and recvbuf resolve to the same device memory address.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclbroadcast
+        """
+        self._check_valid("broadcast")
+
+        s, r = None, None
+        if root == self._rank:
+            s = NcclBuffer(sendbuf)
+            self._validate_buffer_device(s, "sendbuf")
+        r = NcclBuffer(recvbuf)
+        self._validate_buffer_device(r, "recvbuf")
+
+        if s is not None:
+            if s.dtype != r.dtype:
+                raise NcclInvalid(
+                    f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+                )
+            if r.count != s.count:
+                raise NcclInvalid(
+                    f"Buffer count mismatch: recvbuf must have exactly {s.count} elements, got {r.count}"
+                )
+
+        s_ptr = s.ptr if s is not None else 0
+        r_ptr = r.ptr
+        count = r.count
+        dtype = r.dtype
+
+        _nccl_bindings.broadcast(
+            s_ptr, r_ptr, count, int(dtype), int(root), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def reduce(
+        self,
+        sendbuf: NcclBufferSpec,
+        recvbuf: NcclBufferSpec | Any,
+        op: NcclRedOp | CustomRedOp,
+        root: int,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Reduces data arrays of length count in sendbuf into recvbuf on the root rank using the specified operation.
+
+        The recvbuf is only used on the root rank and is ignored for other ranks.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer specification containing data to be reduced.
+            - recvbuf (NcclBufferSpec | Any): Destination buffer specification (only used on root rank, automatically set to sendbuf on other ranks).
+            - op (NcclRedOp | CustomRedOp): Reduction operator to apply (e.g., SUM, MAX, MIN, AVG, PROD, or custom operator).
+            - root (int): Root rank that receives the reduced result (must be between 0 and nranks-1).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, mismatched counts, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - On root rank, both send and receive buffers must have matching data types.
+            - Element count is inferred from the sendbuf specification: count = sendcount.
+            - On root rank, requires recvcount >= sendcount.
+            - In-place operation occurs when sendbuf and recvbuf resolve to the same device memory address.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclreduce
+        """
+        self._check_valid("reduce")
+
+        s, r = None, None
+        if root == self._rank:
+            r = NcclBuffer(recvbuf)
+            self._validate_buffer_device(r, "recvbuf")
+        s = NcclBuffer(sendbuf)
+        self._validate_buffer_device(s, "sendbuf")
+
+        if r is not None:
+            if s.dtype != r.dtype:
+                raise NcclInvalid(
+                    f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+                )
+            if r.count < s.count:
+                raise NcclInvalid(
+                    f"Buffer count mismatch: recvbuf must have at least {s.count} elements, got {r.count}"
+                )
+
+        s_ptr = s.ptr
+        r_ptr = r.ptr if r is not None else 0
+        count = s.count
+        dtype = s.dtype
+
+        _nccl_bindings.reduce(
+            s_ptr,
+            r_ptr,
+            count,
+            int(dtype),
+            int(op),
+            int(root),
+            int(self._comm),
+            get_stream_ptr(stream),
+        )
+
+    def all_gather(
+        self,
+        sendbuf: NcclBufferSpec,
+        recvbuf: NcclBufferSpec,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Gathers sendcount values from all ranks and leaves identical copies of the result in each recvbuf, receiving data from rank i at offset i*sendcount.
+
+        All ranks receive the same concatenated result containing data from all ranks.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer specification containing sendcount elements.
+            - recvbuf (NcclBufferSpec): Destination buffer specification (must have size at least nranks*sendcount elements).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, recvbuf is too small, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - Both send and receive buffers must have matching data types.
+            - Element count is inferred from the sendbuf specification: count = sendcount.
+            - Requires recvcount >= nranks * sendcount.
+            - Data from rank i is placed at recvbuf + i*sendcount.
+            - In-place operation occurs when sendbuf resolves to device memory address: recvbuf_address + rank*sendcount.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclallgather
+        """
+        self._check_valid("all_gather")
+
+        s, r = NcclBuffer(sendbuf), NcclBuffer(recvbuf)
+        self._validate_buffer_device(s, "sendbuf")
+        self._validate_buffer_device(r, "recvbuf")
+
+        if s.dtype != r.dtype:
+            raise NcclInvalid(
+                f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+            )
+        expected_recv_count = self._nranks * s.count
+        if r.count < expected_recv_count:
+            raise NcclInvalid(
+                f"Buffer count mismatch: recvbuf must have at least {expected_recv_count} elements (nranks * sendcount), got {r.count}"
+            )
+
+        s_ptr = s.ptr
+        r_ptr = r.ptr
+        count = s.count
+        dtype = s.dtype
+
+        _nccl_bindings.all_gather(
+            s_ptr, r_ptr, count, int(dtype), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def reduce_scatter(
+        self,
+        sendbuf: NcclBufferSpec,
+        recvbuf: NcclBufferSpec,
+        op: NcclRedOp | CustomRedOp,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Reduces data in sendbuf from all ranks using the specified operation and leaves the reduced result scattered over the devices so that recvbuf on rank i contains the i-th block of the result.
+
+        Each rank receives a different portion of the reduced result.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer specification (must have size at least nranks*recvcount elements).
+            - recvbuf (NcclBufferSpec): Destination buffer specification containing recvcount elements.
+            - op (NcclRedOp | CustomRedOp): Reduction operator to apply (e.g., SUM, MAX, MIN, AVG, PROD, or custom operator).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, sendbuf is too small, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - Both send and receive buffers must have matching data types.
+            - Element count is inferred from the sendbuf specification: count = sendcount / nranks.
+            - Requires sendcount >= nranks and recvcount >= count.
+            - Rank i receives the i-th block of the reduced result in its recvbuf.
+            - In-place operation occurs when recvbuf resolves to device memory address: sendbuf_address + rank*count.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclreducescatter
+        """
+        self._check_valid("reduce_scatter")
+
+        s, r = NcclBuffer(sendbuf), NcclBuffer(recvbuf)
+        self._validate_buffer_device(s, "sendbuf")
+        self._validate_buffer_device(r, "recvbuf")
+
+        if s.dtype != r.dtype:
+            raise NcclInvalid(
+                f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+            )
+        per_rank_count = s.count // self._nranks
+        if per_rank_count < 1:
+            raise NcclInvalid(
+                f"Buffer count mismatch: sendbuf must have at least {self._nranks} elements (nranks), got {s.count}"
+            )
+        if r.count < per_rank_count:
+            raise NcclInvalid(
+                f"Buffer count mismatch: recvbuf must have at least {per_rank_count} elements (sendcount / nranks), got {r.count}"
+            )
+
+        s_ptr = s.ptr
+        r_ptr = r.ptr
+        count = per_rank_count
+        dtype = s.dtype
+
+        _nccl_bindings.reduce_scatter(
+            s_ptr, r_ptr, count, int(dtype), int(op), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def all_to_all(
+        self,
+        sendbuf: NcclBufferSpec,
+        recvbuf: NcclBufferSpec,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Each rank sends count values to all other ranks and receives count values from all other ranks.
+
+        Data to send to destination rank j is taken from sendbuf+j*count and data received from source rank i is placed at recvbuf+i*count.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer specification (must have size at least nranks*count elements).
+            - recvbuf (NcclBufferSpec): Destination buffer specification (must have size at least nranks*count elements).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, buffer sizes incompatible with nranks, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - Both send and receive buffers must have matching data types.
+            - Element count is inferred from the sendbuf specification: count = sendcount / nranks.
+            - Requires sendcount >= nranks and recvcount >= sendcount.
+            - Data sent to rank j is at sendbuf + j*count and data received from rank i is at recvbuf + i*count.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclalltoall
+        """
+        self._check_valid("all_to_all")
+
+        s, r = NcclBuffer(sendbuf), NcclBuffer(recvbuf)
+        self._validate_buffer_device(s, "sendbuf")
+        self._validate_buffer_device(r, "recvbuf")
+
+        if s.dtype != r.dtype:
+            raise NcclInvalid(
+                f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+            )
+        per_rank_count = s.count // self._nranks
+        if per_rank_count < 1:
+            raise NcclInvalid(
+                f"Buffer count mismatch: sendbuf must have at least {self._nranks} elements (nranks), got {s.count}"
+            )
+        if r.count < s.count:
+            raise NcclInvalid(
+                f"Buffer count mismatch: recvbuf must have at least {s.count} elements (nranks * count), got {r.count}"
+            )
+
+        s_ptr = s.ptr
+        r_ptr = r.ptr
+        count = per_rank_count
+        dtype = s.dtype
+
+        _nccl_bindings.allto_all(
+            s_ptr, r_ptr, count, int(dtype), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def gather(
+        self,
+        sendbuf: NcclBufferSpec,
+        recvbuf: NcclBufferSpec | Any,
+        root: int,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Each rank sends count elements from sendbuf to the root rank. On the root rank, data from rank i is placed at recvbuf + i*count.
+
+        On non-root ranks, recvbuf is not used.
+
+        Args:
+            - sendbuf (NcclBufferSpec): Source buffer specification containing count elements.
+            - recvbuf (NcclBufferSpec | Any): Destination buffer specification (only used on root rank, must have size at least nranks*count elements; automatically set to sendbuf on other ranks).
+            - root (int): Root rank that receives the gathered data (must be between 0 and nranks-1).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, recvbuf is too small on root rank, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - On root rank, both send and receive buffers must have matching data types.
+            - Element count is inferred from the sendbuf specification: count = sendcount.
+            - On root rank, requires recvcount >= nranks * count.
+            - On root rank, data from rank i is placed at recvbuf + i*count.
+            - In-place operation occurs when sendbuf resolves to device memory address: recvbuf_address + root*count.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclgather
+        """
+        self._check_valid("gather")
+
+        s, r = None, None
+        if root == self._rank:
+            r = NcclBuffer(recvbuf)
+            self._validate_buffer_device(r, "recvbuf")
+        s = NcclBuffer(sendbuf)
+        self._validate_buffer_device(s, "sendbuf")
+
+        if r is not None:
+            if r.dtype != s.dtype:
+                raise NcclInvalid(
+                    f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+                )
+            expected_recv_count = self._nranks * s.count
+            if r.count < expected_recv_count:
+                raise NcclInvalid(
+                    f"Buffer count mismatch: recvbuf must have at least {expected_recv_count} elements (nranks * sendcount), got {r.count}"
+                )
+
+        s_ptr = s.ptr
+        r_ptr = r.ptr if r is not None else 0
+        count = s.count
+        dtype = s.dtype
+
+        _nccl_bindings.gather(
+            s_ptr, r_ptr, count, int(dtype), int(root), int(self._comm), get_stream_ptr(stream)
+        )
+
+    def scatter(
+        self,
+        sendbuf: NcclBufferSpec | Any,
+        recvbuf: NcclBufferSpec,
+        root: int,
+        stream: NcclStreamSpec | None = None,
+    ) -> None:
+        """
+        Each rank receives count elements from the root rank. On the root rank, count elements from sendbuf + i*count are sent to rank i.
+
+        On non-root ranks, sendbuf is not used.
+
+        Args:
+            - sendbuf (NcclBufferSpec | Any): Source buffer specification (only used on root rank, must have size at least nranks*count elements; automatically set to recvbuf on other ranks).
+            - recvbuf (NcclBufferSpec): Destination buffer specification containing count elements.
+            - root (int): Root rank that scatters the data (must be between 0 and nranks-1).
+            - stream (NcclStreamSpec, optional): CUDA stream for the operation. Defaults to None (uses default stream).
+
+        Raises:
+            - ``NcclInvalid``: If send and receive buffers have mismatched dtypes, sendbuf is too small on root rank, buffers on wrong device, invalid buffer specifications, or communicator is not initialized.
+
+        Notes:
+            - On root rank, both send and receive buffers must have matching data types.
+            - Element count is inferred from the recvbuf specification: count = recvcount.
+            - On root rank, requires sendcount >= nranks and sendcount / nranks == recvcount.
+            - On root rank, data at sendbuf + i*count is sent to rank i.
+            - In-place operation occurs when recvbuf resolves to device memory address: sendbuf_address + root*count.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/colls.html#ncclscatter
+        """
+        self._check_valid("scatter")
+
+        s, r = None, None
+        if root == self._rank:
+            s = NcclBuffer(sendbuf)
+            self._validate_buffer_device(s, "sendbuf")
+        r = NcclBuffer(recvbuf)
+        self._validate_buffer_device(r, "recvbuf")
+
+        if s is not None:
+            if s.dtype != r.dtype:
+                raise NcclInvalid(
+                    f"Dtype mismatch: sendbuf has dtype {s.dtype}, recvbuf has dtype {r.dtype}"
+                )
+            per_rank_count = s.count // self._nranks
+            if per_rank_count < 1:
+                raise NcclInvalid(
+                    f"Buffer count mismatch: sendbuf must have at least {self._nranks} elements (nranks), got {s.count}"
+                )
+            if r.count != per_rank_count:
+                raise NcclInvalid(
+                    f"Buffer count mismatch: recvbuf must have exactly {per_rank_count} elements (sendcount / nranks), got {r.count}"
+                )
+
+        s_ptr = s.ptr if s is not None else 0
+        r_ptr = r.ptr
+        count = r.count
+        dtype = r.dtype
+
+        _nccl_bindings.scatter(
+            s_ptr, r_ptr, count, int(dtype), int(root), int(self._comm), get_stream_ptr(stream)
+        )
+
+    # --- Registration ---
+    def register_buffer(self, buffer: NcclBufferSpec) -> RegisteredBufferHandle:
+        """
+        Registers a buffer with this communicator for zero-copy communication.
+
+        Registered buffers can enable performance optimizations in NCCL operations.
+        The returned RegisteredBufferHandle must be explicitly closed when no longer needed.
+
+        Args:
+            - buffer (NcclBufferSpec): Buffer to register (array, Buffer, or buffer-like object).
+
+        Returns:
+            ``RegisteredBufferHandle``: Resource handle that can be closed manually or automatically when the communicator is destroyed / aborted.
+
+        Raises:
+            - ``NcclInvalid``: If buffer is on wrong device or communicator is not initialized.
+
+        Notes:
+            - Buffer size is automatically derived from buffer count and dtype.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommregister
+        """
+        self._check_valid("register_buffer")
+
+        nccl_buf = NcclBuffer(buffer)
+        self._validate_buffer_device(nccl_buf, "buffer")
+        buffer_ptr = nccl_buf.ptr
+        size = nccl_buf.count * nccl_buf.dtype.itemsize
+
+        resource = RegisteredBufferHandle(self._comm, buffer_ptr, size)
+        self._resources.append(resource)
+        return resource
+
+    def register_window(
+        self, buffer: NcclBufferSpec, flags: WindowFlag | None = None
+    ) -> RegisteredWindowHandle:
+        """
+        Collectively registers a local buffer into an NCCL window for optimized communication.
+
+        Since this is a collective call, every rank in the communicator must participate,
+        and buffer size must be equal among ranks by default. Windows enable optimized
+        communication patterns in NCCL.
+
+        Args:
+            - buffer (NcclBufferSpec): Local buffer to register as window.
+            - flags (WindowFlag, optional): Window registration flags to control behavior. Defaults to None.
+
+        Returns:
+            ``RegisteredWindowHandle``: Resource handle that can be closed manually or automatically when the communicator is destroyed / aborted.
+
+        Raises:
+            - ``NcclInvalid``: If buffer is on wrong device or communicator is not initialized.
+
+        Notes:
+            - This is a collective operation. All ranks in the communicator must call this method.
+            - Buffer sizes must be equal among ranks by default.
+            - Buffer size is automatically derived from buffer count and dtype.
+            - If called within a group, the handle value may not be filled until ncclGroupEnd() completes.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommwindowregister
+        """
+        self._check_valid("register_window")
+
+        nccl_buf = NcclBuffer(buffer)
+        self._validate_buffer_device(nccl_buf, "buffer")
+        buffer_ptr = nccl_buf.ptr
+        size = nccl_buf.count * nccl_buf.dtype.itemsize
+
+        resource = RegisteredWindowHandle(self._comm, buffer_ptr, size, flags)
+        self._resources.append(resource)
+        return resource
+
+    # --- Custom Reduction APIs ---
+    def create_pre_mul_sum(
+        self,
+        scalar: NcclScalarSpec,
+        datatype: NcclDataType | None = None,
+    ) -> CustomRedOp:
+        """
+        Creates a PreMulSum custom reduction operator.
+
+        The PreMulSum operator performs: output = scalar * sum(inputs).
+        This is useful for averaging (scalar = 1/N) or weighted reductions.
+        The returned CustomRedOp must be explicitly closed when no longer needed.
+
+        Args:
+            scalar: Scalar multiplier value. Can be:
+                - Python int/float: Converted to NumPy array, uses host memory
+                - NumPy array: Must contain exactly 1 element, uses host memory
+                - NcclSupportedBuffer: Device buffer
+            datatype: NCCL data type of the scalar and reduction. If None, inferred from scalar.
+                - For Python int/float: inferred from NumPy's natural dtype (int64/float64)
+                - For NumPy array: inferred from array dtype
+                - For device buffer: inferred from buffer dtype
+
+        Returns:
+            CustomRedOp resource that can be closed manually or automatically when the communicator is destroyed / aborted.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized, scalar type is not supported, NumPy array or buffer doesn't contain exactly 1 element, or datatype cannot be inferred or is incompatible.
+        """
+        self._check_valid("create_pre_mul_sum")
+
+        # Determine residence and prepare scalar pointer
+        scalar_array = None  # Will hold host scalar to prevent GC
+        residence: _nccl_bindings.ScalarResidence
+
+        if isinstance(scalar, (int, float)):
+            # Python scalar: Convert to NumPy array in host memory
+            residence = _nccl_bindings.ScalarResidence.HostImmediate
+
+            if datatype is None:
+                scalar_array = _np.array([scalar])
+                datatype = NcclDataType(scalar_array.dtype)
+            else:
+                scalar_array = _np.array([scalar], dtype=datatype.numpy_dtype)
+            scalar_ptr = scalar_array.ctypes.data
+        elif isinstance(scalar, _np.ndarray):
+            # NumPy array: Host memory
+            residence = _nccl_bindings.ScalarResidence.HostImmediate
+
+            # Validate array has exactly 1 element
+            if scalar.size != 1:
+                raise NcclInvalid(
+                    f"NumPy array must contain exactly 1 element for scalar, got {scalar.size} elements"
+                )
+
+            # Ensure contiguous array
+            scalar_array = _np.ascontiguousarray(scalar.ravel())
+            scalar_ptr = scalar_array.ctypes.data
+
+            if datatype is None:
+                datatype = NcclDataType(scalar_array.dtype)
+        else:
+            # Assume it's NcclSupportedBuffer (device buffer)
+            # Use NcclBuffer to handle Buffer, DLPack, CAI, etc.
+            residence = _nccl_bindings.ScalarResidence.Device
+
+            try:
+                buf = NcclBuffer(scalar)
+            except (TypeError, ValueError) as e:
+                raise NcclInvalid(
+                    f"scalar must be int, float, numpy.ndarray, or NcclSupportedBuffer, "
+                    f"got {type(scalar).__name__}: {e}"
+                ) from e
+
+            # Validate buffer contains exactly 1 element
+            if buf.count != 1:
+                raise NcclInvalid(
+                    f"Device buffer must contain exactly 1 element for scalar, got {buf.count} elements"
+                )
+
+            # Infer datatype from buffer if not provided
+            if datatype is None:
+                datatype = buf.dtype
+            else:
+                # Validate buffer datatype matches requested datatype
+                if buf.dtype != datatype:
+                    raise NcclInvalid(
+                        f"Device buffer datatype {buf.dtype} doesn't match requested datatype {datatype}"
+                    )
+
+            scalar_ptr = buf.ptr
+
+        # Create the custom reduction operator
+        resource = CustomRedOp(self._comm, scalar_ptr, datatype, residence)
+
+        # Keep scalar_array alive by storing in resource to prevent premature GC
+        # (only needed for host scalars; device buffers are managed by user)
+        if scalar_array is not None:
+            resource._scalar_array = scalar_array
+
+        self._resources.append(resource)
+        return resource
+
+    def close_all_resources(self) -> None:
+        """
+        Closes all resources owned by this communicator.
+
+        This method is called automatically during ``destroy()`` and ``abort()`` but can
+        be called manually if needed. It performs best-effort cleanup, ignoring
+        any errors that occur during resource deallocation.
+
+        Notes:
+            This method is idempotent - calling it multiple times is safe.
+        """
+        for resource in self._resources:
+            try:
+                resource.close()
+            except Exception:
+                # Best-effort cleanup - ignore errors to avoid masking
+                # user exceptions or preventing communicator destruction
+                pass
+        self._resources.clear()
+
+    # --- Miscellaneous ---
+    def get_last_error(self) -> str:
+        """
+        Gets the last error string for this communicator.
+
+        Returns:
+            ``str``: Error message string.
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized.
+        """
+        self._check_valid("get last error")
+        return _nccl_bindings.get_last_error(self._comm)
+
+    def get_async_error(self) -> _nccl_bindings.Result:
+        """
+        Queries the progress and potential errors of asynchronous NCCL operations.
+
+        Operations without a stream argument (e.g., finalize) are complete when they return ncclSuccess.
+        Operations with a stream argument (e.g., all_reduce) return ncclSuccess when posted but may
+        report errors through this method until completed. If any NCCL function returns ncclInProgress,
+        users must query communicator state until it becomes ncclSuccess before calling another NCCL function.
+
+        Returns:
+            ``Result``: Current state of the communicator (ncclSuccess, ncclInProgress, or error code).
+
+        Raises:
+            - ``NcclInvalid``: If communicator is not initialized.
+
+        Notes:
+            - Before state becomes ncclSuccess, do not issue CUDA kernels on streams used by NCCL.
+            - If an error occurs, destroy the communicator with ``abort()``.
+            - Nothing can be assumed about completion or correctness of enqueued operations after an error.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommgetasyncerror
+        """
+        self._check_valid("get async error")
+        return _nccl_bindings.comm_get_async_error(self._comm)

--- a/nccl4py/nccl/core/constants.py
+++ b/nccl4py/nccl/core/constants.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL constants and enums.
+
+This module centralizes all NCCL constants for easy access and organization.
+"""
+
+from enum import IntEnum
+
+__all__ = [
+    "NCCL_UNDEF_INT",
+    "NCCL_UNDEF_FLOAT",
+    "NCCL_SPLIT_NOCOLOR",
+    "CTAPolicy",
+    "CommShrinkFlag",
+    "WindowFlag",
+]
+
+# NCCL sentinel values for undefined config fields
+NCCL_UNDEF_INT: int = -2147483648  # INT_MIN
+"""NCCL sentinel value for undefined integer configuration fields."""
+
+NCCL_UNDEF_FLOAT: float = -1.0
+"""NCCL sentinel value for undefined float fields."""
+
+# Communicator split constants
+NCCL_SPLIT_NOCOLOR: int = -1
+"""Color value for ncclCommSplit to indicate rank will not be part of any group."""
+
+
+# CTA (Cooperative Thread Array) Policy flags
+class CTAPolicy(IntEnum):
+    """
+    NCCL performance policy for CTA scheduling.
+    """
+
+    Default = 0x00
+    """Default CTA policy."""
+    Efficiency = 0x01
+    """Optimize for efficiency."""
+    Zero = 0x02
+    """Zero-CTA optimization."""
+
+
+# Communicator shrink flags
+class CommShrinkFlag(IntEnum):
+    """
+    Flags for ncclCommShrink behavior.
+    """
+
+    Default = 0x00
+    """Shrink the parent communicator."""
+    Abort = 0x01
+    """First terminate ongoing parent operations, then shrink the parent communicator."""
+
+
+# Window registration flags
+class WindowFlag(IntEnum):
+    """
+    Flags for window registration.
+    """
+
+    Default = 0x00
+    """Default window registration."""
+    CollSymmetric = 0x01
+    """Collective symmetric window registration."""

--- a/nccl4py/nccl/core/cuda.py
+++ b/nccl4py/nccl/core/cuda.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+CUDA device and stream utilities for NCCL operations.
+
+This module provides context managers and helper functions for working with
+CUDA devices and streams in NCCL operations, including device context management
+and stream resolution.
+"""
+
+from __future__ import annotations
+
+from cuda.core.experimental import Device, Stream
+
+from nccl.core.typing import NcclDeviceSpec, NcclStreamSpec
+
+
+class CudaDeviceContext:
+    def __init__(self, device: Device) -> None:
+        self._device = device
+        self._old_device = Device()
+
+    def __enter__(self):
+        if self._device.device_id != self._old_device.device_id:
+            self._device.set_current()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._device.device_id != self._old_device.device_id:
+            self._old_device.set_current()
+        return False  # Re-raise any exception
+
+
+def get_cuda_device(device: NcclDeviceSpec | None = None) -> Device:
+    if device is None:
+        return Device()
+    elif isinstance(device, Device):
+        return device
+    else:
+        return Device(device)
+
+
+def get_device_id(device: NcclDeviceSpec | None = None) -> int:
+    if isinstance(device, int):
+        return device
+    else:
+        return get_cuda_device(device).device_id
+
+
+def get_cuda_stream(
+    stream: NcclStreamSpec | None = None, device: NcclDeviceSpec | None = None
+) -> Stream:
+    if stream is None:
+        device = get_cuda_device(device)
+        return device.default_stream
+    elif isinstance(stream, Stream):
+        return stream
+    elif isinstance(stream, int):
+        return Stream.from_handle(handle=stream)
+    else:
+        device = get_cuda_device(device)
+        return device.create_stream(stream)
+
+
+def get_stream_ptr(stream: NcclStreamSpec | None = None) -> int:
+    if stream is None:
+        return 0
+    elif isinstance(stream, int):
+        return stream
+    elif isinstance(stream, Stream):
+        return int(stream.handle)
+    else:
+        return int(stream.__cuda_stream__()[1])

--- a/nccl4py/nccl/core/group.py
+++ b/nccl4py/nccl/core/group.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL group operations for batching collective communications.
+
+This module provides APIs for grouping multiple NCCL operations together to enable
+efficient batching and overlapping of communication operations. Group calls allow
+multiple collective operations to be launched together with better performance and
+the ability to simulate operations for performance analysis.
+
+See more details at: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/groups.html
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Generator
+
+from nccl import bindings as _nccl_bindings
+
+from nccl.core.constants import NCCL_UNDEF_FLOAT
+
+__all__ = ["GroupSimInfo", "group_start", "group_end", "group_simulate_end", "group"]
+
+
+class GroupSimInfo:
+    """
+    Information for NCCL group operation simulation.
+
+    This class holds simulation information that can be used to estimate
+    the performance of group operations without actually executing them.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes group simulation info with default values.
+        """
+        self._sim_info = _nccl_bindings.SimInfo()
+
+        # Apply NCCL_SIM_INFO_INITIALIZER defaults
+        self._sim_info.size_ = int(_nccl_bindings.sim_info_dtype.itemsize)
+        self._sim_info.magic = 0x74685283  # NCCL protocol magic number for ncclSimInfo_t validation
+        self._sim_info.version = _nccl_bindings.get_version()
+        self._sim_info.estimated_time = NCCL_UNDEF_FLOAT
+
+    @property
+    def ptr(self) -> int:
+        """
+        Raw NCCL simulation info pointer.
+
+        Returns:
+            ``int``: The simulation info pointer.
+        """
+        return int(self._sim_info.ptr)
+
+    # Field proxies
+    @property
+    def estimated_time(self) -> float:
+        """
+        Estimated execution time for the group operations (in seconds).
+
+        Returns:
+            ``float``: Estimated time in seconds.
+        """
+        return self._sim_info.estimated_time
+
+
+def group_start() -> None:
+    """
+    Starts a group of NCCL operations.
+
+    All NCCL operations called after this will be batched together
+    and executed when group_end() is called. This can improve
+    performance by allowing NCCL to optimize the operation sequence.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/group.html#ncclgroupstart
+    """
+    return _nccl_bindings.group_start()
+
+
+def group_end() -> None:
+    """
+    Ends a group of NCCL operations.
+
+    Executes all operations that were queued since the last group_start().
+    This must be called to actually perform the batched operations.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/group.html#ncclgroupend
+    """
+    return _nccl_bindings.group_end()
+
+
+def group_simulate_end(sim_info: GroupSimInfo | None) -> None:
+    """
+    Simulates the end of a group of NCCL operations.
+
+    This estimates the execution time of the queued operations without
+    actually executing them. The estimated time is stored in sim_info.
+
+    Args:
+        - sim_info (GroupSimInfo, optional): Simulation info object to store estimated time, or None.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/group.html#ncclgroupsimulateend
+    """
+    if sim_info is None:
+        return _nccl_bindings.group_simulate_end(None)
+    return _nccl_bindings.group_simulate_end(int(sim_info.ptr))
+
+
+@contextlib.contextmanager
+def group() -> Generator[None, None, None]:
+    """
+    Context manager for NCCL group operations.
+
+    Automatically calls group_start() on entry and group_end() on exit.
+    This ensures proper cleanup even if an exception occurs.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/groups.html
+    """
+    group_start()
+    try:
+        yield
+    finally:
+        group_end()

--- a/nccl4py/nccl/core/interop/__init__.py
+++ b/nccl4py/nccl/core/interop/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL4Py interop modules: PyTorch and CuPy integration.
+
+This module provides utilities for integrating NCCL4Py with PyTorch and CuPy:
+- Memory allocation backed by NCCL allocator
+- Buffer resolution utilities
+"""
+
+import nccl.core.interop.cupy as cupy
+import nccl.core.interop.torch as torch
+
+__all__ = ["cupy", "torch"]

--- a/nccl4py/nccl/core/interop/cupy.py
+++ b/nccl4py/nccl/core/interop/cupy.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+CuPy interoperability for NCCL4Py.
+
+This module provides utilities for creating CuPy arrays backed by NCCL-allocated
+memory, enabling zero-copy integration between NCCL operations and CuPy workflows.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Literal
+
+from nccl.core.buffer import mem_alloc
+from nccl.core.typing import (
+    NcclInvalid,
+    NcclDataType,
+    INT8,
+    UINT8,
+    INT32,
+    UINT32,
+    INT64,
+    UINT64,
+    FLOAT16,
+    FLOAT32,
+    FLOAT64,
+    BFLOAT16,
+    FLOAT8E4M3,
+    FLOAT8E5M2,
+)
+
+__all__ = ["empty", "resolve_array"]
+
+
+try:
+    import cupy
+
+    _cupy_enabled = True
+except ImportError:
+    _cupy_enabled = False
+
+
+def _to_nccl_dtype(cupy_dtype) -> NcclDataType:
+    """
+    Converts CuPy dtype to NcclDataType.
+
+    Note:
+        CuPy dtypes are numpy.dtype objects. This function maps them to
+        global NCCL data type constants.
+
+        ml-dtypes is needed for bfloat16, float8_e4m3fn, float8_e5m2.
+
+    Args:
+        - cupy_dtype (cupy.dtype): CuPy data type.
+
+    Returns:
+        ``NcclDataType``: Corresponding NCCL data type (global constant).
+
+    Raises:
+        - ``ModuleNotFoundError``: If CuPy is not installed.
+        - ``NcclInvalid``: If cupy_dtype has no NCCL equivalent.
+    """
+    if not _cupy_enabled:
+        raise ModuleNotFoundError("CuPy is not installed")
+
+    # CuPy dtypes are numpy dtypes - convert to numpy dtype first
+    try:
+        np_dtype = np.dtype(cupy_dtype)
+    except (TypeError, ValueError) as e:
+        raise NcclInvalid(
+            f"Invalid data type: could not convert {cupy_dtype} (type: {type(cupy_dtype).__name__}) "
+            f"to numpy dtype: {e}"
+        )
+
+    # Map numpy dtype to global NcclDataType constants
+    # First try name-based for ml-dtypes (higher priority)
+    if np_dtype.name == "bfloat16":
+        return BFLOAT16
+    elif np_dtype.name == "float8_e4m3fn":
+        return FLOAT8E4M3
+    elif np_dtype.name == "float8_e5m2":
+        return FLOAT8E5M2
+
+    # Explicitly unsupported types - detect and give clear error
+    _unsupported_kinds = {
+        "c": "complex",
+        "V": "void/structured",
+        "O": "object",
+        "S": "byte string",
+        "U": "unicode string",
+        "M": "datetime",
+        "m": "timedelta",
+    }
+
+    if np_dtype.kind in _unsupported_kinds:
+        kind_name = _unsupported_kinds[np_dtype.kind]
+        raise NcclInvalid(
+            f"Unsupported data type: numpy dtype {np_dtype} ({kind_name} type) has no NCCL equivalent. "
+            f"NCCL only supports numeric types."
+        )
+
+    # Map standard numpy types by kind+size
+    _numpy_to_nccl = {
+        ("f", 2): FLOAT16,
+        ("f", 4): FLOAT32,
+        ("f", 8): FLOAT64,
+        ("i", 1): INT8,
+        ("i", 2): None,  # int16 - explicitly not supported by NCCL
+        ("i", 4): INT32,
+        ("i", 8): INT64,
+        ("u", 1): UINT8,
+        ("u", 2): None,  # uint16 - explicitly not supported by NCCL
+        ("u", 4): UINT32,
+        ("u", 8): UINT64,
+        ("b", 1): UINT8,  # bool -> uint8
+    }
+
+    kind_size = (np_dtype.kind, np_dtype.itemsize)
+    if kind_size in _numpy_to_nccl:
+        result = _numpy_to_nccl[kind_size]
+        if result is None:
+            raise NcclInvalid(
+                f"Unsupported data type: numpy dtype {np_dtype} (kind={np_dtype.kind}, "
+                f"itemsize={np_dtype.itemsize}). NCCL does not support {np_dtype.kind}{np_dtype.itemsize * 8}-bit types."
+            )
+        return result
+    else:
+        raise NcclInvalid(
+            f"Unsupported data type: numpy dtype {np_dtype} (kind={np_dtype.kind}, "
+            f"itemsize={np_dtype.itemsize}, name={np_dtype.name}) has no NCCL equivalent. "
+            f"NCCL supports: int8/32/64, uint8/32/64, float16/32/64, bfloat16, float8_e4m3fn, float8_e5m2."
+        )
+
+
+def _allocate_nccl_array(shape: tuple[int, ...], dtype: np.dtype, order: str) -> cupy.ndarray:
+    """
+    Allocates NCCL-backed CuPy array with specified parameters.
+
+    Args:
+        - shape (tuple[int, ...]): Shape of array.
+        - dtype (np.dtype): Data type.
+        - order (str): Memory order ("C" or "F").
+
+    Returns:
+        ``cupy.ndarray``: Allocated array with NCCL-backed memory.
+
+    Raises:
+        - ``ModuleNotFoundError``: If CuPy is not installed.
+
+    Notes:
+        Uses current CuPy device for allocation.
+    """
+    if not _cupy_enabled:
+        raise ModuleNotFoundError("CuPy is not installed")
+
+    size = int(np.prod(shape) * dtype.itemsize)
+
+    # Allocate buffer on current device (CuPy manages device context)
+    buf = mem_alloc(size)
+
+    # Important! Disable copy to force allocation to stay in NCCL memory
+    cupy_array = cupy.from_dlpack(buf, copy=False)
+    return cupy_array.view(dtype).reshape(shape, order=order)
+
+
+def empty(
+    shape: int | tuple[int, ...],
+    dtype: str | np.dtype | cupy.dtype | type = float,
+    order: Literal["C", "F"] = "C",
+) -> cupy.ndarray:
+    """
+    Creates an uninitialized CuPy array backed by NCCL-allocated memory.
+
+    Returns an array filled with uninitialized data using NCCL's memory allocator.
+    This provides a CuPy-compatible interface while using NCCL's memory allocator
+    for efficient GPU memory management in distributed scenarios.
+
+    Args:
+        - shape (int | tuple[int, ...]): Dimensionalities of the array.
+        - dtype (str | np.dtype | cupy.dtype | type, optional): Data type specifier. Defaults to float.
+        - order (Literal['C', 'F'], optional): Row-major (C-style) or column-major (Fortran-style) order. Only 'C' and 'F' are supported. Defaults to 'C'.
+
+    Returns:
+        ``cupy.ndarray``: An uninitialized CuPy array backed by NCCL-allocated memory.
+
+    Raises:
+        - ``NcclInvalid``: If order is not 'C' or 'F'.
+        - ``ModuleNotFoundError``: If CuPy is not installed.
+
+    Notes:
+        - Unlike ``cupy.empty()``, this allocates memory using NCCL's memory allocator.
+        - For zero-copy optimization, register using ``Communicator.register_buffer()`` or ``Communicator.register_window()``.
+        - Memory is automatically freed when the array is garbage collected. No explicit free call is required.
+    """
+    if not _cupy_enabled:
+        raise ModuleNotFoundError("CuPy is not installed")
+
+    # Validate order parameter
+    if order not in ("C", "F"):
+        raise NcclInvalid(
+            f"Invalid memory order: must be 'C' or 'F', got '{order}'. "
+            f"NCCL arrays support row-major (C) and column-major (F) layouts only."
+        )
+
+    # Parse shape
+    if isinstance(shape, int):
+        shape = (shape,)
+    else:
+        shape = tuple(shape)
+
+    # Parse dtype
+    np_dtype = np.dtype(dtype)
+
+    # Allocate NCCL-backed array on current device
+    view = _allocate_nccl_array(shape, np_dtype, order)
+
+    return view
+
+
+def resolve_array(array: cupy.ndarray) -> tuple[int, int, NcclDataType, int]:
+    """
+    Resolves a CuPy array to a tuple of (ptr, count, dtype, device_id).
+
+    Args:
+        - array (cupy.ndarray): CuPy array to resolve.
+
+    Returns:
+        ``tuple[int, int, NcclDataType, int]``: Tuple of (ptr, count, dtype, device_id).
+    """
+    if not _cupy_enabled:
+        raise ModuleNotFoundError("CuPy is not installed")
+
+    if not isinstance(array, cupy.ndarray):
+        raise NcclInvalid(f"array must be a CuPy array, got {type(array).__name__}")
+
+    return (array.data.ptr, array.size, _to_nccl_dtype(array.dtype), array.device.id)

--- a/nccl4py/nccl/core/interop/torch.py
+++ b/nccl4py/nccl/core/interop/torch.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+PyTorch interoperability for NCCL4Py.
+
+This module provides utilities for creating PyTorch tensors backed by NCCL-allocated
+memory, enabling zero-copy integration between NCCL operations and PyTorch workflows.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Literal
+
+from nccl.core.buffer import mem_alloc
+from nccl.core.typing import (
+    NcclInvalid,
+    NcclDataType,
+    FLOAT16,
+    FLOAT32,
+    FLOAT64,
+    INT8,
+    INT32,
+    INT64,
+    UINT8,
+    BFLOAT16,
+    FLOAT8E4M3,
+    FLOAT8E5M2,
+)
+
+__all__ = ["empty", "resolve_tensor"]
+
+
+try:
+    import torch
+
+    _torch_enabled = True
+except ImportError:
+    _torch_enabled = False
+
+
+def _to_nccl_dtype(torch_dtype) -> NcclDataType:
+    """
+    Converts PyTorch dtype to NcclDataType.
+
+    Args:
+        - torch_dtype (torch.dtype): PyTorch data type.
+
+    Returns:
+        ``NcclDataType``: Corresponding NCCL data type (global constant).
+
+    Raises:
+        - ``ModuleNotFoundError``: If PyTorch is not installed.
+        - ``NcclInvalid``: If torch_dtype has no NCCL equivalent.
+    """
+    if not _torch_enabled:
+        raise ModuleNotFoundError("PyTorch is not installed")
+
+    _torch_to_nccl = {
+        # Float types (all NCCL-supported)
+        torch.float16: FLOAT16,
+        torch.half: FLOAT16,  # Alias
+        torch.float32: FLOAT32,
+        torch.float: FLOAT32,  # Alias
+        torch.float64: FLOAT64,
+        torch.double: FLOAT64,  # Alias
+        torch.bfloat16: BFLOAT16,
+        # Signed integer types
+        torch.int8: INT8,
+        torch.int32: INT32,
+        torch.int64: INT64,
+        torch.long: INT64,  # Alias
+        # Unsigned types
+        torch.uint8: UINT8,
+        torch.bool: UINT8,  # Map bool to uint8 for convenience
+    }
+
+    # Add float8 types if available (PyTorch 2.1+)
+    if hasattr(torch, "float8_e4m3fn"):
+        _torch_to_nccl[torch.float8_e4m3fn] = FLOAT8E4M3
+    if hasattr(torch, "float8_e5m2"):
+        _torch_to_nccl[torch.float8_e5m2] = FLOAT8E5M2
+
+    # Explicitly unsupported PyTorch dtypes (no NCCL equivalent)
+    _unsupported_dtypes = set()
+
+    # Integer types not in NCCL
+    if hasattr(torch, "int16"):
+        _unsupported_dtypes.add(torch.int16)
+    if hasattr(torch, "short"):
+        _unsupported_dtypes.add(torch.short)
+
+    # Complex types (NCCL doesn't support)
+    if hasattr(torch, "complex64"):
+        _unsupported_dtypes.add(torch.complex64)
+        _unsupported_dtypes.add(torch.cfloat)
+    if hasattr(torch, "complex128"):
+        _unsupported_dtypes.add(torch.complex128)
+        _unsupported_dtypes.add(torch.cdouble)
+
+    # Quantized types (NCCL doesn't support)
+    for qtype in ["qint8", "quint8", "qint32", "quint4x2", "quint2x4"]:
+        if hasattr(torch, qtype):
+            _unsupported_dtypes.add(getattr(torch, qtype))
+
+    # Check if dtype is explicitly unsupported
+    if torch_dtype in _unsupported_dtypes:
+        raise NcclInvalid(
+            f"Unsupported data type: torch dtype {torch_dtype} has no NCCL equivalent. "
+            f"NCCL does not support complex, int16, or quantized types."
+        )
+
+    # Check if dtype is supported
+    if torch_dtype in _torch_to_nccl:
+        return _torch_to_nccl[torch_dtype]
+    else:
+        # Unknown dtype - list what we do support
+        supported_list = [str(dt) for dt in sorted(_torch_to_nccl.keys(), key=str)]
+        raise NcclInvalid(
+            f"Unknown torch dtype {torch_dtype}. "
+            f"Supported types: {', '.join(supported_list[:12])}..."
+        )
+
+
+def _parse_device(device: torch.device | int | str | None) -> int:
+    """
+    Parses device specification into device index.
+
+    Args:
+        - device (torch.device | int | str, optional): Device specification.
+
+    Returns:
+        ``int``: CUDA device index.
+
+    Raises:
+        - ``ModuleNotFoundError``: If PyTorch is not installed.
+        - ``NcclInvalid``: If device is not a CUDA device.
+    """
+    if not _torch_enabled:
+        raise ModuleNotFoundError("PyTorch is not installed")
+
+    if device is None:
+        # Use current CUDA device
+        return torch.cuda.current_device()
+    elif isinstance(device, torch.device):
+        if device.type != "cuda":
+            raise NcclInvalid(f"NCCL tensors must be on CUDA device, got {device}")
+        return device.index if device.index is not None else torch.cuda.current_device()
+    elif isinstance(device, str):
+        device_obj = torch.device(device)
+        if device_obj.type != "cuda":
+            raise NcclInvalid(f"NCCL tensors must be on CUDA device, got {device}")
+        return device_obj.index if device_obj.index is not None else torch.cuda.current_device()
+    else:
+        # device is int, use it directly
+        return device
+
+
+def _allocate_nccl_tensor(
+    shape: tuple[int, ...], dtype: torch.dtype, device: int, morder: str
+) -> torch.Tensor:
+    """
+    Allocates NCCL-backed tensor with specified parameters.
+
+    Args:
+        - shape (tuple[int, ...]): Shape of tensor.
+        - dtype (torch.dtype): Data type.
+        - device (int): CUDA device index.
+        - morder (str): Memory order ("C" or "F").
+
+    Returns:
+        ``torch.Tensor``: Allocated tensor with NCCL-backed memory.
+
+    Raises:
+        - ``ModuleNotFoundError``: If PyTorch is not installed.
+    """
+    if not _torch_enabled:
+        raise ModuleNotFoundError("PyTorch is not installed")
+
+    # Get itemsize for the dtype
+    itemsize = torch.tensor([], dtype=dtype).element_size()
+    size_bytes = int(np.prod(shape) * itemsize)
+
+    # Allocate buffer on the specified device
+    buf = mem_alloc(size_bytes, device=device)
+
+    # Create tensor via DLPack
+    torch_tensor = torch.from_dlpack(buf)  # type: ignore[attr-defined]
+    view = torch_tensor.view(dtype).view(shape)
+
+    # Handle Fortran order if requested
+    if morder == "F":
+        # Compute Fortran-style (column-major) strides
+        if len(shape) > 0:
+            strides = [1]
+            for dim in shape[:-1]:
+                strides.append(strides[-1] * dim)
+            view = view.as_strided(size=shape, stride=strides)
+
+    return view
+
+
+def empty(
+    *size,
+    dtype: torch.dtype | None = None,
+    device: torch.device | int | str | None = None,
+    morder: Literal["C", "F"] = "C",
+) -> torch.Tensor:
+    """
+    Creates an uninitialized PyTorch tensor backed by NCCL-allocated memory.
+
+    Returns a tensor filled with uninitialized data using NCCL's memory allocator.
+    This provides a PyTorch-compatible interface while using NCCL's memory allocator
+    for efficient GPU memory management in distributed scenarios.
+
+    Args:
+        - *size (int...): A sequence of integers defining the shape of the output tensor. Can be a variable number of arguments or a collection like a list or tuple.
+        - dtype (torch.dtype, optional): The desired data type of returned tensor. If None, uses global default (see ``torch.set_default_dtype()``). Defaults to None.
+        - device (torch.device | int | str, optional): The device of the constructed tensor. If None, uses the current CUDA device. Defaults to None.
+        - morder (Literal["C", "F"], optional): Memory layout - "C" for row-major (C-style), "F" for column-major (Fortran-style). Defaults to "C".
+
+    Returns:
+        ``torch.Tensor``: An uninitialized PyTorch tensor backed by NCCL-allocated memory.
+
+    Raises:
+        - ``NcclInvalid``: If morder is invalid (must be "C" or "F"), or device is not a CUDA device.
+        - ``ModuleNotFoundError``: If PyTorch is not installed.
+
+    Notes:
+        - Unlike ``torch.empty()``, this allocates memory using NCCL's memory allocator.
+        - For zero-copy optimization, register using ``Communicator.register_buffer()`` or ``Communicator.register_window()``.
+        - Memory is automatically freed when the tensor is garbage collected. No explicit free call is required.
+    """
+    if not _torch_enabled:
+        raise ModuleNotFoundError("PyTorch is not installed")
+
+    # Validate morder parameter
+    if morder not in ("C", "F"):
+        raise NcclInvalid(f"Invalid memory order: must be 'C' or 'F', got '{morder}'")
+
+    # Parse size arguments (can be *args or a single tuple/list)
+    if len(size) == 1 and isinstance(size[0], (tuple, list)):
+        shape = tuple(size[0])
+    else:
+        shape = size
+
+    # Handle dtype - use PyTorch's default if not specified
+    if dtype is None:
+        dtype = torch.get_default_dtype()
+
+    # Parse device specification
+    device_idx = _parse_device(device)
+
+    # Allocate NCCL-backed tensor
+    view = _allocate_nccl_tensor(shape, dtype, device_idx, morder)
+
+    return view
+
+
+def resolve_tensor(tensor: torch.Tensor) -> tuple[int, int, NcclDataType, int]:
+    """
+    Resolves a PyTorch tensor to a tuple of (ptr, count, dtype, device_id).
+
+    Args:
+        - tensor (torch.Tensor): PyTorch tensor to resolve.
+
+    Returns:
+        ``tuple[int, int, NcclDataType, int]``: Tuple of (ptr, count, dtype, device_id).
+    """
+    if not _torch_enabled:
+        raise ModuleNotFoundError("PyTorch is not installed")
+
+    if not isinstance(tensor, torch.Tensor):
+        raise NcclInvalid(f"tensor must be a PyTorch tensor, got {type(tensor).__name__}")
+
+    return (tensor.data_ptr(), tensor.numel(), _to_nccl_dtype(tensor.dtype), tensor.device.index)

--- a/nccl4py/nccl/core/memory.py
+++ b/nccl4py/nccl/core/memory.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+NCCL-backed memory resource management.
+
+This module provides NcclMemoryResource, a MemoryResource implementation that uses
+NCCL's memory allocation functions to allocate device memory optimized for NCCL operations.
+Memory resources are thread-local and device-specific.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from cuda.core.experimental import Buffer, Device, MemoryResource, Stream
+from cuda.core.experimental._memory import DevicePointerT
+
+from nccl import bindings as _nccl_bindings
+
+from nccl.core.cuda import CudaDeviceContext
+
+__all__ = ["NcclMemoryResource", "get_memory_resource"]
+
+_mr_instances = threading.local()
+
+
+class NcclMemoryResource(MemoryResource):
+    """
+    NCCL-backed device memory resource for Buffer allocations.
+
+    This memory resource uses NCCL's memory allocation functions to allocate
+    device memory that is optimized for NCCL operations. The resource is tied
+    to a specific CUDA device and ensures proper device context during allocation.
+    """
+
+    def __init__(self, device_id: int) -> None:
+        """
+        Initializes NCCL memory resource for a specific device.
+
+        Args:
+            - device_id (int): CUDA device ID to allocate memory on.
+        """
+        self.device = Device(device_id)
+
+    def allocate(self, size: int, stream: Stream | None = None) -> Buffer:
+        """
+        Allocates device memory using NCCL.
+
+        Args:
+            - size (int): Number of bytes to allocate.
+            - stream (Stream, optional): CUDA stream for allocation (currently unused). Defaults to None.
+
+        Returns:
+            ``Buffer``: Buffer object wrapping the allocated memory.
+
+        Raises:
+            - ``NCCLError``: If allocation fails.
+        """
+        with CudaDeviceContext(self.device):
+            ptr = _nccl_bindings.mem_alloc(size)  # mem_alloc raises NCCLError if ptr is 0
+            buf = Buffer.from_handle(ptr=ptr, size=size, mr=self)
+            return buf
+
+    def deallocate(self, ptr: DevicePointerT, size: int, stream: Stream | None = None) -> None:
+        """
+        Deallocates device memory using NCCL.
+
+        Args:
+            - ptr (DevicePointerT): Device pointer to deallocate.
+            - size (int): Size of the allocation (for compatibility).
+            - stream (Stream, optional): CUDA stream for deallocation (currently unused). Defaults to None.
+        """
+        with CudaDeviceContext(self.device):
+            _nccl_bindings.mem_free(ptr)
+
+    @property
+    def device_id(self) -> int:
+        """
+        CUDA device ID this resource is associated with.
+
+        Returns:
+            ``int``: Device ID.
+        """
+        return self.device.device_id
+
+    @property
+    def is_device_accessible(self) -> bool:
+        """
+        Whether this memory is accessible from device code.
+
+        Returns:
+            ``bool``: Always True for NCCL-allocated memory.
+        """
+        return True
+
+    @property
+    def is_host_accessible(self) -> bool:
+        """
+        Whether this memory is accessible from host code.
+
+        Returns:
+            ``bool``: Always False for device memory.
+        """
+        return False
+
+
+def get_memory_resource(device_id: int) -> NcclMemoryResource:
+    """
+    Gets a thread-local ``NcclMemoryResource`` for the given device.
+
+    This function provides a cached, thread-local memory resource for each device.
+    Multiple calls with the same device will return the same resource instance,
+    ensuring efficient memory management.
+
+    Args:
+        - device_id (int): CUDA device ID to get memory resource for.
+
+    Returns:
+        ``NcclMemoryResource``: Thread-local NcclMemoryResource for the device.
+    """
+    if not hasattr(_mr_instances, "memory_resources"):
+        _mr_instances.memory_resources = {}
+
+    if device_id not in _mr_instances.memory_resources:
+        _mr_instances.memory_resources[device_id] = NcclMemoryResource(device_id)
+
+    return _mr_instances.memory_resources[device_id]

--- a/nccl4py/nccl/core/resources.py
+++ b/nccl4py/nccl/core/resources.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+Communicator-owned resource management.
+
+This module provides resource classes for NCCL communicator-owned objects including
+registered buffers for zero-copy communication, registered windows for RMA operations,
+and custom reduction operators. All resources are automatically cleaned up when the
+owning communicator is destroyed or aborted.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from nccl import bindings as _nccl_bindings
+
+from nccl.core.constants import WindowFlag
+from nccl.core.typing import NcclDataType, NcclInvalid
+
+__all__ = [
+    "RegisteredBufferHandle",
+    "RegisteredWindowHandle",
+    "CustomRedOp",
+]
+
+
+class CommResource(ABC):
+    """
+    Abstract base class for NCCL communicator-owned resources.
+
+    Resources are tied to a specific communicator and must be explicitly
+    deallocated before the communicator is destroyed.
+    """
+
+    def __init__(self, comm_ptr: int):
+        """
+        Initializes resource with communicator pointer.
+
+        Args:
+            - comm_ptr (int): Raw NCCL communicator pointer.
+
+        Raises:
+            - ``NcclInvalid``: If comm_ptr is 0 (invalid communicator).
+        """
+        if comm_ptr == 0:
+            raise NcclInvalid(
+                "Invalid communicator: cannot create resource with communicator ptr=0"
+            )
+        self._comm_ptr = comm_ptr
+        self._closed = False
+
+    @abstractmethod
+    def _allocate(self) -> None:
+        """
+        Allocates the underlying NCCL resource.
+
+        Notes:
+            This method is called during initialization and must be implemented by subclasses.
+        """
+        pass
+
+    @abstractmethod
+    def _deallocate(self) -> None:
+        """
+        Deallocates the underlying NCCL resource.
+
+        Notes:
+            This method is called during close() and must be implemented by subclasses.
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Explicitly deallocates the resource.
+
+        Notes:
+            This method is idempotent and safe to call multiple times.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._deallocate()
+
+    def _check_valid(self) -> None:
+        """
+        Checks if resource is valid and raises if closed.
+
+        Raises:
+            - ``RuntimeError``: If resource has been closed.
+        """
+        if self._closed:
+            raise RuntimeError(f"{self.__class__.__name__} has been closed and is no longer valid")
+
+    @property
+    def is_valid(self) -> bool:
+        """
+        Checks if resource is still valid (not closed).
+
+        Returns:
+            ``bool``: True if valid, False if closed.
+        """
+        return not self._closed
+
+
+class RegisteredBufferHandle(CommResource):
+    """
+    NCCL registered buffer handle for zero-copy optimized communication.
+
+    Registers a user buffer with the communicator to enable performance optimizations
+    in NCCL operations. The registration handle can be closed manually or is automatically
+    closed when the communicator is destroyed or aborted.
+
+    Attributes:
+        handle (int): Registration handle for NCCL operations.
+        size (int): Size of registered buffer in bytes.
+        is_valid (bool): Whether the registration is still valid.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommregister
+    """
+
+    def __init__(self, comm_ptr: int, buffer_ptr: int, size: int):
+        """
+        Creates and registers a buffer with NCCL.
+
+        Args:
+            - comm_ptr (int): NCCL communicator raw pointer.
+            - buffer_ptr (int): Device pointer to the buffer.
+            - size (int): Size of buffer in bytes.
+
+        Raises:
+            - ``NcclInvalid``: If comm_ptr is 0 (invalid communicator).
+        """
+        self._buffer_ptr = buffer_ptr
+        self._size = size
+        self._handle: int | None = None
+        super().__init__(comm_ptr)
+        self._allocate()
+
+    def _allocate(self) -> None:
+        """
+        Registers buffer with NCCL for zero-copy communication.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommregister
+        """
+        self._handle = _nccl_bindings.comm_register(self._comm_ptr, self._buffer_ptr, self._size)
+
+    def _deallocate(self) -> None:
+        """
+        Deregisters buffer from NCCL.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommderegister
+        """
+        if self._handle is not None:
+            _nccl_bindings.comm_deregister(self._comm_ptr, self._handle)
+            self._handle = None
+
+    @property
+    def handle(self) -> int:
+        """
+        Registration handle for NCCL operations.
+
+        Returns:
+            ``int``: The registration handle.
+
+        Raises:
+            - ``RuntimeError``: If buffer has been deregistered or handle is invalid.
+        """
+        self._check_valid()
+        if self._handle is None:
+            raise RuntimeError("Buffer registration handle is invalid")
+        return self._handle
+
+    @property
+    def size(self) -> int:
+        """
+        Size of the registered buffer in bytes.
+
+        Returns:
+            ``int``: Buffer size in bytes.
+        """
+        return self._size
+
+    def __repr__(self) -> str:
+        if not self.is_valid:
+            return "<RegisteredBufferHandle: closed>"
+        return f"<RegisteredBufferHandle: size={self._size}, handle={self._handle:#x}>"
+
+
+class RegisteredWindowHandle(CommResource):
+    """
+    NCCL registered window handle for Remote Memory Access (RMA) operations.
+
+    Registers a memory window with the communicator for one-sided communication patterns.
+    The window handle can be closed manually or is automatically closed when the
+    communicator is destroyed or aborted.
+
+    Attributes:
+        handle (int): Window handle for NCCL operations.
+        size (int): Size of registered window in bytes.
+        is_valid (bool): Whether the window registration is still valid.
+
+    Notes:
+        This is a collective operation. All ranks must call register_window() with equal buffer sizes.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommwindowregister
+    """
+
+    def __init__(self, comm_ptr: int, buffer_ptr: int, size: int, flags: WindowFlag | None = None):
+        """
+        Creates and registers a memory window with NCCL.
+
+        Args:
+            - comm_ptr (int): NCCL communicator raw pointer.
+            - buffer_ptr (int): Device pointer to the buffer.
+            - size (int): Size of window in bytes.
+            - flags (WindowFlag, optional): Window registration flags to control behavior. Defaults to None.
+
+        Raises:
+            - ``NcclInvalid``: If comm_ptr is 0 (invalid communicator).
+        """
+        self._buffer_ptr = buffer_ptr
+        self._size = size
+        self._flags = flags if flags is not None else WindowFlag.Default
+        self._handle: int | None = None
+        super().__init__(comm_ptr)
+        self._allocate()
+
+    def _allocate(self) -> None:
+        """
+        Collectively registers window with NCCL.
+
+        Notes:
+            This is a collective operation called during initialization.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommwindowregister
+        """
+        self._handle = _nccl_bindings.comm_window_register(
+            self._comm_ptr, self._buffer_ptr, self._size, self._flags.value
+        )
+
+    def _deallocate(self) -> None:
+        """
+        Deregisters window from NCCL.
+
+        Notes:
+            Deregistration is local to the rank. Caller must ensure the buffer is not being
+            accessed by any NCCL operation.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommwindowderegister
+        """
+        if self._handle is not None:
+            _nccl_bindings.comm_window_deregister(self._comm_ptr, self._handle)
+            self._handle = None
+
+    @property
+    def handle(self) -> int:
+        """
+        Window handle for NCCL operations.
+
+        Returns:
+            ``int``: The window handle.
+
+        Raises:
+            - ``RuntimeError``: If window has been deregistered or handle is invalid.
+        """
+        self._check_valid()
+        if self._handle is None:
+            raise RuntimeError("Window registration handle is invalid")
+        return self._handle
+
+    @property
+    def size(self) -> int:
+        """
+        Size of the registered window in bytes.
+
+        Returns:
+            ``int``: Window size in bytes.
+        """
+        return self._size
+
+    def __repr__(self) -> str:
+        if not self.is_valid:
+            return "<RegisteredWindowHandle: closed>"
+        return f"<RegisteredWindowHandle: size={self._size}, handle={self._handle:#x}, flags={self._flags}>"
+
+
+class CustomRedOp(CommResource):
+    """
+    NCCL user-defined custom reduction operator.
+
+    Creates a custom reduction operator (e.g., PreMulSum) for collective operations.
+    The PreMulSum operator performs: output = scalar * sum(inputs), useful for averaging
+    or weighted reductions. The operator can be closed manually or is automatically
+    destroyed when the communicator is destroyed or aborted.
+
+    Attributes:
+        op (int): Operator handle for use in reduction operations.
+
+    See Also:
+        https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/ops.html#ncclredopcreatepremulsum
+    """
+
+    def __init__(
+        self,
+        comm_ptr: int,
+        scalar_ptr: int,
+        datatype: NcclDataType,
+        residence: _nccl_bindings.ScalarResidence,
+    ):
+        """
+        Creates a custom reduction operator.
+
+        Args:
+            - comm_ptr (int): NCCL communicator raw pointer.
+            - scalar_ptr (int): Pointer to scalar value (host or device memory).
+            - datatype (NcclDataType): NCCL data type of the scalar and reduction.
+            - residence (ScalarResidence): Enum indicating scalar memory location (HostImmediate or Device).
+
+        Raises:
+            - ``NcclInvalid``: If comm_ptr is 0 (invalid communicator).
+        """
+        self._scalar_ptr = scalar_ptr
+        self._datatype = datatype
+        self._residence = residence
+        self._op: int | None = None
+
+        super().__init__(comm_ptr)
+        self._allocate()
+
+    def _allocate(self) -> None:
+        """
+        Creates the custom reduction operator in NCCL.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/ops.html#ncclredopcreatepremulsum
+        """
+        self._op = _nccl_bindings.red_op_create_pre_mul_sum(
+            self._scalar_ptr, int(self._datatype), int(self._residence), self._comm_ptr
+        )
+
+    def _deallocate(self) -> None:
+        """
+        Destroys the custom reduction operator in NCCL.
+
+        See Also:
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/ops.html#ncclredopdestroy
+        """
+        if self._op is not None:
+            _nccl_bindings.red_op_destroy(self._op, self._comm_ptr)
+            self._op = None
+
+    @property
+    def op(self) -> int:
+        """
+        Operator handle for use in reduction operations.
+
+        Returns:
+            ``int``: The custom reduction operator handle.
+
+        Raises:
+            - ``RuntimeError``: If operator has been destroyed or is invalid.
+        """
+        self._check_valid()
+        if self._op is None:
+            raise RuntimeError("RedOp is invalid")
+        return self._op
+
+    def __int__(self) -> int:
+        """
+        Returns operator handle as int for direct use in collective operations.
+
+        Returns:
+            ``int``: The custom reduction operator handle.
+
+        Raises:
+            - ``RuntimeError``: If operator has been destroyed or is invalid.
+        """
+        self._check_valid()
+        if self._op is None:
+            raise RuntimeError("RedOp is invalid")
+        return self._op
+
+    def __repr__(self) -> str:
+        if not self.is_valid:
+            return "<CustomRedOp: closed>"
+        return f"<CustomRedOp: type=PreMulSum, dtype={self._datatype}, residence={self._residence.name}, op={self._op}>"

--- a/nccl4py/nccl/core/typing.py
+++ b/nccl4py/nccl/core/typing.py
@@ -1,0 +1,369 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+Type definitions, protocols, and type aliases for NCCL4Py.
+
+This module defines all type specifications used throughout NCCL4Py including
+data types, reduction operators, buffer specifications, and protocol classes
+for DLPack and CUDA Array Interface compatibility. It provides type-safe
+interfaces for NCCL operations with comprehensive type hints.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeAlias
+
+import numpy as _np
+from cuda.core.experimental import Buffer, Device
+from cuda.core.experimental._stream import IsStreamT, Stream
+
+from nccl import bindings as _nccl_bindings
+from nccl.bindings import DataType, RedOp
+
+__all__ = [
+    "NcclDataType",
+    "NcclRedOp",
+    "NcclBufferSpec",
+    "NcclScalarSpec",
+    "NcclDeviceSpec",
+    "NcclStreamSpec",
+    "NcclInvalid",
+    # Data type constants
+    "INT8",
+    "CHAR",
+    "UINT8",
+    "INT32",
+    "INT",
+    "UINT32",
+    "INT64",
+    "UINT64",
+    "FLOAT16",
+    "HALF",
+    "FLOAT32",
+    "FLOAT",
+    "FLOAT64",
+    "DOUBLE",
+    "BFLOAT16",
+    "FLOAT8E4M3",
+    "FLOAT8E5M2",
+    # Reduction op constants
+    "SUM",
+    "PROD",
+    "MAX",
+    "MIN",
+    "AVG",
+]
+
+_PyCapsule: TypeAlias = object
+_DeviceType: TypeAlias = int
+_DeviceID: TypeAlias = int
+
+
+class NcclInvalid(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        return f"<NcclInvalid: {self.msg}>"
+
+
+class NcclDataType:
+    def __init__(self, datatype: int | _np.dtype):
+        if isinstance(datatype, _np.dtype):
+            # First try name-based mapping for ml-dtypes (has higher priority)
+            _name_mapping = {
+                "bfloat16": DataType.Bfloat16,
+                "float8_e4m3fn": DataType.Float8e4m3,
+                "float8_e5m2": DataType.Float8e5m2,
+            }
+            if datatype.name in _name_mapping:
+                self._datatype = _name_mapping[datatype.name]
+            else:
+                # Fall back to kind+size mapping for standard NumPy types
+                _mapping = {
+                    ("f", 2): DataType.Float16,
+                    ("f", 4): DataType.Float32,
+                    ("f", 8): DataType.Float64,
+                    ("i", 1): DataType.Int8,
+                    ("i", 4): DataType.Int32,
+                    ("i", 8): DataType.Int64,
+                    ("u", 1): DataType.Uint8,
+                    ("u", 4): DataType.Uint32,
+                    ("u", 8): DataType.Uint64,
+                }
+                kind_size = (datatype.kind, datatype.itemsize)
+                if kind_size in _mapping:
+                    self._datatype = _mapping[kind_size]
+                else:
+                    raise NcclInvalid(
+                        f"Unsupported data type: numpy dtype {datatype} (kind={datatype.kind}, "
+                        f"itemsize={datatype.itemsize}, name={datatype.name}) has no NCCL equivalent"
+                    )
+        else:
+            try:
+                self._datatype = DataType(int(datatype))
+            except Exception:
+                raise NcclInvalid(
+                    f"Unsupported data type: NCCL datatype value {datatype} is invalid"
+                )
+
+    def __int__(self) -> int:
+        return int(self._datatype)
+
+    def __str__(self) -> str:
+        return self._datatype.name
+
+    def __repr__(self) -> str:
+        return f"NcclDataType({self._datatype.name})"
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Compares two NcclDataType instances for equality.
+
+        Returns:
+            ``bool``: True if data types are equal.
+        """
+        if not isinstance(other, NcclDataType):
+            return NotImplemented
+        return self._datatype == other._datatype
+
+    def __hash__(self) -> int:
+        """
+        Makes NcclDataType hashable.
+
+        Returns:
+            ``int``: Hash value.
+        """
+        return hash(self._datatype)
+
+    @property
+    def value(self) -> int:
+        """
+        Integer value of the NCCL data type.
+
+        Returns:
+            ``int``: Data type value.
+        """
+        return int(self._datatype)
+
+    @property
+    def name(self) -> str:
+        """
+        Name of the NCCL data type.
+
+        Returns:
+            ``str``: Data type name (e.g., "Float32", "Int64").
+        """
+        return self._datatype.name
+
+    @property
+    def itemsize(self) -> int:
+        """
+        Size in bytes of this data type.
+
+        Returns:
+            ``int``: Byte size (1, 2, 4, or 8).
+
+        Raises:
+            - ``NcclInvalid``: If data type is unsupported.
+        """
+        if self._datatype in [
+            DataType.Int8,
+            DataType.Char,
+            DataType.Uint8,
+            DataType.Float8e4m3,
+            DataType.Float8e5m2,
+        ]:
+            return 1
+        elif self._datatype in [DataType.Float16, DataType.Half, DataType.Bfloat16]:
+            return 2
+        elif self._datatype in [
+            DataType.Int32,
+            DataType.Int,
+            DataType.Uint32,
+            DataType.Float32,
+            DataType.Float,
+        ]:
+            return 4
+        elif self._datatype in [DataType.Int64, DataType.Uint64, DataType.Float64, DataType.Double]:
+            return 8
+        else:
+            raise NcclInvalid(
+                f"Unsupported data type: NCCL datatype {self._datatype} has no byte size mapping"
+            )
+
+    @property
+    def numpy_dtype(self) -> _np.dtype:
+        """
+        NumPy dtype corresponding to this NCCL data type.
+
+        Returns:
+            ``np.dtype``: Equivalent NumPy data type.
+
+        Raises:
+            - ``NcclInvalid``: If data type is unsupported.
+        """
+        # Mapping from NCCL DataType to numpy dtype string
+        _dtype_to_numpy = {
+            DataType.Int8: "int8",
+            DataType.Char: "int8",
+            DataType.Uint8: "uint8",
+            DataType.Int32: "int32",
+            DataType.Int: "int32",
+            DataType.Uint32: "uint32",
+            DataType.Int64: "int64",
+            DataType.Uint64: "uint64",
+            DataType.Float16: "float16",
+            DataType.Half: "float16",
+            DataType.Float32: "float32",
+            DataType.Float: "float32",
+            DataType.Float64: "float64",
+            DataType.Double: "float64",
+            # ml-dtypes
+            DataType.Bfloat16: "bfloat16",
+            DataType.Float8e4m3: "float8_e4m3fn",
+            DataType.Float8e5m2: "float8_e5m2",
+        }
+
+        if self._datatype not in _dtype_to_numpy:
+            raise NcclInvalid(
+                f"Unsupported data type: NCCL datatype {self._datatype} has no numpy dtype mapping"
+            )
+
+        dtype_str = _dtype_to_numpy[self._datatype]
+
+        # For ml-dtypes, provide helpful error if package is missing (optional dependency)
+        if dtype_str in ("bfloat16", "float8_e4m3fn", "float8_e5m2"):
+            try:
+                return _np.dtype(dtype_str)
+            except TypeError as e:
+                raise NcclInvalid(
+                    f"Cannot create numpy dtype '{dtype_str}': ml-dtypes package is not installed. "
+                    f"ml-dtypes is required for bfloat16 and float8 support. "
+                    f"Install with: pip install ml-dtypes"
+                ) from e
+        else:
+            return _np.dtype(dtype_str)
+
+
+INT8 = NcclDataType(DataType.Int8)
+CHAR = NcclDataType(DataType.Char)
+UINT8 = NcclDataType(DataType.Uint8)
+INT32 = NcclDataType(DataType.Int32)
+INT = NcclDataType(DataType.Int)
+UINT32 = NcclDataType(DataType.Uint32)
+INT64 = NcclDataType(DataType.Int64)
+UINT64 = NcclDataType(DataType.Uint64)
+FLOAT16 = NcclDataType(DataType.Float16)
+HALF = NcclDataType(DataType.Half)
+FLOAT32 = NcclDataType(DataType.Float32)
+FLOAT = NcclDataType(DataType.Float)
+FLOAT64 = NcclDataType(DataType.Float64)
+DOUBLE = NcclDataType(DataType.Double)
+BFLOAT16 = NcclDataType(DataType.Bfloat16)
+FLOAT8E4M3 = NcclDataType(DataType.Float8e4m3)
+FLOAT8E5M2 = NcclDataType(DataType.Float8e5m2)
+
+
+class NcclRedOp:
+    """
+    NCCL reduction operator wrapper with validation.
+
+    Wraps NCCL reduction operator values and validates them against
+    the built-in operators (Sum, Prod, Max, Min, Avg).
+    """
+
+    def __init__(self, value: int):
+        """
+        Initializes NcclRedOp with validation.
+
+        Args:
+            - value (int): Integer value of the reduction operator.
+
+        Raises:
+            - ``NcclInvalid``: If the reduction operator value is invalid.
+        """
+        try:
+            _ro = getattr(_nccl_bindings, "RedOp")
+            # Access a few known attributes to ensure class exists
+            _ = getattr(_ro, "Sum")
+        except Exception:
+            raise NcclInvalid("NCCL bindings error: NcclRedOp bindings not found")
+
+        # Validate that the value corresponds to a valid reduction operator
+        try:
+            self._redop_value = _ro(value)
+            self._redop_name = self._redop_value.name
+        except Exception:
+            raise NcclInvalid(
+                f"Invalid reduction operator: value {value} is not a valid NCCL reduction operator"
+            )
+
+    def __int__(self) -> int:
+        return int(self._redop_value)
+
+    def __str__(self) -> str:
+        return self._redop_name
+
+    def __repr__(self) -> str:
+        return f"<NcclRedOp: {self._redop_name}>"
+
+    @property
+    def value(self) -> int:
+        """
+        Integer value of the reduction operator.
+
+        Returns:
+            ``int``: Operator value.
+        """
+        return int(self._redop_value)
+
+    @property
+    def name(self) -> str:
+        """
+        Gets the name of the reduction operator.
+
+        Returns:
+            ``str``: Operator name (e.g., "Sum", "Max").
+        """
+        return self._redop_name
+
+
+SUM = NcclRedOp(RedOp.Sum)
+PROD = NcclRedOp(RedOp.Prod)
+MAX = NcclRedOp(RedOp.Max)
+MIN = NcclRedOp(RedOp.Min)
+AVG = NcclRedOp(RedOp.Avg)
+
+
+class SupportsDLPack(Protocol):
+    def __dlpack__(self, /, *, stream: Any | None = None) -> _PyCapsule: ...
+    def __dlpack_device__(self) -> tuple[_DeviceType, _DeviceID]: ...
+
+
+class SupportsCAI(Protocol):
+    @property
+    def __cuda_array_interface__(self) -> dict[str, Any]: ...
+
+
+NcclSupportedBuffer: TypeAlias = Buffer | SupportsDLPack | SupportsCAI
+
+NcclBufferSpec: TypeAlias = NcclSupportedBuffer
+
+NcclScalarSpec: TypeAlias = (
+    int
+    | float
+    | _np.ndarray  # NumPy array for host scalars
+    | NcclSupportedBuffer  # Device buffer (Buffer, DLPack, or CUDA Array Interface)
+)
+
+NcclDeviceSpec: TypeAlias = Device | int
+NcclStreamSpec: TypeAlias = Stream | IsStreamT | int

--- a/nccl4py/nccl/core/utils.py
+++ b/nccl4py/nccl/core/utils.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# See LICENSE.txt for license information
+
+"""
+Utility functions and classes for NCCL operations.
+
+This module provides version information, unique identifiers for communicator
+initialization, and error string utilities for NCCL operations.
+"""
+
+from __future__ import annotations
+
+import numpy as _np
+from packaging.version import Version as _Version
+
+from nccl._version import version
+from nccl import bindings as _nccl_bindings
+
+__all__ = ["Version", "get_version", "UniqueId", "get_unique_id", "get_error_string"]
+
+
+class Version:
+    """
+    Version information for NCCL4Py and NCCL library.
+
+    Attributes:
+        nccl_version (Version): NCCL library version.
+        nccl4py_version (Version): NCCL4Py package version.
+    """
+
+    def __init__(self, nccl_version: int) -> None:
+        """
+        Initializes Version object from NCCL version integer.
+
+        Args:
+            - nccl_version (int): NCCL version as an integer.
+        """
+        v = nccl_version
+        if v >= 10000:
+            major = v // 10000
+            minor = (v % 10000) // 100
+            patch = v % 100
+        else:
+            major = v // 1000
+            minor = (v % 1000) // 100
+            patch = v % 100
+
+        self.nccl_version = _Version(f"{major}.{minor}.{patch}")
+        self.nccl4py_version = _Version(version)
+
+    def __repr__(self) -> str:
+        return f"""
+Versions:
+    NCCL4Py version: {self.nccl4py_version}
+    NCCL Library version: {self.nccl_version}
+"""
+
+
+def get_version() -> Version:
+    """
+    Gets the version information for NCCL and NCCL4Py.
+
+    Returns:
+        ``Version``: Version object containing NCCL and NCCL4Py version information.
+    """
+    v = int(_nccl_bindings.get_version())
+    return Version(v)
+
+
+class UniqueId:
+    """
+    NCCL unique identifier for communicator initialization.
+
+    A UniqueId is used to coordinate communicator initialization across multiple ranks.
+    All ranks must use the same UniqueId to form a communicator.
+
+    Attributes:
+        ptr (int): Pointer to the internal NCCL unique ID structure.
+        as_ndarray (np.ndarray): NumPy array representation of the unique ID.
+        as_bytes (bytes): Bytes representation of the unique ID.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes an empty UniqueId.
+
+        Notes:
+            Use ``get_unique_id()`` to generate a valid unique ID for communicator initialization.
+        """
+        self._internal: _nccl_bindings.UniqueId = _nccl_bindings.UniqueId()
+
+    def __repr__(self) -> str:
+        """
+        Returns truncated bytes representation of UniqueId.
+
+        Returns:
+            ``str``: Hex representation showing first and last 8 bytes.
+        """
+        # Show first 8 and last 8 bytes in hex
+        bytes_data = self.as_bytes
+        if len(bytes_data) <= 32:
+            hex_str = bytes_data.hex()
+        else:
+            hex_str = bytes_data[:8].hex() + "..." + bytes_data[-8:].hex()
+        return f"<UniqueId: {hex_str}>"
+
+    @staticmethod
+    def from_bytes(b: bytes) -> UniqueId:
+        """
+        Creates a UniqueId from bytes.
+
+        Args:
+            - b (bytes): Bytes representation of a UniqueId.
+
+        Returns:
+            ``UniqueId``: Reconstructed UniqueId object.
+
+        Raises:
+            - ``TypeError``: If b is not a bytes-like object.
+            - ``ValueError``: If b has incorrect length.
+        """
+        try:
+            buf = b if isinstance(b, (bytes, bytearray)) else b.tobytes()
+        except Exception as e:
+            raise TypeError("'b' must be a bytes-like object") from e
+
+        expected = int(_nccl_bindings.unique_id_dtype.itemsize)
+        if len(buf) != expected:
+            raise ValueError(f"unique id must be {expected} bytes, got {len(buf)}")
+
+        arr = _np.frombuffer(buf, dtype=_nccl_bindings.unique_id_dtype, count=1)
+
+        uid = UniqueId.__new__(UniqueId)
+        uid._internal = _nccl_bindings.UniqueId.from_data(arr)
+        return uid
+
+    @property
+    def ptr(self) -> int:
+        """
+        Pointer to the internal NCCL unique ID structure.
+
+        Returns:
+            ``int``: Internal structure pointer.
+        """
+        return self._internal.ptr
+
+    @property
+    def as_ndarray(self) -> _np.ndarray:
+        """
+        NumPy array representation of the unique ID.
+
+        Returns:
+            ``np.ndarray``: Array containing the unique ID data.
+        """
+        return self._internal._data
+
+    @property
+    def as_bytes(self) -> bytes:
+        """
+        Bytes representation of the unique ID.
+
+        Returns:
+            ``bytes``: Unique ID as bytes (for serialization/broadcast).
+        """
+        return self._internal._data.tobytes()
+
+
+def get_unique_id(empty: bool = False) -> UniqueId:
+    """
+    Generates a new NCCL unique identifier for communicator initialization.
+
+    Args:
+        - empty (bool, optional): If True, return an empty UniqueId without calling NCCL. Defaults to False.
+
+    Returns:
+        ``UniqueId``: A new unique identifier to be shared across ranks.
+
+    Notes:
+        This should be called by one rank (typically rank 0) and the resulting
+        UniqueId should be broadcast to all other ranks.
+    """
+    uid = UniqueId()
+    if empty:
+        return uid
+    _nccl_bindings.get_unique_id(uid.ptr)
+    return uid
+
+
+def get_error_string(nccl_result: _nccl_bindings.Result | int) -> str:
+    """
+    Gets the error string for an NCCL result code.
+
+    Args:
+        - nccl_result (Result | int): NCCL result code.
+
+    Returns:
+        ``str``: Human-readable error message corresponding to the result code.
+    """
+    return _nccl_bindings.get_error_string(int(nccl_result))

--- a/nccl4py/nccl4py_cu12/pyproject.toml
+++ b/nccl4py/nccl4py_cu12/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "nccl4py-cu12"
+dynamic = ["version", "dependencies"]
+requires-python = ">=3.10"
+description = "Python bindings for NCCL"
+authors = [
+    { name = "NVIDIA Corporation" }
+]
+readme = "README.md"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6.0",
+    "pytest-cov",
+    "pytest-mpi",
+    "mpi4py",
+    "ruff",
+    "pyright",
+    "ml-dtypes",
+]
+
+[build-system]
+requires = [
+    "setuptools>=64",
+    "setuptools_scm",
+    "wheel",
+    "Cython>=0.29.24"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["nccl", "nccl.*"]
+exclude = ["__pycache__"]
+
+[tool.setuptools.package-data]
+"nccl.bindings" = ["*.pyi"]
+
+[tool.setuptools.exclude-package-data]
+"*" = ["__pycache__/*", "*.py[co]", "*.stamp", "*.pyx", "*.pxd", "*.cpp", "*.c"]
+
+[tool.setuptools_scm]
+version_file = "nccl/_version.py"
+# TODO: setuptools_scm is meant to use a git tag for the version
+# Once we have releases, we should move to that system
+fallback_version = "0.1.0"
+version_scheme = "guess-next-dev"
+
+[tool.ruff]
+line-length = 100
+
+[tool.pyright]
+include = ["nccl", "tests"]
+exclude = ["build", "dist", "*.egg-info"]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/nccl4py/nccl4py_cu12/setup.py
+++ b/nccl4py/nccl4py_cu12/setup.py
@@ -1,0 +1,118 @@
+import os
+from pathlib import Path
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+
+
+CUDA_VARIANT = "12"
+
+CUDA_HOME = os.environ.get("CUDA_HOME", "/usr/local/cuda")
+CUDA_INC = str(Path(CUDA_HOME, "include"))
+if not Path(CUDA_INC).exists():
+    raise SystemExit(
+        f"CUDA include directory not found: {CUDA_INC}\n"
+        f"Set CUDA_HOME=/path/to/cuda"
+    )
+
+ext_modules = [
+    "nccl.bindings.nccl"
+]
+
+def calculate_modules(module: str):
+    module_parts = module.split(".")
+
+    # nccl.bindings.nccl -> nccl/bindings/nccl.pyx
+    lowpp_mod = module_parts.copy()
+    lowpp_pyx = os.path.join(*lowpp_mod[:-1], f"{lowpp_mod[-1]}.pyx")
+    lowpp_mod = ".".join(lowpp_mod)
+    lowpp_ext = Extension(
+        lowpp_mod,
+        sources=[lowpp_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # cy variant: nccl.bindings.nccl -> nccl/bindings/cynccl.pyx
+    cy_mod = module_parts.copy()
+    cy_mod[-1] = f"cy{cy_mod[-1]}"
+    cy_mod_pyx = os.path.join(*cy_mod[:-1], f"{cy_mod[-1]}.pyx")
+    cy_mod = ".".join(cy_mod)
+    cy_ext = Extension(
+        cy_mod,
+        sources=[cy_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # internal variant: source is nccl_linux.pyx, but published module name is nccl.bindings._internal.nccl
+    inter_mod = module_parts.copy()
+    inter_mod.insert(-1, "_internal")
+    inter_mod_pyx = os.path.join(*inter_mod[:-1], f"{inter_mod[-1]}_linux.pyx")
+    inter_mod = ".".join(inter_mod)
+    inter_ext = Extension(
+        inter_mod,
+        sources=[inter_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # internal variant: insert _internal and use utils.pyx
+    inter_utils_mod = module_parts.copy()
+    inter_utils_mod.insert(-1, "_internal")
+    inter_utils_mod[-1] = "utils"
+    inter_utils_mod_pyx = os.path.join(*inter_utils_mod[:-1], f"{inter_utils_mod[-1]}.pyx")
+    inter_utils_mod = ".".join(inter_utils_mod)
+    inter_utils_ext = Extension(
+        inter_utils_mod,
+        sources=[inter_utils_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    return lowpp_ext, cy_ext, inter_ext, inter_utils_ext
+
+
+# Note: the extension attributes are overwritten in build_extension()
+ext_modules = [e for ext in ext_modules for e in calculate_modules(ext)]
+
+
+compiler_directives = {"embedsignature": True, "show_performance_hints": True}
+
+
+BASE_REQ = [
+    "packaging",
+    "numpy",
+    "cuda.core==0.4.1",
+]
+
+DEPS_CU12 = BASE_REQ + [
+    "nvidia-nccl-cu12",
+    "cuda-python>=12.0,<13.0",
+]
+
+VARIANT_TO_REQ = {
+    "12": DEPS_CU12,
+}
+INSTALL_REQUIRES = VARIANT_TO_REQ.get((CUDA_VARIANT or "").strip(), DEPS_CU12)
+
+
+setup(
+    ext_modules=cythonize(
+        ext_modules,
+        verbose=True,
+        language_level=3,
+        compiler_directives=compiler_directives,
+    ),
+    zip_safe=False,
+    options={"build_ext": {"inplace": False}},
+    install_requires=INSTALL_REQUIRES,
+)

--- a/nccl4py/nccl4py_cu13/pyproject.toml
+++ b/nccl4py/nccl4py_cu13/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "nccl4py-cu13"
+dynamic = ["version", "dependencies"]
+requires-python = ">=3.10"
+description = "Python bindings for NCCL"
+authors = [
+    { name = "NVIDIA Corporation" }
+]
+readme = "README.md"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6.0",
+    "pytest-cov",
+    "pytest-mpi",
+    "mpi4py",
+    "ruff",
+    "pyright",
+    "ml-dtypes",
+]
+
+[build-system]
+requires = [
+    "setuptools>=64",
+    "setuptools_scm",
+    "wheel",
+    "Cython>=0.29.24"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["nccl", "nccl.*"]
+exclude = ["__pycache__"]
+
+[tool.setuptools.package-data]
+"nccl.bindings" = ["*.pyi"]
+
+[tool.setuptools.exclude-package-data]
+"*" = ["__pycache__/*", "*.py[co]", "*.stamp", "*.pyx", "*.pxd", "*.cpp", "*.c"]
+
+[tool.setuptools_scm]
+version_file = "nccl/_version.py"
+# TODO: setuptools_scm is meant to use a git tag for the version
+# Once we have releases, we should move to that system
+fallback_version = "0.1.0"
+version_scheme = "guess-next-dev"
+
+[tool.ruff]
+line-length = 100
+
+[tool.pyright]
+include = ["nccl", "tests"]
+exclude = ["build", "dist", "*.egg-info"]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/nccl4py/nccl4py_cu13/setup.py
+++ b/nccl4py/nccl4py_cu13/setup.py
@@ -1,0 +1,120 @@
+import os
+from pathlib import Path
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+
+
+CUDA_VARIANT = "13"
+
+CUDA_HOME = os.environ.get("CUDA_HOME", "/usr/local/cuda")
+CUDA_INC = str(Path(CUDA_HOME, "include"))
+if not Path(CUDA_INC).exists():
+    raise SystemExit(
+        f"CUDA include directory not found: {CUDA_INC}\n"
+        f"Set CUDA_HOME=/path/to/cuda"
+    )
+
+ext_modules = [
+    "nccl.bindings.nccl"
+]
+
+def calculate_modules(module: str):
+    module_parts = module.split(".")
+
+    # nccl.bindings.nccl -> nccl/bindings/nccl.pyx
+    lowpp_mod = module_parts.copy()
+    lowpp_pyx = os.path.join(*lowpp_mod[:-1], f"{lowpp_mod[-1]}.pyx")
+    lowpp_mod = ".".join(lowpp_mod)
+    lowpp_ext = Extension(
+        lowpp_mod,
+        sources=[lowpp_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # cy variant: nccl.bindings.nccl -> nccl/bindings/cynccl.pyx
+    cy_mod = module_parts.copy()
+    cy_mod[-1] = f"cy{cy_mod[-1]}"
+    cy_mod_pyx = os.path.join(*cy_mod[:-1], f"{cy_mod[-1]}.pyx")
+    cy_mod = ".".join(cy_mod)
+    cy_ext = Extension(
+        cy_mod,
+        sources=[cy_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # internal variant: source is nccl_linux.pyx, but published module name is nccl.bindings._internal.nccl
+    inter_mod = module_parts.copy()
+    inter_mod.insert(-1, "_internal")
+    inter_mod_pyx = os.path.join(*inter_mod[:-1], f"{inter_mod[-1]}_linux.pyx")
+    inter_mod = ".".join(inter_mod)
+    inter_ext = Extension(
+        inter_mod,
+        sources=[inter_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # internal variant: insert _internal and use utils.pyx
+    inter_utils_mod = module_parts.copy()
+    inter_utils_mod.insert(-1, "_internal")
+    inter_utils_mod[-1] = "utils"
+    inter_utils_mod_pyx = os.path.join(*inter_utils_mod[:-1], f"{inter_utils_mod[-1]}.pyx")
+    inter_utils_mod = ".".join(inter_utils_mod)
+    inter_utils_ext = Extension(
+        inter_utils_mod,
+        sources=[inter_utils_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    return lowpp_ext, cy_ext, inter_ext, inter_utils_ext
+
+
+# Note: the extension attributes are overwritten in build_extension()
+ext_modules = [e for ext in ext_modules for e in calculate_modules(ext)]
+
+
+compiler_directives = {"embedsignature": True, "show_performance_hints": True}
+
+
+BASE_REQ = [
+    "packaging",
+    "numpy",
+    "cuda.core==0.4.1",
+]
+
+
+DEPS_CU13 = BASE_REQ + [
+    "nvidia-nccl-cu13",
+    "cuda-python>=13.0,<14.0",
+]
+
+VARIANT_TO_REQ = {
+
+    "13": DEPS_CU13,
+}
+INSTALL_REQUIRES = VARIANT_TO_REQ.get((CUDA_VARIANT or "").strip(), DEPS_CU13)
+
+
+setup(
+    ext_modules=cythonize(
+        ext_modules,
+        verbose=True,
+        language_level=3,
+        compiler_directives=compiler_directives,
+    ),
+    zip_safe=False,
+    options={"build_ext": {"inplace": False}},
+    install_requires=INSTALL_REQUIRES,
+)

--- a/nccl4py/pyproject.toml
+++ b/nccl4py/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "nccl4py"
+dynamic = ["version", "dependencies"]
+requires-python = ">=3.10"
+description = "Python bindings for NCCL"
+authors = [
+    { name = "NVIDIA Corporation" }
+]
+readme = "README.md"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6.0",
+    "pytest-cov",
+    "pytest-mpi",
+    "mpi4py",
+    "ruff",
+    "pyright",
+    "ml-dtypes",
+]
+
+[build-system]
+requires = [
+    "setuptools>=64",
+    "setuptools_scm",
+    "wheel",
+    "Cython>=0.29.24"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["nccl", "nccl.*"]
+exclude = ["__pycache__"]
+
+[tool.setuptools.package-data]
+"nccl.bindings" = ["*.pyi"]
+
+[tool.setuptools.exclude-package-data]
+"*" = ["__pycache__/*", "*.py[co]", "*.stamp", "*.pyx", "*.pxd", "*.cpp", "*.c"]
+
+[tool.setuptools_scm]
+version_file = "nccl/_version.py"
+# TODO: setuptools_scm is meant to use a git tag for the version
+# Once we have releases, we should move to that system
+fallback_version = "0.1.0"
+version_scheme = "guess-next-dev"
+
+[tool.ruff]
+line-length = 100
+
+[tool.pyright]
+include = ["nccl", "tests"]
+exclude = ["build", "dist", "*.egg-info"]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/nccl4py/setup.py
+++ b/nccl4py/setup.py
@@ -1,0 +1,123 @@
+import os
+from pathlib import Path
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+
+
+CUDA_VARIANT = os.environ.get("CUDA_VARIANT")
+
+CUDA_HOME = os.environ.get("CUDA_HOME", "/usr/local/cuda")
+CUDA_INC = str(Path(CUDA_HOME, "include"))
+if not Path(CUDA_INC).exists():
+    raise SystemExit(
+        f"CUDA include directory not found: {CUDA_INC}\n"
+        f"Set CUDA_HOME=/path/to/cuda"
+    )
+
+ext_modules = [
+    "nccl.bindings.nccl"
+]
+
+def calculate_modules(module: str):
+    module_parts = module.split(".")
+
+    # nccl.bindings.nccl -> nccl/bindings/nccl.pyx
+    lowpp_mod = module_parts.copy()
+    lowpp_pyx = os.path.join(*lowpp_mod[:-1], f"{lowpp_mod[-1]}.pyx")
+    lowpp_mod = ".".join(lowpp_mod)
+    lowpp_ext = Extension(
+        lowpp_mod,
+        sources=[lowpp_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # cy variant: nccl.bindings.nccl -> nccl/bindings/cynccl.pyx
+    cy_mod = module_parts.copy()
+    cy_mod[-1] = f"cy{cy_mod[-1]}"
+    cy_mod_pyx = os.path.join(*cy_mod[:-1], f"{cy_mod[-1]}.pyx")
+    cy_mod = ".".join(cy_mod)
+    cy_ext = Extension(
+        cy_mod,
+        sources=[cy_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # internal variant: source is nccl_linux.pyx, but published module name is nccl.bindings._internal.nccl
+    inter_mod = module_parts.copy()
+    inter_mod.insert(-1, "_internal")
+    inter_mod_pyx = os.path.join(*inter_mod[:-1], f"{inter_mod[-1]}_linux.pyx")
+    inter_mod = ".".join(inter_mod)
+    inter_ext = Extension(
+        inter_mod,
+        sources=[inter_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    # internal variant: insert _internal and use utils.pyx
+    inter_utils_mod = module_parts.copy()
+    inter_utils_mod.insert(-1, "_internal")
+    inter_utils_mod[-1] = "utils"
+    inter_utils_mod_pyx = os.path.join(*inter_utils_mod[:-1], f"{inter_utils_mod[-1]}.pyx")
+    inter_utils_mod = ".".join(inter_utils_mod)
+    inter_utils_ext = Extension(
+        inter_utils_mod,
+        sources=[inter_utils_mod_pyx],
+        include_dirs=[CUDA_INC],
+        language="c++",
+        extra_compile_args=["-std=c++14"],
+        libraries=["dl"],
+    )
+
+    return lowpp_ext, cy_ext, inter_ext, inter_utils_ext
+
+
+# Note: the extension attributes are overwritten in build_extension()
+ext_modules = [e for ext in ext_modules for e in calculate_modules(ext)]
+
+
+compiler_directives = {"embedsignature": True, "show_performance_hints": True}
+
+
+BASE_REQ = [
+    "packaging",
+    "numpy",
+    "cuda.core==0.4.1",
+]
+
+DEPS_CU12 = BASE_REQ + [
+    "nvidia-nccl-cu12",
+    "cuda-python>=12.0,<13.0",
+]
+DEPS_CU13 = BASE_REQ + [
+    "nvidia-nccl-cu13",
+    "cuda-python>=13.0,<14.0",
+]
+
+VARIANT_TO_REQ = {
+    "12": DEPS_CU12,
+    "13": DEPS_CU13,
+}
+INSTALL_REQUIRES = VARIANT_TO_REQ.get((CUDA_VARIANT or "").strip(), DEPS_CU12)
+
+
+setup(
+    ext_modules=cythonize(
+        ext_modules,
+        verbose=True,
+        language_level=3,
+        compiler_directives=compiler_directives,
+    ),
+    zip_safe=False,
+    options={"build_ext": {"inplace": False}},
+    install_requires=INSTALL_REQUIRES,
+)


### PR DESCRIPTION
NCCL4Py provides Python language bindings for NCCL, providing a Pythonic interface to NCCL library's functionality. It enables Python applications to leverage NCCL's GPU-accelerated multi-GPU and multi-node communication capabilities for distributed computing workloads.

## Key Features
- Pythonic Interface: Clean, intuitive Python API that follows Python conventions and best practices
- Seamless Integration: Direct compatibility with PyTorch and CuPy for zero-copy GPU data transfer
- Complete NCCL Support: Access to all NCCL collective operations, point-to-point communication, and advanced features
- Type Safety: Comprehensive type annotations for better IDE support and code validation
- Resource Management: Automatic resource cleanup with Python's context managers and garbage collection
- Flexible Initialization: Multiple initialization methods including MPI and manual unique ID distribution
- NCCL4Py supports all NCCL collective communication primitives: AllReduce, Broadcast, Reduce, AllGather, ReduceScatter, AllToAll, Gather, and Scatter.

## Usage Model
NCCL4Py follows a simple workflow:
- Obtain Unique ID: Generate or receive a NCCL unique ID for communicator initialization
- Initialize Communicator: Create a communicator that connects multiple ranks using the unique ID
- Allocate Buffers: Create GPU buffers using PyTorch, CuPy, or NCCL's memory allocator
- Perform Communication: Use collective operations (all_reduce, broadcast, etc.) or point-to-point (send/recv)
- Cleanup: Destroy the communicator when done

## Limitations
- GPU-Only: NCCL4Py only supports CUDA-enabled GPUs (CPU operations are not supported)
- Python 3.10+: Requires Python 3.10 or later
- Dependencies: Requires NCCL library, CUDA toolkit, and optionally PyTorch or CuPy for array operations

For more details, see the respective sections in this documentation.

## Quick Start
Here's a minimal example demonstrating NCCL4Py with an AllReduce operation:

```
from mpi4py import MPI
import cupy as cp
from cuda.core.experimental import Device, system
import nccl.core as nccl

comm_mpi = MPI.COMM_WORLD
rank = comm_mpi.Get_rank()
nranks = comm_mpi.Get_size()

dev = Device(rank % system.num_devices)
dev.set_current()

unique_id = nccl.get_unique_id() if rank == 0 else None
unique_id = comm_mpi.bcast(unique_id, root=0)

nccl_comm = nccl.Communicator.init(nranks=nranks, rank=rank, unique_id=unique_id)

data = cp.array([float(rank)], dtype=cp.float32)

nccl_comm.all_reduce(data, data, nccl.SUM)
cp.cuda.Stream.null.synchronize()

expected = float(nranks * (nranks - 1) // 2)
print(f"Rank {rank}: result = {float(data[0]):.0f} (expected {expected:.0f})")

nccl_comm.destroy()
```