### PR TITLE
cmake: open version.mk relative to repo root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25) # ipp6 is using 3.28
 
 # Version information
 # Read makefiles/version.mk file
-file(READ ${CMAKE_SOURCE_DIR}/makefiles/version.mk VERSION_CONTENT)
+file(READ ${CMAKE_CURRENT_LIST_DIR}/makefiles/version.mk VERSION_CONTENT)
 string(REGEX REPLACE ".*NCCL_MAJOR[ ]*:=[ ]*([0-9]+).*" "\\1" NCCL_MAJOR "${VERSION_CONTENT}")
 string(REGEX REPLACE ".*NCCL_MINOR[ ]*:=[ ]*([0-9]+).*" "\\1" NCCL_MINOR "${VERSION_CONTENT}")
 string(REGEX REPLACE ".*NCCL_PATCH[ ]*:=[ ]*([0-9]+).*" "\\1" NCCL_PATCH "${VERSION_CONTENT}")


### PR DESCRIPTION
## Description

under FetchContent usage, CMAKE_SOURCE_DIR does not refer to the nccl project root until project() is invoked, but we need to parse the version before we can call project(). Avoid by using CMAKE_CURRENT_LIST_DIR instead, which remains stable between project() calls.

## Related Issues

N/A

## Changes & Impact

N/A, build annoyance.

## Performance Impact

N/A

