### PR TITLE
Make proxy dump print out meaningful information.

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -82,6 +82,10 @@ struct ncclProxyOp {
   uint8_t* recvbuff;
   int isOneRPN;
   RingAlgorithm *ringAlgo;
+
+  int nextRank;
+  int prevRank;
+
   union ncclProxyOpSpecifics specifics;
   int nChannels;
   int nPeers;
@@ -196,6 +200,11 @@ struct ncclProxyArgs {
   struct ncclProxyArgs** proxyAppendPtr;
 
   union ncclProxyOpSpecifics specifics;
+
+  int prevRank;
+  int nextRank;
+  int send;
+  int retry_total;
 };
 #define NCCL_MAX_NETDEVS 128
 


### PR DESCRIPTION
Fix: proxy dump is being fixed to print meaningful and actionable information.

Credit: Arm.Patinyasakdikul@amd.com (initial implementation in RCCL).

## Description

Proxy dump was broken at some point and prints CollNet when CollNet is not in use.  This fixes that.