### PR TITLE
Fix: dumpProxyState visibility issues for multiple communication groups

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -100,6 +100,7 @@ struct ncclProxyOp {
   bool incWorkCounter;
   int eActivationMask;
   void* taskEventHandle;
+  uint64_t commHash;
   int rank;
   int peer;
   pid_t pid;
@@ -164,6 +165,7 @@ struct ncclProxySubArgs {
 struct ncclProxyArgs {
   struct ncclProxySubArgs subs[NCCL_PROXY_MAX_SUBS];
   proxyProgressFunc_t progress;
+  uint64_t commHash;
   int nsubs;
   int done;
   int onePPN;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -263,7 +263,7 @@ ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) 
         else if (sub->transmitted < sub->posted) status = 'G'; // Waiting on GPU
         else if (sub->done < sub->transmitted) status = 'S'; // Sending
         else status = 'D'; // Done
-        printf(": %d -> %d / status %c (nsteps %d, posted %ld, transmitted %ld, done %ld)", sub->rank, sub->peer, status, sub->nsteps, sub->posted, sub->transmitted, sub->done);
+        printf(": %d -> %d / status %c (nsteps %d, posted %lu, transmitted %lu, done %lu)", sub->rank, sub->peer, status, sub->nsteps, sub->posted, sub->transmitted, sub->done);
       } else {
         if (sub->posted < sub->nsteps && sub->posted < sub->done + NCCL_STEPS) status = 'I'; // Init
         else if (sub->received < sub->posted) status = 'R'; // Receiving
@@ -271,7 +271,7 @@ ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) 
         else if (sub->transmitted < sub->received) status = 'F'; // Flushing
         else if (sub->done < sub->transmitted) status = 'G'; // Waiting on GPU
         else status = 'D'; // Done
-        printf(": %d <- %d / status %c (nsteps %d, posted %ld, received %ld, transmitted %ld, done %ld)", sub->rank, sub->peer, status, sub->nsteps, sub->posted, sub->received, sub->transmitted, sub->done);
+        printf(": %d <- %d / status %c (nsteps %d, posted %lu, received %lu, transmitted %lu, done %lu)", sub->rank, sub->peer, status, sub->nsteps, sub->posted, sub->received, sub->transmitted, sub->done);
       }
     }
   }


### PR DESCRIPTION
## Description
This MR enhances dumpProxyState to improve visibility, correctness, and debug value in multi-group and collective communication scenarios.
1. Fix dumpProxyState visibility issues with multiple communication groups.
2. Add support for collective (Coll) operations in proxy state dumps.
3. Improve proxy state dump with more detailed information.

## Related Issues

#1930

## Changes & Impact

1. Replace process-global static variable `ncclLastProxyState` with thread-local static variable.
2. Determine whether a flow is send or recv based on `sub->connection->send` rather than `op->pattern`, enabling to dump proxy state for collective communications.
3. Print more detailed chunk information.

## How To Use
1. Set environment variables
```
export NCCL_PROXY_DUMP_SIGNAL=10
export NCCL_SET_THREAD_NAME=1
```
2. Find the proxy thread ID (TID)
```
ps -eL | grep "NCCL Progress"
```
3. Send the signal to trigger the dump and view the output
```
kill -10 <tid>
```
Example Output
```
ACTIVE OPS
[0-0|0| Reduce | recv channel NET/00: 0 <- 2 / status R (nsteps 6144, posted 677, received 669, transmitted 669, done 669)]
| `-> [0-2|2| AllGather | recv channel NET/00]
| `-> [0-6|4| ReduceScatter | recv channel NET/00]
v
[0-1|0| Reduce | recv channel NET/02: 0 <- 2 / status R (nsteps 6144, posted 676, received 668, transmitted 668, done 668)]
| `-> [0-4|2| AllGather | recv channel NET/02]
| `-> [0-8|4| ReduceScatter | recv channel NET/02]
v
[0-3|2| AllGather | send channel NET/01: 0 -> 2 / status G (nsteps 12, posted 8, transmitted 0, done 0)]
| `-> [0-7|4| ReduceScatter | send channel NET/01]
v
[0-5|2| AllGather | send channel NET/03: 0 -> 2 / status G (nsteps 12, posted 8, transmitted 0, done 0)]
| `-> [0-9|4| ReduceScatter | send channel NET/03]
v
[X]
```

## Performance Impact

No impact on execution performance; changes affect only proxy state dumping for debugging purposes.

