### PR TITLE
Fix sharedDevMems cuMem import cleanup to prevent proxy-side device memory leaks

### DIFF
--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1931,7 +1931,10 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
             if (sharedProxyState->sharedDevMems[i]) {
               if (!ncclCuMemEnable()) {
                 CUDACHECK(cudaIpcCloseMemHandle(sharedProxyState->sharedDevMems[i]));
+              } else {
+                NCCLCHECK(ncclCudaFree((char*)sharedProxyState->sharedDevMems[i]));
               }
+              sharedProxyState->sharedDevMems[i] = NULL;
             }
             int type = ncclProxyMsgClose;
             (void)ncclSocketSend(sharedProxyState->peerSocks + i, &type, sizeof(int));


### PR DESCRIPTION
## Description

Fixes proxy-side cleanup for sharedDevMems imported via cuMem to prevent GPU memory leaks across communicator lifetimes. The import path does not early-release handles, so teardown must perform proper unmap/addressFree and handle release.

## Related Issues

N/A

## Changes & Impact

- Ensures sharedDevMems cuMem mappings are released during proxy shutdown.
- This leak can be triggered via `ncclCommAbort()` when the communicator is using the NET transport/path (abort may bypass the normal finalize path, but proxy resources still need correct teardown).
- No API changes; expected behavior is cleanup-only.

## Performance Impact

Not measured; no expected runtime impact beyond cleanup on teardown.
Testing: Not run (not requested).

