### PR TITLE
fix: Invalid nullptr initialization for CUmemGenericAllocationHandle when compiling with Clang

### DIFF
--- a/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -283,7 +283,7 @@ class GdakiGlobalGPUBufferTable {
   uint32_t *get_rkeys_d() { return this->rkeys_hd_mhandle.gpu_buf; }
 
   GdakiGlobalGPUBufferTable()
-    : gpu_ptr(nullptr), mr(nullptr), cumemhandle(nullptr), num_elements(0), next_unused_idx(0){};
+    : gpu_ptr(nullptr), mr(nullptr), cumemhandle(0), num_elements(0), next_unused_idx(0){};
   GdakiGlobalGPUBufferTable(unsigned int num_elements, unsigned int num_ranks) {
     this->allocate(num_elements, num_ranks);
   };


### PR DESCRIPTION
## Description

CUmemGenericAllocationHandle is defined as unsigned long long (not a pointer type). Initializing it with nullptr is invalid in C++ since nullptr cannot be implicitly converted to an integer type. This causes a compilation error with Clang:

```
error: cannot initialize a member subobject of type 'CUmemGenericAllocationHandle' 
(aka 'unsigned long long') with an rvalue of type 'std::nullptr_t'
```

### Why this was not caught with Makefile build? 

NVIDIA's Makefile build uses NVCC with GCC as the host compiler, which historically allows implicit nullptr to integer conversions as a GCC extension (with only a warning). Clang rejects this as a hard error per the C++ standard.

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

This was the  original code in v2.28, only change in v2.29 to nullptr, so this PR just revert that.


<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

