### PR TITLE
Fix #1978 - Preserve plugin name when unloading net plugin

### DIFF
--- a/src/plugin/net.cc
+++ b/src/plugin/net.cc
@@ -82,8 +82,12 @@ static ncclResult_t ncclNetPluginUnload(netPluginLib_t* pluginLib) {
   if ((pluginLib->dlHandle) && ((pluginLib->ncclNetPluginRefCount) == 0)) {
     INFO(NCCL_INIT|NCCL_NET, "Unloading plugin %s", pluginLib->name);
     NCCLCHECK(ncclClosePluginLib(pluginLib->dlHandle, ncclPluginTypeNet));
+    char savedName[sizeof(pluginLib->name)];
+    strcpy(savedName,pluginLib->name);
     // memset will reset the status to ncllNetPluginStateLoadReady
     memset(pluginLib, 0, sizeof(netPluginLib_t));
+    // reset plugin name
+    strcpy(pluginLib->name, savedName);
     // reset the count of devices to UNDEF_DEV_COUNT
     pluginLib->netPhysDevs = pluginLib->netVirtDevs = NCCL_UNDEF_DEV_COUNT;
     pluginLib->collNetPhysDevs = pluginLib->collNetVirtDevs = NCCL_UNDEF_DEV_COUNT;


### PR DESCRIPTION
When unloading a net plugin, the plugin name was being cleared due to the use of memset on the entire pluginLib structure. This caused issues when attempting to reload the plugin later, as the name was no longer available.

To fix this, we now save the plugin name before the memset operation and restore it afterward. This ensures that the plugin name remains intact even after unloading, allowing for successful reloading of the plugin.

