### PR TITLE
[BUG] fix opCount not self-increasing in single node communicator

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1395,7 +1395,6 @@ static ncclResult_t hostStreamPlanTask(struct ncclComm* comm, struct ncclKernelP
     // Notify main thread of our reclaiming. This will reclaim plan concurrently.
     ncclIntruQueueMpscEnqueue(&comm->callbackQueue, &plan->reclaimer);
   }
-  comm->opCount++;
   return ncclSuccess;
 }
 
@@ -3009,6 +3008,7 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
 
   NCCLCHECKGOTO(taskAppend(info->comm, info), ret, fail);
 
+  info->comm->opCount++;
 exit:
   if (devOld != -1) CUDACHECK(cudaSetDevice(devOld));
   ncclGroupErrCheck(ret);

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1395,6 +1395,7 @@ static ncclResult_t hostStreamPlanTask(struct ncclComm* comm, struct ncclKernelP
     // Notify main thread of our reclaiming. This will reclaim plan concurrently.
     ncclIntruQueueMpscEnqueue(&comm->callbackQueue, &plan->reclaimer);
   }
+  comm->opCount++;
   return ncclSuccess;
 }
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1013,7 +1013,6 @@ ncclResult_t ncclProxyStart(struct ncclComm* comm) {
     ops->nextOps = ops->nextOpsEnd = -1;
     ops->count = 0;
   }
-  comm->opCount++;
   TIME_STOP(1);
   return ncclSuccess;
 }


### PR DESCRIPTION
## Description

in single node, opCount not self-increasing

<img width="2882" height="1836" alt="image" src="https://github.com/user-attachments/assets/b6bf1d3f-19d6-411b-976c-728f79ceeb03" />

after fix:

<img width="2900" height="1982" alt="image" src="https://github.com/user-attachments/assets/d6a23e34-2ea1-4007-b68a-4a7e395187d8" />



<!-- Clearly describe what the PR does and why -->

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

