### PR TITLE
Fix buffer overflow in parseStringList

### DIFF
--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -165,8 +165,10 @@ int parseStringList(const char* string, struct netIf* ifList, int maxList) {
         ifNum++; ifC = 0;
       }
     } else {
-      ifList[ifNum].prefix[ifC] = c;
-      ifC++;
+      if (ifC < sizeof(ifList[ifNum].prefix) - 1) {
+        ifList[ifNum].prefix[ifC] = c;
+        ifC++;
+      }
     }
     ptr++;
   } while (ifNum < maxList && c);


### PR DESCRIPTION
Fixes: NVIDIA/nccl#2026

## Description

Adds a bounds check in parseStringList to fix a buffer overflow.

## Related Issues

#2026 

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

