### PR TITLE
Fix wrong cumemhandle initialization to nullptr.

### DIFF
--- a/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -283,7 +283,7 @@ class GdakiGlobalGPUBufferTable {
   uint32_t *get_rkeys_d() { return this->rkeys_hd_mhandle.gpu_buf; }
 
   GdakiGlobalGPUBufferTable()
-    : gpu_ptr(nullptr), mr(nullptr), cumemhandle(nullptr), num_elements(0), next_unused_idx(0){};
+    : gpu_ptr(nullptr), mr(nullptr), cumemhandle(0), num_elements(0), next_unused_idx(0){};
   GdakiGlobalGPUBufferTable(unsigned int num_elements, unsigned int num_ranks) {
     this->allocate(num_elements, num_ranks);
   };


### PR DESCRIPTION
## Description

While building pytorch I noticed a compile error in the constructor GdakiGlobalGPUBufferTable given that cumemhandle is wrongly initialized as nullptr instead of 0.

## Changes & Impact

Minor fix

## Performance Impact

None
