### PR TITLE
fix(profiler): add ncclUint8 mapping

### DIFF
--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -45,6 +45,7 @@ const char* ncclDevRedOpToString(ncclDevRedOp_t op) {
 const char* ncclDatatypeToString(ncclDataType_t type) {
   switch (type) {
   case ncclInt8: return "ncclInt8";
+  case ncclUint8: return "ncclUint8";
   case ncclInt32: return "ncclInt32";
   case ncclUint32: return "ncclUint32";
   case ncclInt64: return "ncclInt64";

--- a/src/plugin/profiler/profiler_v1.cc
+++ b/src/plugin/profiler/profiler_v1.cc
@@ -42,6 +42,7 @@ static uint8_t ncclStringToProto(const char* proto) {
 
 static uint8_t ncclStringToDatatype(const char* dt) {
   if (0 == strcmp(dt, "ncclInt8")) return ncclInt8;
+  if (0 == strcmp(dt, "ncclUint8")) return ncclUint8;
   if (0 == strcmp(dt, "ncclInt32")) return ncclInt32;
   if (0 == strcmp(dt, "ncclUint32")) return ncclUint32;
   if (0 == strcmp(dt, "ncclInt64")) return ncclInt64;


### PR DESCRIPTION
## Description

Adds missing `ncclUint8` handling in the profiler and v1 adapter.

## Related Issues

Fixes https://github.com/NVIDIA/nccl/issues/1764.

## Changes & Impact

- `ncclDatatypeToString(ncclUint8)` now returns `ncclUint8` instead of `Unknown`
- Profiler v1 adapter now parses `"ncclUint8"` to `ncclUint8 (value 1)`.

## Testing

I ran `nccl-tests all_reduce_perf` with `uint8`

```
env NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=COLL /tmp/nccl-tests/build/all_reduce_perf -b 8 -e 8 -f 2 -g 1 -d uint8
```

```
#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)
NCCL INFO AllReduce: opCount 0 sendbuff 0x1018400000 recvbuff 0x1018600000 count 8 datatype 1 op 0 root 0 comm 0x57038b900ee0 [nranks=1] stream 0x57038b6ca920
           8             8     uint8     sum      -1
...
```