### PR TITLE
env var to specify absolute path of libibverbs.so to use

### DIFF
--- a/src/misc/ibvsymbols.cc
+++ b/src/misc/ibvsymbols.cc
@@ -80,13 +80,24 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
   static void* ibvhandle = NULL;
   void* tmp;
   void** cast;
-
-  ibvhandle=dlopen("libibverbs.so", RTLD_NOW);
-  if (!ibvhandle) {
-    ibvhandle=dlopen("libibverbs.so.1", RTLD_NOW);
+  const char* abs_libibverbs_so;
+  
+  if ((abs_libibverbs_so = ncclGetEnv("NCCL_LIBIBVERBS_SO")) != nullptr) {
+    INFO(NCCL_ENV|NCCL_INIT, "NCCL_LIBIBVERBS_SO set by environment to %s", abs_libibverbs_so);
+    ibvhandle = dlopen(abs_libibverbs_so, RTLD_NOW);
     if (!ibvhandle) {
-      INFO(NCCL_INIT, "Failed to open libibverbs.so[.1]");
+      INFO(NCCL_INIT, "Failed to open %s", abs_libibverbs_so);
       goto teardown;
+    }
+  }
+  else {
+    ibvhandle=dlopen("libibverbs.so", RTLD_NOW);
+    if (!ibvhandle) {
+      ibvhandle=dlopen("libibverbs.so.1", RTLD_NOW);
+      if (!ibvhandle) {
+        INFO(NCCL_INIT, "Failed to open libibverbs.so[.1]");
+        goto teardown;
+      }
     }
   }
 

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1553,8 +1553,11 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
 #if defined (__x86_64__)
               // Force a PCI-E read from GPU memory
               asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
+#elif defined(__aarch64__)
+              // Force a PCI-E read from GPU memory
+              asm volatile ("ldr wzr, [%0]" : : "r"(resources->gdcFlush) : "memory");
 #else
-              WARN("NET: GDR Flush only supported on x86_64");
+              WARN("NET: GDR Flush only supported on x86_64 and aarch64");
               return ncclInternalError;
 #endif
             } else {

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1553,9 +1553,6 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
 #if defined (__x86_64__)
               // Force a PCI-E read from GPU memory
               asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
-#elif defined(__aarch64__)
-              // Force a PCI-E read from GPU memory
-              asm volatile ("ldr wzr, [%0]" : : "r"(resources->gdcFlush) : "memory");
 #else
               WARN("NET: GDR Flush only supported on x86_64 and aarch64");
               return ncclInternalError;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1554,7 +1554,7 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               // Force a PCI-E read from GPU memory
               asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
 #else
-              WARN("NET: GDR Flush only supported on x86_64 and aarch64");
+              WARN("NET: GDR Flush only supported on x86_64");
               return ncclInternalError;
 #endif
             } else {


### PR DESCRIPTION
## Description

This PR:
- adds an environment variable which specifies an absolute path of libibverbs.so to load (NCCL_LIBIBVERBS_SO). We have a good use case for this.

## Related Issues

Not aware of related issues.

## Changes & Impact

No changes to any APIs. 

## Performance Impact

No additional performance impact expected.
