### PR TITLE
Add ncclNotifyTag API for user-defined profiler-v7

### DIFF
--- a/plugins/profiler/example/event.h
+++ b/plugins/profiler/example/event.h
@@ -302,6 +302,15 @@ struct ceBatch {
   struct ceBatch* pollerNext;  // For poller tracking list
 };
 
+struct userTag {
+  uint64_t type;
+  struct context* ctx;
+  int rank;
+  char tag[NCCL_TAG_MAX_LEN];
+  double startTs;
+  double stopTs;
+};
+
 struct groupApi {
   uint64_t type;
   struct context* ctx;
@@ -392,6 +401,11 @@ struct context {
   int ceBatchPoolBase;
   int ceBatchPoolIndex;
   struct ceBatch* ceBatchPool;
+
+  int userTagPoolSize;
+  int userTagPoolBase;
+  int userTagPoolIndex;
+  struct userTag* userTagPool;
 };
 
 template <typename T>

--- a/plugins/profiler/example/nccl/profiler.h
+++ b/plugins/profiler/example/nccl/profiler.h
@@ -30,6 +30,8 @@ enum {
   ncclProfileCeColl         = (1 << 12), // CE collective operation
   ncclProfileCeSync         = (1 << 13), // CE synchronization operation
   ncclProfileCeBatch        = (1 << 14), // CE batch operation
+  // User-defined tag events (v7)
+  ncclProfileUserTag        = (1 << 15), // User-defined tag annotation
 };
 
 typedef enum {
@@ -84,7 +86,11 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v3_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v4_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v5_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
+typedef ncclProfilerEventState_t ncclProfilerEventState_v7_t;
 
+#define NCCL_TAG_MAX_LEN 32
+
+#include "profiler_v7.h"
 #include "profiler_v6.h"
 #include "profiler_v5.h"
 #include "profiler_v4.h"
@@ -93,10 +99,10 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
 #include "profiler_v1.h"
 #include "profiler_net.h"
 
-// Use v6 as default to support CE events
-// v5 and earlier versions are still supported for backward compatibility
-typedef ncclProfiler_v6_t ncclProfiler_t;
-typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_t;
-typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_t;
+// Use v7 as default to support UserTag events
+// v6 and earlier versions are still supported for backward compatibility
+typedef ncclProfiler_v7_t ncclProfiler_t;
+typedef ncclProfilerEventDescr_v7_t ncclProfilerEventDescr_t;
+typedef ncclProfilerEventStateArgs_v7_t ncclProfilerEventStateArgs_t;
 
 #endif // end include guard

--- a/plugins/profiler/example/nccl/profiler_v7.h
+++ b/plugins/profiler/example/nccl/profiler_v7.h
@@ -1,0 +1,151 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Poolside Inc & AFFILIATES
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef PROFILER_V7_H_
+#define PROFILER_V7_H_
+
+#include "profiler_v6.h"
+
+// Extend v6 descriptor with UserTag support
+typedef struct {
+  uint64_t type;                // event type descriptor
+  void* parentObj;              // pointer to the profiler parent object
+  int rank;                     // originating rank
+  union {
+    // All v6 descriptors
+    struct {
+      bool graphCaptured;
+      int groupDepth;
+    } groupApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      int root;
+      void* stream;
+      bool graphCaptured;
+    } collApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      void* stream;
+      bool graphCaptured;
+    } p2pApi;
+
+    struct {
+      void* stream;
+    } kernelLaunch;
+
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      uint8_t nChannels;
+      uint8_t nWarps;
+      const char* algo;
+      const char* proto;
+      void* parentGroup;
+    } coll;
+
+    struct {
+      const char* func;
+      void* buff;
+      const char* datatype;
+      size_t count;
+      int peer;
+      uint8_t nChannels;
+      void* parentGroup;
+    } p2p;
+
+    struct {
+      pid_t pid;
+      uint8_t channelId;
+      int peer;
+      int nSteps;
+      int chunkSize;
+      int isSend;
+    } proxyOp;
+
+    struct {
+      int step;
+    } proxyStep;
+
+    struct {
+      uint8_t channelId;
+      uint64_t pTimer;
+    } kernelCh;
+
+    struct {
+      int64_t id;
+      void* data;
+    } netPlugin;
+
+    // v6 CE-specific descriptors
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      const char* syncStrategy;
+      bool intraBatchSync;
+      uint32_t batchSize;
+      uint32_t numBatches;
+      uint32_t ceSeqNum;
+      void* stream;
+    } ceColl;
+
+    struct {
+      bool isComplete;
+      int nRanks;
+    } ceCollSync;
+
+    struct {
+      int numOps;
+      size_t totalBytes;
+      bool useIntraSync;
+    } ceCollBatch;
+
+    // v7 UserTag descriptor
+    struct {
+      const char* tag;  // Pointer valid only during startEvent/stopEvent
+    } userTag;
+  };
+} ncclProfilerEventDescr_v7_t;
+
+// v7 uses same state args as v6
+typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_v7_t;
+
+typedef struct {
+  const char* name;
+
+  // init - initialize the profiler plugin
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+
+  // startEvent - initialize and start a new event
+  ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v7_t* eDescr);
+
+  // stopEvent - stop/finalize an event
+  ncclResult_t (*stopEvent)(void* eHandle);
+
+  // recordEventState - record event state transitions and updates
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v7_t eState, ncclProfilerEventStateArgs_v7_t* eStateArgs);
+
+  // finalize - finalize the profiler plugin
+  ncclResult_t (*finalize)(void* context);
+} ncclProfiler_v7_t;
+
+#endif // PROFILER_V7_H_

--- a/plugins/profiler/example/plugin.cc
+++ b/plugins/profiler/example/plugin.cc
@@ -31,6 +31,7 @@ static const int defaultGroupPoolSize = 8;
 static const int defaultCeCollPoolSize = 8;
 static const int defaultCeSyncPoolSize = 8;
 static const int defaultCeBatchPoolSize = 8;
+static const int defaultUserTagPoolSize = 8;
 static const int defaultCollPoolSize = 8;
 static const int defaultP2pPoolSize = 8;
 static const int defaultProxyCtrlPoolSize = 16;
@@ -47,6 +48,7 @@ static int proxyCtrlPoolSize;
 static int ceCollPoolSize;
 static int ceSyncPoolSize;
 static int ceBatchPoolSize;
+static int userTagPoolSize;
 static int detachPoolSize;
 static int detachPoolBase;
 static int detachPoolIndex;
@@ -110,6 +112,9 @@ static void initPoolSizes(void) {
 
   str = getenv("NCCL_PROFILE_PROXY_DETACH_POOL_SIZE");
   detachPoolSize = str ? atoi(str) : defaultDetachPoolSize;
+
+  str = getenv("NCCL_PROFILE_USER_TAG_POOL_SIZE");
+  userTagPoolSize = str ? atoi(str) : defaultUserTagPoolSize;
 }
 
 // Allocate global shared pools
@@ -165,9 +170,16 @@ static ncclResult_t allocateContextPools(struct context* ctx) {
   ctx->ceBatchPoolBase = 0;
   ctx->ceBatchPoolIndex = 0;
 
+  ctx->userTagPool = (struct userTag *)calloc(userTagPoolSize, sizeof(*ctx->userTagPool));
+  if (!ctx->userTagPool) goto fail;
+  ctx->userTagPoolSize = userTagPoolSize;
+  ctx->userTagPoolBase = 0;
+  ctx->userTagPoolIndex = 0;
+
   return ncclSuccess;
 
 fail:
+  if (ctx->userTagPool) free(ctx->userTagPool);
   if (ctx->ceBatchPool) free(ctx->ceBatchPool);
   if (ctx->ceSyncPool) free(ctx->ceSyncPool);
   if (ctx->ceCollPool) free(ctx->ceCollPool);
@@ -299,6 +311,13 @@ static void printAllEvents(FILE* fh, struct context* ctx) {
   }
 
   // CeSync and CeBatch are printed via their CeColl parent
+
+  // Print UserTag events
+  start = (ctx->userTagPoolIndex - ctx->userTagPoolSize >= 0) ? ctx->userTagPoolIndex - ctx->userTagPoolSize : 0;
+  end = ctx->userTagPoolIndex;
+  for (int i = start; i < end; i++) {
+    printEvent(fh, &ctx->userTagPool[i % ctx->userTagPoolSize]);
+  }
 }
 
 // Free all context pools
@@ -314,6 +333,7 @@ static void freeContextPools(struct context* ctx) {
   free(ctx->ceCollPool);
   free(ctx->ceSyncPool);
   free(ctx->ceBatchPool);
+  free(ctx->userTagPool);
 }
 
 // Global cleanup on last thread
@@ -1041,6 +1061,73 @@ ncclProfiler_v6_t ncclProfiler_v6 = {
   exampleProfilerStartEvent_v6,
   exampleProfilerStopEvent_v6,
   exampleProfilerRecordEventState_v6,
+  exampleProfilerFinalize,
+};
+
+// ============================================================================
+// v7 implementation with UserTag support
+// ============================================================================
+
+#include "nccl/profiler_v7.h"
+
+__hidden ncclResult_t exampleProfilerStartEvent_v7(void* context, void** eHandle, ncclProfilerEventDescr_v7_t* eDescr) {
+  struct context* ctx = (struct context*)context;
+
+  if (ctx == NULL) {
+    *eHandle = NULL;
+    return ncclSuccess;
+  }
+
+  if (eDescr->type == ncclProfileUserTag) {
+    struct userTag* event;
+    int tagId = __atomic_fetch_add(&ctx->userTagPoolIndex, 1, __ATOMIC_RELAXED);
+    if ((tagId - __atomic_load_n(&ctx->userTagPoolBase, __ATOMIC_RELAXED)) < ctx->userTagPoolSize) {
+      event = &ctx->userTagPool[tagId % ctx->userTagPoolSize];
+    } else {
+      __atomic_fetch_sub(&ctx->userTagPoolIndex, 1, __ATOMIC_RELAXED);
+      return ncclSuccess;
+    }
+    event->type = ncclProfileUserTag;
+    event->ctx = ctx;
+    event->rank = eDescr->rank;
+    if (eDescr->userTag.tag) {
+      strncpy(event->tag, eDescr->userTag.tag, NCCL_TAG_MAX_LEN - 1);
+      event->tag[NCCL_TAG_MAX_LEN - 1] = '\0';
+    } else {
+      event->tag[0] = '\0';
+    }
+    event->startTs = gettime() - startTime;
+    *eHandle = event;
+    return ncclSuccess;
+  }
+
+  // Delegate all other events to v6
+  return exampleProfilerStartEvent_v6(context, eHandle, (ncclProfilerEventDescr_v6_t*)eDescr);
+}
+
+__hidden ncclResult_t exampleProfilerStopEvent_v7(void* eHandle) {
+  if (!eHandle) return ncclSuccess;
+
+  uint64_t type = *(uint64_t*)eHandle;
+  if (type == ncclProfileUserTag) {
+    struct userTag* event = (struct userTag*)eHandle;
+    event->stopTs = gettime() - startTime;
+    return ncclSuccess;
+  }
+
+  return exampleProfilerStopEvent_v6(eHandle);
+}
+
+__hidden ncclResult_t exampleProfilerRecordEventState_v7(void* eHandle, ncclProfilerEventState_v7_t eState, ncclProfilerEventStateArgs_v7_t* eStateArgs) {
+  return exampleProfilerRecordEventState_v6(eHandle, (ncclProfilerEventState_v6_t)eState, (ncclProfilerEventStateArgs_v6_t*)eStateArgs);
+}
+
+ncclProfiler_v7_t ncclProfiler_v7 = {
+  "Example-profiler-v7",
+  exampleProfilerInit,
+  exampleProfilerStartEvent_v7,
+  exampleProfilerStopEvent_v7,
+  exampleProfilerRecordEventState_v7,
   exampleProfilerFinalize,
 };
 

--- a/plugins/profiler/example/print_event.cc
+++ b/plugins/profiler/example/print_event.cc
@@ -486,6 +486,10 @@ void printEvent(FILE* fh, void* handle) {
   } else if (type == ncclProfileCeBatch) {
     struct ceBatch* ce = (struct ceBatch*)handle;
     printCeBatchEvent(fh, ce);
+  } else if (type == ncclProfileUserTag) {
+    struct userTag* ut = (struct userTag*)handle;
+    fprintf(fh, "{\"name\": \"UserTag\", \"cat\": \"USER_TAG\", \"ph\": \"i\", \"s\": \"g\", \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"tag\": \"%s\", \"rank\": %d}},\n",
+            getpid(), 1, ut->startTs, ut->tag, ut->rank);
   }
   return;
 }

--- a/plugins/profiler/inspector/inspector.cc
+++ b/plugins/profiler/inspector/inspector.cc
@@ -503,6 +503,10 @@ static inline inspectorResult_t inspectorCompletedColl(jsonFileOutput* jfo,
 
     JSON_CHK(jsonKey(jfo, "coll_busbw_gbs")); JSON_CHK(jsonDouble(jfo, collInfo->busBwGbs));
 
+    if (collInfo->userTag[0] != '\0') {
+      JSON_CHK(jsonKey(jfo, "user_tag")); JSON_CHK(jsonStr(jfo, collInfo->userTag));
+    }
+
     if (enableNcclInspectorDumpVerbose) {
       INS_CHK(inspectorCompletedCollVerbose(jfo, collInfo));
     }
@@ -1709,6 +1713,7 @@ void inspectorUpdateCollPerf(struct inspectorCompletedCollInfo *completedColl,
   completedColl->msgSizeBytes = collInfo->msgSizeBytes;
   completedColl->execTimeUsecs =
     calculateMaxKernelExecTimeUsecs(collInfo, &completedColl->timingSource);
+  memcpy(completedColl->userTag, collInfo->userTag, NCCL_TAG_MAX_LEN);
   completedColl->collEvtTrk = collInfo->collEvtTrk;
 }
 

--- a/plugins/profiler/inspector/inspector.h
+++ b/plugins/profiler/inspector/inspector.h
@@ -17,6 +17,7 @@
 #include "json.h"
 #include "common.h"
 #include "version.h"
+#include "nccl/profiler.h"
 
 #define MAX_CHANNELS                     64
 
@@ -140,6 +141,7 @@ struct inspectorCompletedCollInfo {
   inspectorTimingSource_t timingSource;
   double algoBwGbs;
   double busBwGbs;
+  char userTag[NCCL_TAG_MAX_LEN]; // User tag active when collective was enqueued
   // Event trace information
   struct inspectorEventTrkCollInfo collEvtTrk;
 };
@@ -160,6 +162,8 @@ struct inspectorCommInfo {
   int cudaDeviceId;     // CUDA device ID for this communicator
   char deviceUuidStr[37]; // Pre-computed device UUID string for filename generation
   char cachedStaticLabels[256]; // Cached static parts of Prometheus labels (hostname, job, comm, rank, etc.)
+
+  char activeTag[NCCL_TAG_MAX_LEN]; // Current user tag, set by UserTag events
 
   bool dump;
   struct inspectorCompletedCollInfo completedCollInfo;
@@ -226,6 +230,7 @@ struct inspectorCollInfo {
   uint32_t nChannels;
   uint32_t nKernelChStarted;
   uint32_t nKernelChCompleted;
+  char userTag[NCCL_TAG_MAX_LEN]; // Tag captured at collective insertion time
   pthread_rwlock_t guard;
   struct inspectorKernelChInfo kernelCh[MAX_CHANNELS];
   struct inspectorEventTrkCollInfo collEvtTrk;

--- a/plugins/profiler/inspector/inspector_plugin.cc
+++ b/plugins/profiler/inspector/inspector_plugin.cc
@@ -114,7 +114,7 @@ __hidden ncclResult_t inspectorPluginInit(void** context, uint64_t commHash,
                    inspectorErrorString(res));
     return ncclSuccess;
   }
-  *eActivationMask = ncclProfileColl | ncclProfileKernelCh;
+  *eActivationMask = ncclProfileColl | ncclProfileKernelCh | ncclProfileUserTag;
   INFO(NCCL_INIT, "PROFILER/Plugin: init commName: %s commHash: %lu nranks: %d rank: %d",
        commName ? commName : "", commHash, nranks, rank);
   return ncclSuccess;
@@ -225,6 +225,12 @@ static void inspectorPluginCollInfoInit(struct inspectorCollInfo **collInfo,
 
 
   collInfoPtr->commInfo = commInfo;
+  // Capture active tag at collective insertion time
+  if (commInfo->activeTag[0] != '\0') {
+    memcpy(collInfoPtr->userTag, commInfo->activeTag, NCCL_TAG_MAX_LEN);
+  } else {
+    collInfoPtr->userTag[0] = '\0';
+  }
   collInfoPtr->collEvtTrk.sn = 0;
   collInfoPtr->collEvtTrk.nChannels = collInfoPtr->nChannels;
   inspectorRecordEventTrace(collInfoPtr->collEvtTrk.evntTrace,
@@ -484,11 +490,55 @@ __hidden ncclResult_t inspectorPluginRecordEventState(void* eHandle,
   return ncclSuccess;
 }
 
-ncclProfiler_t ncclProfiler_v5 = {
+ncclProfiler_v5_t ncclProfiler_v5 = {
   "Inspector",
   inspectorPluginInit,
-  inspectorPluginStartEvent,
+  (ncclResult_t (*)(void*, void**, ncclProfilerEventDescr_v5_t*))inspectorPluginStartEvent,
   inspectorPluginStopEvent,
-  inspectorPluginRecordEventState,
+  (ncclResult_t (*)(void*, ncclProfilerEventState_v5_t, ncclProfilerEventStateArgs_v5_t*))inspectorPluginRecordEventState,
+  inspectorPluginFinalize,
+};
+
+// ============================================================================
+// v7 implementation with UserTag support
+// ============================================================================
+
+__hidden ncclResult_t inspectorPluginStartEvent_v7(void* context,
+                                                   void** eHandle,
+                                                   ncclProfilerEventDescr_v7_t* eDescr) {
+  if (context == nullptr || eDescr == nullptr) {
+    return ncclSuccess;
+  }
+
+  if (eDescr->type == ncclProfileUserTag) {
+    struct inspectorCommInfo *commInfo = (struct inspectorCommInfo *)context;
+    if (eDescr->userTag.tag) {
+      strncpy(commInfo->activeTag, eDescr->userTag.tag, NCCL_TAG_MAX_LEN - 1);
+      commInfo->activeTag[NCCL_TAG_MAX_LEN - 1] = '\0';
+    } else {
+      commInfo->activeTag[0] = '\0';
+    }
+    *eHandle = NULL;
+    return ncclSuccess;
+  }
+
+  // Delegate all other events to the base handler
+  return inspectorPluginStartEvent(context, eHandle, (ncclProfilerEventDescr_t*)eDescr);
+}
+
+__hidden ncclResult_t inspectorPluginRecordEventState_v7(void* eHandle,
+                                                         ncclProfilerEventState_v7_t eState,
+                                                         ncclProfilerEventStateArgs_v7_t* eStateArgs) {
+  return inspectorPluginRecordEventState(eHandle,
+                                          (ncclProfilerEventState_t)eState,
+                                          (ncclProfilerEventStateArgs_t*)eStateArgs);
+}
+
+ncclProfiler_v7_t ncclProfiler_v7 = {
+  "Inspector-v7",
+  inspectorPluginInit,
+  inspectorPluginStartEvent_v7,
+  inspectorPluginStopEvent,
+  inspectorPluginRecordEventState_v7,
   inspectorPluginFinalize,
 };

--- a/plugins/profiler/inspector/inspector_prom.cc
+++ b/plugins/profiler/inspector/inspector_prom.cc
@@ -147,13 +147,25 @@ static inspectorResult_t inspectorPromGetLabels(char* labels,
   inspectorFormatHumanReadableSize(collInfo->msgSizeBytes, msgSizeStr, sizeof(msgSizeStr));
 
 
-  int ret = snprintf(labels, labelSize,
-                     "%s,collective=\"%s\",coll_sn=\"%lu\",timestamp=\"%s\",message_size=\"%s\"",
-                     commInfo->cachedStaticLabels,
-                     ncclFuncToString(collInfo->func),
-                     collInfo->sn,
-                     datetimeStr,
-                     msgSizeStr);
+  int ret;
+  if (collInfo->userTag[0] != '\0') {
+    ret = snprintf(labels, labelSize,
+                   "%s,collective=\"%s\",coll_sn=\"%lu\",timestamp=\"%s\",message_size=\"%s\",user_tag=\"%s\"",
+                   commInfo->cachedStaticLabels,
+                   ncclFuncToString(collInfo->func),
+                   collInfo->sn,
+                   datetimeStr,
+                   msgSizeStr,
+                   collInfo->userTag);
+  } else {
+    ret = snprintf(labels, labelSize,
+                   "%s,collective=\"%s\",coll_sn=\"%lu\",timestamp=\"%s\",message_size=\"%s\"",
+                   commInfo->cachedStaticLabels,
+                   ncclFuncToString(collInfo->func),
+                   collInfo->sn,
+                   datetimeStr,
+                   msgSizeStr);
+  }
 
   if (ret < 0 || (size_t)ret >= labelSize) {
     return inspectorMemoryError;

--- a/plugins/profiler/inspector/nccl/profiler.h
+++ b/plugins/profiler/inspector/nccl/profiler.h
@@ -26,6 +26,12 @@ enum {
   ncclProfileCollApi        = (1 << 9),  // Collective API events
   ncclProfileP2pApi         = (1 << 10), // Point-to-Point API events
   ncclProfileKernelLaunch   = (1 << 11), // Kernel launch events
+  // CE events (v6)
+  ncclProfileCeColl         = (1 << 12), // CE collective operation
+  ncclProfileCeSync         = (1 << 13), // CE synchronization operation
+  ncclProfileCeBatch        = (1 << 14), // CE batch operation
+  // User-defined tag events (v7)
+  ncclProfileUserTag        = (1 << 15), // User-defined tag annotation
 };
 
 typedef enum {
@@ -71,7 +77,13 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v2_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v3_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v4_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v5_t;
+typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
+typedef ncclProfilerEventState_t ncclProfilerEventState_v7_t;
 
+#define NCCL_TAG_MAX_LEN 32
+
+#include "profiler_v7.h"
+#include "profiler_v6.h"
 #include "profiler_v5.h"
 #include "profiler_v4.h"
 #include "profiler_v3.h"
@@ -79,8 +91,9 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v5_t;
 #include "profiler_v1.h"
 #include "profiler_net.h"
 
-typedef ncclProfiler_v5_t ncclProfiler_t;
-typedef ncclProfilerEventDescr_v5_t ncclProfilerEventDescr_t;
-typedef ncclProfilerEventStateArgs_v5_t ncclProfilerEventStateArgs_t;
+// Use v7 as default to support UserTag events
+typedef ncclProfiler_v7_t ncclProfiler_t;
+typedef ncclProfilerEventDescr_v7_t ncclProfilerEventDescr_t;
+typedef ncclProfilerEventStateArgs_v7_t ncclProfilerEventStateArgs_t;
 
 #endif // end include guard

--- a/plugins/profiler/inspector/nccl/profiler_v6.h
+++ b/plugins/profiler/inspector/nccl/profiler_v6.h
@@ -1,0 +1,148 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef PROFILER_V6_H_
+#define PROFILER_V6_H_
+
+#include "profiler_v5.h"
+
+// Extend v5 descriptor with CE-specific fields
+typedef struct {
+  uint64_t type;                // event type descriptor
+  void* parentObj;              // pointer to the profiler parent object
+  int rank;                     // originating rank
+  union {
+    // All v5 descriptors (groupApi, collApi, p2pApi, kernelLaunch, coll, p2p, proxyOp, proxyStep, kernelCh, netPlugin)
+    struct {
+      bool graphCaptured;
+      int groupDepth;
+    } groupApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      int root;
+      void* stream;
+      bool graphCaptured;
+    } collApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      void* stream;
+      bool graphCaptured;
+    } p2pApi;
+
+    struct {
+      void* stream;
+    } kernelLaunch;
+
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      uint8_t nChannels;
+      uint8_t nWarps;
+      const char* algo;
+      const char* proto;
+      void* parentGroup;
+    } coll;
+
+    struct {
+      const char* func;
+      void* buff;
+      const char* datatype;
+      size_t count;
+      int peer;
+      uint8_t nChannels;
+      void* parentGroup;
+    } p2p;
+
+    struct {
+      pid_t pid;
+      uint8_t channelId;
+      int peer;
+      int nSteps;
+      int chunkSize;
+      int isSend;
+    } proxyOp;
+
+    struct {
+      int step;
+    } proxyStep;
+
+    struct {
+      uint8_t channelId;
+      uint64_t pTimer;
+    } kernelCh;
+
+    struct {
+      int64_t id;
+      void* data;
+    } netPlugin;
+
+    // v6 CE-specific descriptors
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      const char* syncStrategy;
+      bool intraBatchSync;
+      uint32_t batchSize;
+      uint32_t numBatches;
+      uint32_t ceSeqNum;
+      void* stream;
+    } ceColl;
+
+    struct {
+      bool isComplete;
+      int nRanks;
+    } ceCollSync;
+
+    struct {
+      int numOps;
+      size_t totalBytes;
+      bool useIntraSync;
+    } ceCollBatch;
+  };
+} ncclProfilerEventDescr_v6_t;
+
+// v6 uses same state args as v5 (no CE-specific state args needed)
+// CE events don't use recordEventState - plugin manages all timing internally
+typedef ncclProfilerEventStateArgs_v5_t ncclProfilerEventStateArgs_v6_t;
+
+typedef struct {
+  const char* name;
+
+  // init - initialize the profiler plugin
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+
+  // startEvent - initialize and start a new event
+  ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v6_t* eDescr);
+
+  // stopEvent - stop/finalize an event
+  ncclResult_t (*stopEvent)(void* eHandle);
+
+  // recordEventState - record event state transitions and updates
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v6_t eState, ncclProfilerEventStateArgs_v6_t* eStateArgs);
+
+  // finalize - finalize the profiler plugin
+  ncclResult_t (*finalize)(void* context);
+} ncclProfiler_v6_t;
+
+#endif // PROFILER_V6_H_
+

--- a/plugins/profiler/inspector/nccl/profiler_v7.h
+++ b/plugins/profiler/inspector/nccl/profiler_v7.h
@@ -1,0 +1,151 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Poolside Inc & AFFILIATES
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef PROFILER_V7_H_
+#define PROFILER_V7_H_
+
+#include "profiler_v6.h"
+
+// Extend v6 descriptor with UserTag support
+typedef struct {
+  uint64_t type;                // event type descriptor
+  void* parentObj;              // pointer to the profiler parent object
+  int rank;                     // originating rank
+  union {
+    // All v6 descriptors
+    struct {
+      bool graphCaptured;
+      int groupDepth;
+    } groupApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      int root;
+      void* stream;
+      bool graphCaptured;
+    } collApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      void* stream;
+      bool graphCaptured;
+    } p2pApi;
+
+    struct {
+      void* stream;
+    } kernelLaunch;
+
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      uint8_t nChannels;
+      uint8_t nWarps;
+      const char* algo;
+      const char* proto;
+      void* parentGroup;
+    } coll;
+
+    struct {
+      const char* func;
+      void* buff;
+      const char* datatype;
+      size_t count;
+      int peer;
+      uint8_t nChannels;
+      void* parentGroup;
+    } p2p;
+
+    struct {
+      pid_t pid;
+      uint8_t channelId;
+      int peer;
+      int nSteps;
+      int chunkSize;
+      int isSend;
+    } proxyOp;
+
+    struct {
+      int step;
+    } proxyStep;
+
+    struct {
+      uint8_t channelId;
+      uint64_t pTimer;
+    } kernelCh;
+
+    struct {
+      int64_t id;
+      void* data;
+    } netPlugin;
+
+    // v6 CE-specific descriptors
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      const char* syncStrategy;
+      bool intraBatchSync;
+      uint32_t batchSize;
+      uint32_t numBatches;
+      uint32_t ceSeqNum;
+      void* stream;
+    } ceColl;
+
+    struct {
+      bool isComplete;
+      int nRanks;
+    } ceCollSync;
+
+    struct {
+      int numOps;
+      size_t totalBytes;
+      bool useIntraSync;
+    } ceCollBatch;
+
+    // v7 UserTag descriptor
+    struct {
+      const char* tag;  // Pointer valid only during startEvent/stopEvent
+    } userTag;
+  };
+} ncclProfilerEventDescr_v7_t;
+
+// v7 uses same state args as v6
+typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_v7_t;
+
+typedef struct {
+  const char* name;
+
+  // init - initialize the profiler plugin
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+
+  // startEvent - initialize and start a new event
+  ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v7_t* eDescr);
+
+  // stopEvent - stop/finalize an event
+  ncclResult_t (*stopEvent)(void* eHandle);
+
+  // recordEventState - record event state transitions and updates
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v7_t eState, ncclProfilerEventStateArgs_v7_t* eStateArgs);
+
+  // finalize - finalize the profiler plugin
+  ncclResult_t (*finalize)(void* context);
+} ncclProfiler_v7_t;
+
+#endif // PROFILER_V7_H_

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ INCEXPORTS  := nccl.h nccl_device.h \
 
 LIBSRCFILES := \
 	bootstrap.cc channel.cc collectives.cc debug.cc enqueue.cc group.cc \
-	init.cc proxy.cc transport.cc mnnvl.cc allocator.cc dev_runtime.cc sym_kernels.cc ce_coll.cc mem_manager.cc \
+	init.cc notify.cc proxy.cc transport.cc mnnvl.cc allocator.cc dev_runtime.cc sym_kernels.cc ce_coll.cc mem_manager.cc \
 	$(wildcard graph/*.cc) \
 	$(wildcard misc/*.cc) \
 	$(wildcard transport/*.cc) \

--- a/src/include/plugin/nccl_profiler.h
+++ b/src/include/plugin/nccl_profiler.h
@@ -25,6 +25,8 @@ enum {
   ncclProfileCeColl         = (1 << 12), // CE collective operation
   ncclProfileCeSync         = (1 << 13), // CE synchronization operation
   ncclProfileCeBatch        = (1 << 14), // CE batch operation
+  // User-defined tag events (v7)
+  ncclProfileUserTag        = (1 << 15), // User-defined tag annotation
 };
 
 typedef enum {
@@ -79,8 +81,13 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v3_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v4_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v5_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
+typedef ncclProfilerEventState_t ncclProfilerEventState_v7_t;
 
 #include <cstdint>
+
+#define NCCL_TAG_MAX_LEN 32
+
+#include "profiler/profiler_v7.h"
 #include "profiler/profiler_v6.h"
 #include "profiler/profiler_v5.h"
 #include "profiler/profiler_v4.h"
@@ -88,11 +95,11 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
 #include "profiler/profiler_v2.h"
 #include "profiler/profiler_v1.h"
 
-// Use v6 as default to support CE events
-// v5 and earlier versions are still supported for backward compatibility
-typedef ncclProfiler_v6_t ncclProfiler_t;
-typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_t;
-typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_t;
+// Use v7 as default to support UserTag events
+// v6 and earlier versions are still supported for backward compatibility
+typedef ncclProfiler_v7_t ncclProfiler_t;
+typedef ncclProfilerEventDescr_v7_t ncclProfilerEventDescr_t;
+typedef ncclProfilerEventStateArgs_v7_t ncclProfilerEventStateArgs_t;
 
 #define NCCL_PROFILER_NET_VER_BITS  (16)
 #define NCCL_PROFILER_NET_VER_MASK  (~0U >> NCCL_PROFILER_NET_VER_BITS)

--- a/src/include/plugin/profiler/profiler_v7.h
+++ b/src/include/plugin/profiler/profiler_v7.h
@@ -1,0 +1,151 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Poolside Inc & AFFILIATES
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef PROFILER_V7_H_
+#define PROFILER_V7_H_
+
+#include "profiler_v6.h"
+
+// Extend v6 descriptor with UserTag support
+typedef struct {
+  uint64_t type;                // event type descriptor
+  void* parentObj;              // pointer to the profiler parent object
+  int rank;                     // originating rank
+  union {
+    // All v6 descriptors
+    struct {
+      bool graphCaptured;
+      int groupDepth;
+    } groupApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      int root;
+      void* stream;
+      bool graphCaptured;
+    } collApi;
+
+    struct {
+      const char* func;
+      size_t count;
+      const char* datatype;
+      void* stream;
+      bool graphCaptured;
+    } p2pApi;
+
+    struct {
+      void* stream;
+    } kernelLaunch;
+
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      uint8_t nChannels;
+      uint8_t nWarps;
+      const char* algo;
+      const char* proto;
+      void* parentGroup;
+    } coll;
+
+    struct {
+      const char* func;
+      void* buff;
+      const char* datatype;
+      size_t count;
+      int peer;
+      uint8_t nChannels;
+      void* parentGroup;
+    } p2p;
+
+    struct {
+      pid_t pid;
+      uint8_t channelId;
+      int peer;
+      int nSteps;
+      int chunkSize;
+      int isSend;
+    } proxyOp;
+
+    struct {
+      int step;
+    } proxyStep;
+
+    struct {
+      uint8_t channelId;
+      uint64_t pTimer;
+    } kernelCh;
+
+    struct {
+      int64_t id;
+      void* data;
+    } netPlugin;
+
+    // v6 CE-specific descriptors
+    struct {
+      uint64_t seqNumber;
+      const char* func;
+      void const* sendBuff;
+      void* recvBuff;
+      size_t count;
+      int root;
+      const char* datatype;
+      const char* syncStrategy;
+      bool intraBatchSync;
+      uint32_t batchSize;
+      uint32_t numBatches;
+      uint32_t ceSeqNum;
+      void* stream;
+    } ceColl;
+
+    struct {
+      bool isComplete;
+      int nRanks;
+    } ceCollSync;
+
+    struct {
+      int numOps;
+      size_t totalBytes;
+      bool useIntraSync;
+    } ceCollBatch;
+
+    // v7 UserTag descriptor
+    struct {
+      const char* tag;  // Pointer valid only during startEvent/stopEvent
+    } userTag;
+  };
+} ncclProfilerEventDescr_v7_t;
+
+// v7 uses same state args as v6
+typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_v7_t;
+
+typedef struct {
+  const char* name;
+
+  // init - initialize the profiler plugin
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+
+  // startEvent - initialize and start a new event
+  ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v7_t* eDescr);
+
+  // stopEvent - stop/finalize an event
+  ncclResult_t (*stopEvent)(void* eHandle);
+
+  // recordEventState - record event state transitions and updates
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v7_t eState, ncclProfilerEventStateArgs_v7_t* eStateArgs);
+
+  // finalize - finalize the profiler plugin
+  ncclResult_t (*finalize)(void* context);
+} ncclProfiler_v7_t;
+
+#endif // PROFILER_V7_H_

--- a/src/include/profiler.h
+++ b/src/include/profiler.h
@@ -125,4 +125,7 @@ ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHand
 ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, struct ncclCeBatchOpsParams* params, cudaStream_t stream, void** ceBatchHandle);
 ncclResult_t ncclProfilerStopCeBatchEvent(struct ncclComm* comm, void* ceBatchHandle, cudaStream_t stream);
 
+// UserTag event
+ncclResult_t ncclProfilerUserTagEvent(struct ncclComm* comm, const char* tag);
+
 #endif

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -731,6 +731,17 @@ ncclResult_t pncclGroupEnd();
 ncclResult_t  ncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 ncclResult_t pncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 
+/*
+ * User-defined tag annotation for profiler plugins.
+ *
+ * Notifies the profiler plugin of a user-defined tag string.
+ * The tag is delivered to the profiler plugin via a start/stop event pair.
+ * The tag pointer must remain valid for the duration of the call.
+ * Maximum tag length is 32 bytes including null terminator (NCCL_TAG_MAX_LEN).
+ */
+ncclResult_t  ncclNotifyTag(const char* tag, ncclComm_t comm, cudaStream_t stream);
+ncclResult_t pncclNotifyTag(const char* tag, ncclComm_t comm, cudaStream_t stream);
+
 #ifdef __cplusplus
 } // end extern "C"
 #endif

--- a/src/notify.cc
+++ b/src/notify.cc
@@ -1,0 +1,19 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Poolside Inc & AFFILIATES
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "nccl.h"
+#include "checks.h"
+#include "comm.h"
+#include "profiler.h"
+
+NCCL_API(ncclResult_t, ncclNotifyTag, const char* tag, ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclNotifyTag(const char* tag, ncclComm_t comm, cudaStream_t stream) {
+  if (comm == NULL) return ncclInvalidArgument;
+  if (tag == NULL) return ncclInvalidArgument;
+  NCCLCHECK(ncclProfilerUserTagEvent(comm, tag));
+  return ncclSuccess;
+}

--- a/src/plugin/profiler.cc
+++ b/src/plugin/profiler.cc
@@ -24,6 +24,7 @@ extern ncclProfiler_t* getNcclProfiler_v3(void* lib);
 extern ncclProfiler_t* getNcclProfiler_v4(void* lib);
 extern ncclProfiler_t* getNcclProfiler_v5(void* lib);
 extern ncclProfiler_t* getNcclProfiler_v6(void* lib);
+extern ncclProfiler_t* getNcclProfiler_v7(void* lib);
 
 static std::mutex profilerMutex;
 static int profilerPluginRefCount;
@@ -71,7 +72,10 @@ static ncclResult_t ncclProfilerPluginLoad(void) {
     profilerName = ncclPluginLibPaths[ncclPluginTypeProfiler];
   }
 
-  ncclProfiler = getNcclProfiler_v6(profilerPluginLib);
+  ncclProfiler = getNcclProfiler_v7(profilerPluginLib);
+  if (ncclProfiler == nullptr) {
+    ncclProfiler = getNcclProfiler_v6(profilerPluginLib);
+  }
   if (ncclProfiler == nullptr) {
     ncclProfiler = getNcclProfiler_v5(profilerPluginLib);
   }
@@ -875,6 +879,28 @@ ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm,
 ncclResult_t ncclProfilerStopCeBatchEvent(struct ncclComm* comm, void* ceBatchHandle, cudaStream_t stream) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && ceBatchHandle) {
     ncclProfiler->stopEvent(ceBatchHandle);
+  }
+  return ncclSuccess;
+}
+
+// ============================================================================
+// UserTag Profiler Function
+// ============================================================================
+
+ncclResult_t ncclProfilerUserTagEvent(struct ncclComm* comm, const char* tag) {
+  if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
+    int eActivationMask = COMPILER_ATOMIC_LOAD(&ncclProfilerEventMask, std::memory_order_relaxed);
+    if (eActivationMask & ncclProfileUserTag) {
+      ncclProfilerEventDescr_t eDescr = { 0 };
+      eDescr.type = ncclProfileUserTag;
+      eDescr.rank = comm->rank;
+      eDescr.userTag.tag = tag;
+      void* eHandle = NULL;
+      ncclProfiler->startEvent(comm->profilerContext, &eHandle, &eDescr);
+      if (eHandle) {
+        ncclProfiler->stopEvent(eHandle);
+      }
+    }
   }
   return ncclSuccess;
 }

--- a/src/plugin/profiler/profiler_v6.cc
+++ b/src/plugin/profiler/profiler_v6.cc
@@ -12,13 +12,40 @@
 #include <dlfcn.h>
 
 static ncclProfiler_v6_t* ncclProfiler_v6;
+static ncclProfiler_t ncclProfiler;
+
+static ncclResult_t ncclProfiler_startEvent(void* ctx, void** eHandle, ncclProfilerEventDescr_t* eDescr) {
+  // Discard v7 UserTag events - not supported in v6
+  if (eDescr->type == ncclProfileUserTag) {
+    *eHandle = NULL;
+    return ncclSuccess;
+  }
+  // v6 and v7 descriptors are layout-compatible for all non-UserTag events
+  return ncclProfiler_v6->startEvent(ctx, eHandle, (ncclProfilerEventDescr_v6_t*)eDescr);
+}
+
+static ncclResult_t ncclProfiler_init(void** ctx, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nRanks, int rank, ncclDebugLogger_t logfn) {
+  NCCLCHECK(ncclProfiler_v6->init(ctx, commId, eActivationMask, commName, nNodes, nRanks, rank, logfn));
+
+  // Clear v7 UserTag bit from activation mask since v6 doesn't support it
+  if (eActivationMask) {
+    *eActivationMask &= ~ncclProfileUserTag;
+  }
+
+  ncclProfiler.startEvent = ncclProfiler_startEvent;
+  ncclProfiler.recordEventState = ncclProfiler_v6->recordEventState;
+  ncclProfiler.stopEvent = ncclProfiler_v6->stopEvent;
+  ncclProfiler.finalize = ncclProfiler_v6->finalize;
+  return ncclSuccess;
+}
 
 ncclProfiler_t* getNcclProfiler_v6(void* lib) {
   ncclProfiler_v6 = (ncclProfiler_v6_t*)dlsym(lib, "ncclProfiler_v6");
   if (ncclProfiler_v6) {
+    ncclProfiler.name = ncclProfiler_v6->name;
+    ncclProfiler.init = ncclProfiler_init;
     INFO(NCCL_INIT, "PROFILER/Plugin: Loaded %s (v6)", ncclProfiler_v6->name);
-    return ncclProfiler_v6;
+    return &ncclProfiler;
   }
   return NULL;
 }
-

--- a/src/plugin/profiler/profiler_v7.cc
+++ b/src/plugin/profiler/profiler_v7.cc
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Poolside Inc & AFFILIATES
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "comm.h"
+#include "nccl_profiler.h"
+#include "plugin/profiler/profiler_v7.h"
+#include "checks.h"
+#include <dlfcn.h>
+
+static ncclProfiler_v7_t* ncclProfiler_v7;
+
+ncclProfiler_t* getNcclProfiler_v7(void* lib) {
+  ncclProfiler_v7 = (ncclProfiler_v7_t*)dlsym(lib, "ncclProfiler_v7");
+  if (ncclProfiler_v7) {
+    INFO(NCCL_INIT, "PROFILER/Plugin: Loaded %s (v7)", ncclProfiler_v7->name);
+    return ncclProfiler_v7;
+  }
+  return NULL;
+}


### PR DESCRIPTION
# Add ncclNotifyTag API for user-defined profiler annotations (v7)

## Motivation

Training frameworks (PyTorch, Megatron, etc.) need a way to correlate NCCL
collective performance with application-level phases -- forward pass, backward
pass, optimizer step, data loading, etc. Today, profiler plugins see a flat
stream of collectives with no application context.

`ncclNotifyTag` lets users inject lightweight string annotations into the
profiler event stream. Plugins can then attribute bandwidth/latency metrics
to specific training phases, enabling:

- Per-phase collective performance dashboards (Prometheus/Grafana)
- Training step boundaries in Chrome traces
- Straggler detection scoped to specific communication patterns

## Original feature request
- https://github.com/NVIDIA/nccl/issues/1916

## API

```c
ncclResult_t ncclNotifyTag(const char* tag, ncclComm_t comm, cudaStream_t stream);
```

- `tag`: null-terminated string, max 32 bytes including terminator (NCCL_TAG_MAX_LEN)
- `comm`: communicator to annotate
- `stream`: unused (reserved for future use)
- Returns `ncclInvalidArgument` if `tag` or `comm` is NULL

The call is synchronous and lightweight -- no CUDA operations, no allocations.

## Usage example

```c
// Annotate training phases for profiler plugins
ncclNotifyTag("forward", comm, stream);
ncclAllReduce(sbuf, rbuf, N, ncclFloat, ncclSum, comm, stream);

ncclNotifyTag("backward", comm, stream);
ncclAllReduce(sbuf, rbuf, N, ncclFloat, ncclSum, comm, stream);
```

## Design

### Profiler plugin API v7

Extends v6 with a new event type `ncclProfileUserTag = (1 << 15)` and a new
descriptor field:

```c
struct {
  const char* tag;  // pointer valid only during startEvent/stopEvent
} userTag;
```

NCCL core delivers UserTag as a start/stop event pair. The tag pointer is valid
only for the duration of the call -- plugins must copy the string if they need
to retain it. NCCL core does zero string copying itself.

Backward compatibility: v6 and earlier plugins receive a v7 shim that filters
out UserTag events and clears the UserTag activation bit. No changes needed
in existing plugins.

### Plugin version chain

```
ncclProfiler_v7 (native)
  -> ncclProfiler_v6 (shim: filters UserTag events)
    -> ncclProfiler_v5 (shim: filters UserTag + CE events)
      -> v4 -> v3 -> v2 -> v1
```

### Example plugin (plugins/profiler/example/)

Records UserTag as Chrome trace instant events:
```json
{"name": "UserTag", "cat": "USER_TAG", "ph": "i", "s": "g",
 "args": {"tag": "forward", "rank": 0}}
```

Uses pool-based allocation (default pool size: 8, configurable via
`NCCL_PROFILE_USER_TAG_POOL_SIZE`).

### Inspector plugin (plugins/profiler/inspector/)

Captures the active tag per communicator at collective insertion time (not
completion time) for deterministic attribution. The tag appears in:

- JSON output: `"user_tag": "forward"` in `coll_perf` records
- Prometheus output: `user_tag="forward"` label on metrics

No lock needed for tag capture -- both UserTag and collective startEvent run
on the same NCCL submission thread, serialized per communicator.

## Testing 

Dockerized integration test with 13 test cases (not included in this PR):

- **Example plugin (6 tests)**: epoch tags, rapid fire (pool exhaustion),
  long tag truncation, empty tag, NULL comm, NULL tag
- **Inspector JSON (6 tests)**: same scenarios, validates `user_tag` in JSON
- **Inspector Prometheus (1 test)**: sustained collectives for 35s, validates
  `user_tag` label in .prom output

All tests pass on H200 with CUDA 13.0.

