### PR TITLE
Fix: Correct inverted boolean logic in matchSubnet causing incorrect interface selection

### DIFF
--- a/src/os/linux.cc
+++ b/src/os/linux.cc
@@ -380,7 +380,7 @@ static bool matchSubnet(struct ifaddrs local_if, union ncclSocketAddress* remote
     struct in_addr local_subnet, remote_subnet;
     local_subnet.s_addr = local_addr->sin_addr.s_addr & mask->sin_addr.s_addr;
     remote_subnet.s_addr = remote_addr.sin_addr.s_addr & mask->sin_addr.s_addr;
-    return (local_subnet.s_addr == remote_subnet.s_addr) ? false : true;
+    return (local_subnet.s_addr == remote_subnet.s_addr) ? true : false;
   } else if (family == AF_INET6) {
     struct sockaddr_in6* local_addr = (struct sockaddr_in6*)(local_if.ifa_addr);
     struct sockaddr_in6* mask = (struct sockaddr_in6*)(local_if.ifa_netmask);

--- a/src/os/linux.cc
+++ b/src/os/linux.cc
@@ -380,7 +380,7 @@ static bool matchSubnet(struct ifaddrs local_if, union ncclSocketAddress* remote
     struct in_addr local_subnet, remote_subnet;
     local_subnet.s_addr = local_addr->sin_addr.s_addr & mask->sin_addr.s_addr;
     remote_subnet.s_addr = remote_addr.sin_addr.s_addr & mask->sin_addr.s_addr;
-    return (local_subnet.s_addr == remote_subnet.s_addr) ? true : false;
+    return (local_subnet.s_addr == remote_subnet.s_addr);
   } else if (family == AF_INET6) {
     struct sockaddr_in6* local_addr = (struct sockaddr_in6*)(local_if.ifa_addr);
     struct sockaddr_in6* mask = (struct sockaddr_in6*)(local_if.ifa_netmask);


### PR DESCRIPTION

**Description**
This PR fixes a logic error in the `matchSubnet` function within `src/os/linux.cc`. The boolean return value for IPv4 subnet matching was inverted, which caused NCCL to erroneously reject the correct network interface and bind to the wrong one (typically the loopback interface `lo`) during bootstrap interface selection.

**Root Cause Analysis**
In the IPv4 branch, the code computes local_subnet and remote_subnet as (addr & netmask) and then returns:
```cpp
return (local_subnet.s_addr == remote_subnet.s_addr) ? false : true;
```
This inverts the intended meaning:
* subnets match → returns `false`
* subnets differ → returns `true`

**Impact**
When a user specifies `NCCL_COMM_ID` (e.g., `NCCL_COMM_ID=172.17.16.2:12340`), NCCL iterates through the local interfaces using `getifaddrs()` to find a matching subnet. Due to this bug:
1. The correct interface (e.g., eth0 with 172.17.16.2/20) is rejected because matching subnets return false.
2. A non-matching interface such as loopback (lo with 127.0.0.1/8) can be accepted because differing subnets return true.

This results in the bootstrap network binding to `lo` (as seen in the logs: `NCCL INFO Bootstrap: Using lo:127.0.0.1<0>`), completely breaking multi-node communication.

**The Fix**
Return `true` when the computed subnets match:
```cpp
return (local_subnet.s_addr == remote_subnet.s_addr) ? true : false;
```
*(Note: Equivalent to `return local_subnet.s_addr == remote_subnet.s_addr;`, but I kept the original code style).*

**How to reproduce / Verification**
1. Set `NCCL_COMM_ID` to an IP address in the same subnet as `eth0`.
2. Run an NCCL test with `NCCL_DEBUG=INFO`.
3. **Before this PR:** The log shows `Bootstrap: Using lo:127.0.0.1<0>`.
4. **After this PR:** The log correctly shows `Bootstrap: Using eth0:172.17.16.2<0>`.


------------------------


Here is the simple test.

```
#include <stdio.h>
#include <stdlib.h>
#include <nccl.h>
#include <cuda_runtime.h>

int main(int argc, char* argv[]) {
    if (argc != 3) {
        fprintf(stderr, "Usage: %s <rank> <nranks>\n", argv[0]);
        return EXIT_FAILURE;
    }

    int rank = atoi(argv[1]);
    int nranks = atoi(argv[2]);
    cudaSetDevice(0);

    ncclUniqueId id;
    ncclGetUniqueId(&id);

    ncclComm_t comm;
    printf("Rank %d/%d initializing NCCL...\n", rank, nranks);
    ncclCommInitRank(&comm, nranks, id, rank);
    printf("Rank %d NCCL initialization successful!\n", rank);

    ncclCommDestroy(comm);
    return 0;
}
```

**Before fix:**

```
ubuntu@VM-16-2-ubuntu:~/tmp$ NCCL_SOCKET_IFNAME=eth0 NCCL_COMM_ID=172.17.16.2:12340 NCCL_DEBUG=INFO ./a.out 0 2
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO ENV/Plugin: Could not find: libnccl-env.so  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO Bootstrap: Using lo:127.0.0.1<0>  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NCCL_COMM_ID set by environment to 172.17.16.2:12340  
Rank 0/2 initializing NCCL...  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO cudaDriverVersion 12080  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NCCL version 2.29.2+cuda12.8  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NCCL git version unknown unknown  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NCCL_COMM_ID set by environment to 172.17.16.2:12340  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NET/Plugin: Could not find: libnccl-net.so  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO Failed to open libibverbs.so[.1]  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO transport/net_ib/init.cc:370 -> 3  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO Failed to initialize NET plugin IB  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NCCL_SOCKET_IFNAME set by environment to eth0  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO NET/Socket : Using [0]eth0:172.17.16.2<0>  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO Initialized NET plugin Socket  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO Assigned NET plugin Socket to comm  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO Using network Socket  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO [Rank 0] ncclCommInitRank comm 0x55913df16380 rank 0 nranks 2 cudaDev 0 nvmlDev 0 busId 80 commId 0xa3f68e0e3a1c36c0 - Init START  
VM-16-2-ubuntu:6682:6688 [0] NCCL INFO ncclOsSocketStartConnect: connect to 127.0.0.1<52243> returned Connection refused, retrying (1/34) after sleep for 100 msec  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO ncclOsSocketPollConnect: connect to 127.0.0.1<56395> returned Connection refused, retrying (1/34) after sleep for 100 msec  
VM-16-2-ubuntu:6682:6682 [0] NCCL INFO ncclOsSocketPollConnect: connect to 127.0.0.1<56395> returned Connection refused, retrying (2/34) after sleep for 200 msec
...
```

**After fix:**

```
ubuntu@VM-16-2-ubuntu:~/tmp$ NCCL_SOCKET_IFNAME=eth0 NCCL_COMM_ID=172.17.16.2:12340 NCCL_DEBUG=INFO ./a.out 0 2
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO ENV/Plugin: Could not find: libnccl-env.so
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Bootstrap: env 172.17.16.2:12340
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Bootstrap: Using eth0:172.17.16.2<0>
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NCCL_COMM_ID set by environment to 172.17.16.2:12340
Rank 0/2 initializing NCCL...
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO cudaDriverVersion 12080
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NCCL version 2.29.2+cuda12.8
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NCCL git version unknown unknown
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NCCL_COMM_ID set by environment to 172.17.16.2:12340
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NET/Plugin: Could not find: libnccl-net.so
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Failed to open libibverbs.so[.1]
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO transport/net_ib/init.cc:370 -> 3
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Failed to initialize NET plugin IB
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NCCL_SOCKET_IFNAME set by environment to eth0
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NET/Socket : Using [0]eth0:172.17.16.2<0>
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Initialized NET plugin Socket
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Assigned NET plugin Socket to comm
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Using network Socket
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO [Rank 0] ncclCommInitRank comm 0x5604629723e0 rank 0 nranks 2 cudaDev 0 nvmlDev 0 busId 80 commId 0x4013a4c1447ce9af - Init START
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO RAS client listening socket at 127.0.0.1<28028>
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Bootstrap timings total 81.611555 (create 0.000037, send 0.000108, recv 81.610464, ring 0.000113, delay 0.000000)
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO NCCL_TOPO_DUMP_FILE set by environment to a.xml
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO ncclTopoGetCpuAffinity: Affinity for GPU 0 is empty, ignoring. (GPU affinity =  ; CPU affinity = 0-9).
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO comm 0x5604629723e0 rank 0 nRanks 2 nNodes 2 localRanks 1 localRank 0 MNNVL 0
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Channel 00/02 : 0 1
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Channel 01/02 : 0 1
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Trees [0] 1/-1/-1->0->-1 [1] -1/-1/-1->0->1
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO P2P Chunksize set to 131072
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO PROFILER/Plugin: Could not find: libnccl-profiler.so
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Check P2P Type isAllDirectP2p 1 directMode 0 isAllCudaP2p 1
VM-16-2-ubuntu:20184:20620 [0] NCCL INFO [Proxy Service] Device 0 CPU core 0
VM-16-2-ubuntu:20184:20621 [0] NCCL INFO [Proxy Service UDS] Device 0 CPU core 2
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO TUNER/Plugin: Could not find: libnccl-tuner.so
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO threadThresholds 8/8/64 | 16/8/64 | 512 | 512
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO 2 coll channels, 2 collnet channels, 0 nvls channels, 2 p2p channels, 1 p2p channels per peer
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Symmetric memory is not supported. cuMemEnable 1, ginSupport 0, globalNicFused 1
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO CC Off, workFifoBytes 1048576
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO ncclCommInitRank comm 0x5604629723e0 rank 0 nranks 2 cudaDev 0 nvmlDev 0 busId 80 commId 0x4013a4c1447ce9af - Init COMPLETE
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO Init timings - ncclCommInitRank: rank 0 nranks 2 total 81.81 (kernels 0.17, alloc 0.02, bootstrap 81.61, allgathers 0.00, topo 0.01, graphs 0.00, connections 0.00, rest 0.00)
Rank 0 NCCL initialization successful!
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO comm 0x5604629723e0 rank 0 nranks 2 cudaDev 0 busId 80 - Destroy COMPLETE
VM-16-2-ubuntu:20184:20184 [0] NCCL INFO ENV/Plugin: Closing env plugin ncclEnvDefault
```