### PR TITLE
Fix nccl_ep cuda shim to only get used for CUDA version below 13.1

### DIFF
--- a/contrib/nccl_ep/device/cuda_compat_shims.cuh
+++ b/contrib/nccl_ep/device/cuda_compat_shims.cuh
@@ -28,7 +28,9 @@
 #include <cuda/ptx>
 
 // Only provide shims for CUDA versions that need them
-#if !defined(__CUDACC_VER_MAJOR__) || (__CUDACC_VER_MAJOR__ < 13)
+#if !defined(__CUDACC_VER_MAJOR__) || (__CUDACC_VER_MAJOR__ < 13) || \
+  ((__CUDACC_VER_MAJOR__ == 13) &&                                   \
+   (!defined(__CUDACC_VER_MINOR__) || (__CUDACC_VER_MINOR__ < 1)))
 
 namespace cuda { namespace ptx {
 


### PR DESCRIPTION
## Description

Fix the preprocessor directive for CUDA compat shims in nccl_ep so shims are enabled for CUDA < 13.1 and disabled for 13.1+

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

