### PR TITLE
graph/tuning: disable LL128 on PATH_P2C inter-node paths (GH200 corruption fix)

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -481,8 +481,15 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
     if (pEnable == 2 && p == NCCL_PROTO_LL128) {
       pEnable = 1;
       if (ncclParamLl128C2c() && minCompCap >= 90) {
-        // Enable LL128 by default only on Hopper/Blackwell for all connections up to P2C and PXN.
-        pEnable &= (graphs[a]->typeInter <= PATH_PXN);
+        // Enable LL128 on Hopper/Blackwell for PXN inter-node paths (e.g. NVLink switch
+        // fabrics) where write ordering is guaranteed. Explicitly exclude PATH_P2C even
+        // though P2C < PXN: on GH200 the NIC writes to GPU HBM via PCIe->NVLink-C2C and
+        // PCIe posted writes through the C2C interconnect do not guarantee sequential
+        // visibility at 128-byte granularity, so the LL128 flag (last 8B of a 128B chunk)
+        // can become visible to the GPU before the preceding data bytes, causing corruption.
+        pEnable &= (graphs[a]->typeInter <= PATH_PXB || graphs[a]->typeInter == PATH_PXN);
+        if (graphs[a]->typeInter == PATH_P2C)
+          INFO(NCCL_GRAPH, "Disabling LL128 over P2C inter-node path: NIC->GPU writes via PCIe->NVLink-C2C do not guarantee 128-byte write ordering required by LL128.");
       } else {
         // Enable LL128 only up to PXB. Don't enable LL128 over PxN because PxN can encapsulate PxB or P2C links.
         pEnable &= (graphs[a]->typeInter <= PATH_PXB);


### PR DESCRIPTION
On GH200 (Grace Hopper), the inter-node NIC->GPU receive path is classified as PATH_P2C (PCIe->NVLink-C2C).  LL128 requires that when the receiver observes the flag at the end of a 128-byte chunk, all preceding bytes in that chunk are already visible in GPU memory.  That ordering guarantee is not met on GH200: the NIC writes directly into GPU HBM via PCIe->NVLink-C2C, and the two 64-byte halves of the 128-byte chunk can become visible to the GPU independently.  If the flag half (last 8 bytes) becomes visible before the data half, the consumer reads stale or incomplete data, resulting in silent corruption.

Previously the condition to enable LL128 on Hopper/Blackwell was:

  typeInter <= PATH_PXN

This included PATH_P2C because numerically P2C < PXN.  The fix changes the condition to:

  typeInter <= PATH_PXB || typeInter == PATH_PXN

which explicitly excludes PATH_P2C.  LL128 remains enabled for NVLink-switch fabrics (PATH_PXN) and closer intra-node paths where the ordering guarantees hold.  LL and Simple are unaffected and were verified clean on GH200.

Verified:
  NCCL_PROTO=Simple  - clean
  NCCL_PROTO=LL      - clean
  NCCL_PROTO=LL128   - corrupt (fixed by this change)
  NCCL_LL128_C2C=0   - clean (env-var workaround, superseded by this fix)

## Description

  graph/tuning: disable LL128 on PATH_P2C inter-node paths (GH200 corruption fix)

  On GH200 (Grace Hopper), the NIC->GPU receive path is classified as PATH_P2C (PCIe->NVLink->C2C). NCCL's LL128 protocol requires that when the receiver sees the flag byte at
  the end of a 128-byte chunk, all preceding data in that chunk is already visible in GPU memory. That guarantee does not hold on GH200: the two 64-byte halves of the chunk
  can become visible independently across the PCIe->C2C boundary, causing silent data corruption.

  Root cause: the previous condition typeInter <= PATH_PXN inadvertently included PATH_P2C (numerically P2C < PXN).

  Fix: change the condition to typeInter <= PATH_PXB || typeInter == PATH_PXN, explicitly excluding PATH_P2C. LL128 stays enabled for NVLink-switch fabrics and tighter intra-node paths. LL and Simple are unaffected.

  Verified clean on GH200: with SIMPLE,LL,LL128 protocols.

Reference any related issues or PRs:

https://github.com/NVIDIA/nccl/issues/2001

## Performance Impact

N/A