### PR TITLE
fix(profiler): handle u8 for inspector

### DIFF
--- a/plugins/profiler/inspector/inspector.cc
+++ b/plugins/profiler/inspector/inspector.cc
@@ -172,6 +172,7 @@ inspectorResult_t inspectorGetTimeUTC(char* buffer, size_t bufferSize) {
  */
 ncclDataType_t inspectorStringToDatatype(const char* str) {
   if (strcmp(str, "ncclInt8") == 0) return ncclInt8;
+  if (strcmp(str, "ncclUint8") == 0) return ncclUint8;
   if (strcmp(str, "ncclInt32") == 0) return ncclInt32;
   if (strcmp(str, "ncclUint32") == 0) return ncclUint32;
   if (strcmp(str, "ncclInt64") == 0) return ncclInt64;

--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -45,6 +45,7 @@ const char* ncclDevRedOpToString(ncclDevRedOp_t op) {
 const char* ncclDatatypeToString(ncclDataType_t type) {
   switch (type) {
   case ncclInt8: return "ncclInt8";
+  case ncclUint8: return "ncclUint8";
   case ncclInt32: return "ncclInt32";
   case ncclUint32: return "ncclUint32";
   case ncclInt64: return "ncclInt64";

--- a/src/plugin/profiler/profiler_v1.cc
+++ b/src/plugin/profiler/profiler_v1.cc
@@ -42,6 +42,7 @@ static uint8_t ncclStringToProto(const char* proto) {
 
 static uint8_t ncclStringToDatatype(const char* dt) {
   if (0 == strcmp(dt, "ncclInt8")) return ncclInt8;
+  if (0 == strcmp(dt, "ncclUint8")) return ncclUint8;
   if (0 == strcmp(dt, "ncclInt32")) return ncclInt32;
   if (0 == strcmp(dt, "ncclUint32")) return ncclUint32;
   if (0 == strcmp(dt, "ncclInt64")) return ncclInt64;


### PR DESCRIPTION
## Description

current behaviour causes it to underflow collInfoPtr->msgSizeBytes, since "Unknown" returns -1. Wondering if this is a good default behaviour? I guess it's very alerting.

## Related Issues

n/a

## Changes & Impact

n/a
## Performance Impact

n/a