### PR TITLE
Fix /dev/shm/nccl-K error.

### DIFF
--- a/src/transport/shm.cc
+++ b/src/transport/shm.cc
@@ -631,6 +631,10 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, 
     if (dptr) *dptr = (void *)hostptr;
     INFO(NCCL_SHM, "CUMEM imported shareable host buffer from proxyRank %d size %zi ptr %p, granularity %ld", proxyRank, desc->shmci.size, descOut->shmci.ptr, granularity);
   } else {
+    if (! desc->legacy) {
+      WARN("Invalid SHM - received CUMEM while expecting MMAP. This can happen with memoryless NUMA domains. Set NCCL_CUMEM_HOST_ENABLE=0.");
+      return ncclInternalError;
+    }
     char shmPath[SHM_PATH_MAX];
     snprintf(shmPath, sizeof(shmPath), "/dev/shm/nccl-%s", desc->shmli.shmSuffix);
     NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), desc->shmli.shmSize, hptr, dptr, -1, &descOut->shmli.handle));


### PR DESCRIPTION
## Description

With memoryless NUMA domains (e.g. if you don't populate all of the memory channels on an EPYC CPU), NCCL IPC has a type confusion that results in this error:
```
[rank1]: Error while attaching to shared memory segment /dev/shm/nccl-Ќ (size 0), error: No such file or directory (2)
```

This happens with memoryless NUMA domains, which would cause the received cuMem SHM descriptor union to be interpreted as a /dev/shm file path. This PR checks the union tag and turns it into a clear warning.

## Related Issues

I have a more detailed writeup here: https://github.com/pytorch/pytorch/issues/152302#issuecomment-4094534698

## Changes & Impact

N/A

## Performance Impact

N/A
