### PR TITLE
Enable mem offload for channel device allocations during suspend

### DIFF
--- a/src/channel.cc
+++ b/src/channel.cc
@@ -40,10 +40,10 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   if (channel->devPeers == NULL) {
     if (sharedRes->devPeers[channelId] == NULL) {
-      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream, comm->memManager));
+      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream, comm->memManager, ncclMemOffload));
     }
     /* channel->devPeers is not shared, so just free it when calling commFree() */
-    NCCLCHECK(ncclCudaCallocAsync(&channel->devPeers, nPeers, deviceStream, comm->memManager));
+    NCCLCHECK(ncclCudaCallocAsync(&channel->devPeers, nPeers, deviceStream, comm->memManager, ncclMemOffload));
     ncclCommPushCudaFree(comm, channel->devPeers);
     NCCLCHECK(ncclCalloc(&channel->devPeersHostPtr, nPeers));
     for (int r = 0; r < nRanks; r++) {
@@ -55,7 +55,7 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   channel->ring.userRanks = ncclMemoryStackAlloc<int>(&comm->memPermanent, nRanks);
   channel->ring.rankToIndex = ncclMemoryStackAlloc<int>(&comm->memPermanent, nRanks);
-  NCCLCHECK(ncclCudaCallocAsync(&channel->devRingUserRanks, nRanks, deviceStream, comm->memManager));
+  NCCLCHECK(ncclCudaCallocAsync(&channel->devRingUserRanks, nRanks, deviceStream, comm->memManager, ncclMemOffload));
   ncclCommPushCudaFree(comm, channel->devRingUserRanks);
 
   /* guarantee addr has been copied into channel->devPeers */


### PR DESCRIPTION
## Summary

This PR extends the suspend path by enabling `ncclMemOffload` for channel-related device allocations in `initChannel()`, including:

- shared `devPeers`
- per-channel `devPeers`
- `devRingUserRanks`

This is a small change, but it fits the suspend direction very well: suspend is already a wonderful feature for reducing NCCL's runtime memory footprint, and channel allocation offload pushes that benefit further by moving more channel state out of precious device memory.

## Motivation

Suspend is especially valuable for large training workloads where reclaiming GPU memory between communication phases matters. The existing suspend behavior already gives meaningful savings, and this change improves it further by covering channel initialization allocations that were still staying resident on device memory.

## Result

Measured in our internal Megatron-LM workload:

- after suspend: about `3.47 GB` remaining
- after suspend + channel suspend: about `1.59 GB` remaining

That is an additional reduction of about `1.88 GB`.

## Notes

The change is intentionally minimal and only adds the `ncclMemOffload` flag to the relevant `ncclCudaCallocAsync` allocations, so behavior stays aligned with the current allocation flow while improving suspend memory efficiency.