### PR TITLE
Enable strict C++ compiler warnings and -Werror by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ option(DEBUG "Enable debug build" OFF)
 option(ASAN "Enable Address Sanitizer" OFF)
 option(UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 option(TRACE "Enable tracing" OFF)
-option(WERROR "Treat warnings as errors" OFF)
+option(WERROR "Treat warnings as errors" ON)
 option(PROFAPI "Enable profiling API" ON)
 option(NVTX "Enable NVTX" ON)
 option(RDMA_CORE "Enable RDMA core" OFF)
@@ -141,7 +141,7 @@ message(STATUS "Using CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
 # Compiler-specific flags
 if(NCCL_COMPILER_GCC)
     # GCC/Clang-specific flags
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fvisibility=hidden -Wall -Wno-unused-function -Wno-sign-compare -Wvla -g")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fvisibility=hidden -Wall -Wextra -Wshadow=local -Wnon-virtual-dtor -Woverloaded-virtual -Wimplicit-fallthrough -Wno-unused-function -Wno-sign-compare -Wvla -g")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all -fPIC")
 elseif(NCCL_COMPILER_MSVC)
     # MSVC-specific flags

--- a/docs/examples/01_communicators/01_multiple_devices_single_process/main.cc
+++ b/docs/examples/01_communicators/01_multiple_devices_single_process/main.cc
@@ -84,7 +84,7 @@
 // MAIN FUNCTION - NCCL Communicator Lifecycle Example
 // =============================================================================
 
-int main(int argc, char *argv[]) {
+int main(int /*argc*/, char */*argv*/[]) {
   // Variables for managing multiple GPU communicators
   int num_gpus;                 // Number of available CUDA devices
   ncclComm_t *comms = NULL;     // Array of NCCL communicators (one per GPU)

--- a/docs/examples/01_communicators/02_one_device_per_pthread/main.cc
+++ b/docs/examples/01_communicators/02_one_device_per_pthread/main.cc
@@ -125,7 +125,7 @@ void *thread_worker(void *arg) {
   return NULL;
 }
 
-int main(int argc, char *argv[]) {
+int main(int /*argc*/, char */*argv*/[]) {
   int num_gpus;
   pthread_t *threads;
   threadData_t *threadData;

--- a/docs/examples/02_point_to_point/01_ring_pattern/main.cc
+++ b/docs/examples/02_point_to_point/01_ring_pattern/main.cc
@@ -52,7 +52,7 @@
     }                                                                          \
   } while (0)
 
-int main(int argc, char *argv[]) {
+int main(int /*argc*/, char */*argv*/[]) {
   // ========================================================================
   // STEP 1: Initialize Environment and Detect GPUs
   // ========================================================================

--- a/docs/examples/03_collectives/01_allreduce/main.cc
+++ b/docs/examples/03_collectives/01_allreduce/main.cc
@@ -51,7 +51,7 @@
     }                                                                          \
   } while (0)
 
-int main(int argc, char *argv[]) {
+int main(int /*argc*/, char */*argv*/[]) {
   // ========================================================================
   // STEP 1: Initialize Variables and Detect Available GPUs
   // ========================================================================

--- a/docs/examples/04_user_buffer_registration/01_allreduce/main.cc
+++ b/docs/examples/04_user_buffer_registration/01_allreduce/main.cc
@@ -35,7 +35,7 @@
  * examples in 01_communicators.
  */
 void *allReduce(int my_rank, int total_ranks, int local_device,
-                int devices_per_rank) {
+                int /*devices_per_rank*/) {
 
   // ========================================================================
   // STEP 1: Initialize NCCL Communicator and Setup

--- a/docs/examples/05_symmetric_memory/01_allreduce/main.cc
+++ b/docs/examples/05_symmetric_memory/01_allreduce/main.cc
@@ -35,7 +35,7 @@
  * examples in 01_communicators.
  */
 void *allReduce(int my_rank, int total_ranks, int local_device,
-                int devices_per_rank) {
+                int /*devices_per_rank*/) {
 
   // ========================================================================
   // STEP 1: Initialize NCCL Communicator and Setup

--- a/docs/examples/common/src/utils.cc
+++ b/docs/examples/common/src/utils.cc
@@ -166,6 +166,8 @@ int initialize(int argc, char *argv[], context_t *ctx) {
   MPI_Comm_free(&node_comm);
 
 #else
+  (void)argc;
+  (void)argv;
 
   // Get number of devices (threads) from environment or default to available
   // GPUs

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -13,7 +13,7 @@ DEBUG ?= 0
 ASAN ?= 0
 UBSAN ?= 0
 TRACE ?= 0
-WERROR ?= 0
+WERROR ?= 1
 PROFAPI ?= 1
 NVTX ?= 1
 RDMA_CORE ?= 0
@@ -77,7 +77,8 @@ else
 endif
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare $(CXXSTD) -Wvla \
+              -Wall -Wextra -Wshadow=local -Wnon-virtual-dtor -Woverloaded-virtual -Wimplicit-fallthrough \
+              -Wno-unused-function -Wno-sign-compare $(CXXSTD) -Wvla \
               -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
@@ -122,7 +123,6 @@ endif
 
 ifneq ($(VERBOSE), 0)
 NVCUFLAGS += -Xptxas -v -Xcompiler -Wall,-Wextra,-Wno-unused-parameter
-CXXFLAGS  += -Wall -Wextra
 else
 .SILENT:
 endif

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -119,7 +119,7 @@ ncclResult_t bootstrapNetInit() {
           return ncclInvalidArgument;
         }
         NCCLCHECK(ncclFindInterfaceMatchSubnet(bootstrapNetIfName, &bootstrapNetIfAddr, &remoteAddr, MAX_IF_NAME_SIZE,
-                                               &nIfs));
+          &nIfs));
         if (nIfs <= 0) {
           WARN("NET/Socket : No usable listening interface found");
           return ncclSystemError;
@@ -166,7 +166,7 @@ static ncclResult_t netDereg(ncclNet_t* net, void* comm, void** handle) {
   return ncclSuccess;
 }
 static ncclResult_t netIsend(ncclNet_t* net, void* sendComm, void* data, int size, void* dataHandle, int tag, void** sendReq,
-                             int* done) {
+    int* done) {
   if (*done) return ncclSuccess;
   if (!*sendReq) {
     NCCLCHECK(net->isend(sendComm, data, (size_t)size, tag, dataHandle, NULL, sendReq));
@@ -180,7 +180,7 @@ static ncclResult_t netIsend(ncclNet_t* net, void* sendComm, void* data, int siz
   return ncclSuccess;
 }
 static ncclResult_t netIrecv(ncclNet_t* net, void* recvComm, void* data, int size, void* dataHandle, int tag, void** recvReq,
-                             int* done) {
+    int* done) {
   if (*done) return ncclSuccess;
   if (!*recvReq) {
     size_t size64 = size;
@@ -195,7 +195,7 @@ static ncclResult_t netIrecv(ncclNet_t* net, void* recvComm, void* data, int siz
   return ncclSuccess;
 }
 static ncclResult_t netSendRecv(ncclNet_t* net, void* sendComm, void* sendData, int sendSize, void* sendDataHandle, void* recvComm,
-                                void* recvData, int recvSize, void* recvDataHandle, int tag, volatile uint32_t* abortFlag) {
+    void* recvData, int recvSize, void* recvDataHandle, int tag, volatile uint32_t* abortFlag) {
   int abortCounter = 0;
   int doneSend = 0, doneRecv = 0;
   void *sendReq = NULL, *recvReq = NULL;
@@ -231,7 +231,7 @@ static ncclResult_t socketRecv(struct ncclSocket* sock, void* data, int size) {
   return ncclSuccess;
 }
 static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, int sendSize, struct ncclSocket* recvSock,
-                                   void* recvData, int recvSize) {
+    void* recvData, int recvSize) {
   int senderRecvSize;
   NCCLCHECK(ncclSocketSendRecv(sendSock, &sendSize, sizeof(int), recvSock, &senderRecvSize, sizeof(int)));
   if (senderRecvSize > recvSize) {
@@ -297,7 +297,7 @@ fail:
   return res;
 }
 static void* bootstrapRoot(void* rargs) {
-  uint64_t timers[BOOTSTRAP_INIT_ROOT_N] = {0};
+  uint64_t timers[BOOTSTRAP_INIT_ROOT_N] = {};
   struct bootstrapRootArgs* args = (struct bootstrapRootArgs*)rargs;
   struct ncclSocket* listenSock = args->listenSock;
   uint64_t magic = args->magic;
@@ -344,8 +344,8 @@ static void* bootstrapRoot(void* rargs) {
 
     if (nranks != info.nranks || nroots != info.nroots || iroot != info.iroot || offset != info.offset) {
       WARN("Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d vs %d",
-        nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
-        goto out;
+          nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
+      goto out;
     }
 
     localId = localIdFromRoot(info.rank, iroot, nranks, nroots, offset);
@@ -354,7 +354,7 @@ static void* bootstrapRoot(void* rargs) {
       goto out;
     }
     if (memcmp(&zeroAddress, &rankAddressesRoot[localId], sizeof(union ncclSocketAddress)) != 0 ||
-        memcmp(&zeroInfo, &rankInfo[localId], sizeof(union ringConnectInfo)) != 0) {
+      memcmp(&zeroInfo, &rankInfo[localId], sizeof(union ringConnectInfo)) != 0) {
       WARN("Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
       goto out;
     }
@@ -389,7 +389,7 @@ static void* bootstrapRoot(void* rargs) {
     // use nrecv to periodize: if 1 root, we will send the first one to the last one, if >1 roots we will send the additional one we have received
     int next = BOOTSTRAP_PID(r + 1, nrecv);
     if (memcmp(&zeroAddress, &rankAddressesRoot[r], sizeof(union ncclSocketAddress)) != 0 &&
-        memcmp(&zeroInfo, &rankInfo[next], sizeof(union ringConnectInfo)) != 0) {
+      memcmp(&zeroInfo, &rankInfo[next], sizeof(union ringConnectInfo)) != 0) {
       NCCLCHECKGOTO(rootSend(&rankAddressesRoot[r], magic, &rankInfo[next]), res, out);
     }
   }
@@ -410,7 +410,7 @@ out:
   return NULL;
 }
 
-ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool idFromEnv) {
+ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool /*idFromEnv*/) {
   ncclResult_t ret = ncclSuccess;
   struct ncclSocket* listenSock = NULL;
   struct bootstrapRootArgs* args = NULL;
@@ -535,7 +535,7 @@ struct bootstrapState {
 
 // helper functions
 static ncclResult_t createListenSocket(struct ncclComm* comm, uint64_t magic, struct ncclSocket* socket, union ncclSocketAddress* addr,
-                                       ncclSocketType type) {
+    ncclSocketType type) {
   NCCLCHECK(ncclSocketInit(socket, &bootstrapNetIfAddr, magic, type, comm->abortFlag));
   NCCLCHECK(ncclSocketListen(socket));
   NCCLCHECK(ncclSocketGetAddr(socket, addr));
@@ -548,7 +548,7 @@ static ncclResult_t getUDS(uint64_t* peerUDS) {
   return ncclSuccess;
 }
 #define MAX_OOB_DEVS 16
-static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
+static ncclResult_t netGetDevice(int /*rank*/, struct ncclComm* comm, int* dev) {
   static int devOOB = -1;
   if (devOOB < 0) {
     std::lock_guard<std::mutex> lock(bootstrapNetMutex);
@@ -600,8 +600,8 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
 }
 
 static ncclResult_t netRingConnect(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
-                                   void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
-                                   void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
+    void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
+    void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
 
   int abortCounter = 0;
   do {
@@ -621,9 +621,9 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
   return ncclSuccess;
 }
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
-                                union ncclSocketAddress* peerAddresss,
-                                union ncclSocketAddress* peerProxy, uint64_t* peerUDS,
-                                struct rasRankInit* rasRanks) {
+    union ncclSocketAddress* peerAddresss,
+    union ncclSocketAddress* peerProxy, uint64_t* peerUDS,
+    struct rasRankInit* rasRanks) {
   ncclResult_t res = ncclSuccess;
   int rank = comm->rank;
   int nRanks = comm->nRanks;
@@ -691,12 +691,12 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   struct bootstrapState* state;
   struct ncclSocket* proxySocket;
   struct ncclSocket sock, listenSockRoot;
-  struct extInfo info = {0};
+  struct extInfo info = {};
   union ringConnectInfo nextPeer;
   bool performRasAddRanks = true;
   struct rasRankInit* rasRanks = nullptr;
 
-  uint64_t timers[BOOTSTRAP_INIT_TIME_N] = {0};
+  uint64_t timers[BOOTSTRAP_INIT_TIME_N] = {};
 
   NCCLCHECK(ncclCalloc(&state, 1));
   state->rank = rank;
@@ -792,7 +792,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
 
   // get info on my "next" rank in the bootstrap ring from root
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RECV]);
-  if(curr_root >= 0){
+  if(curr_root >= 0) {
     NCCLCHECK(ncclSocketInit(&sock));
     NCCLCHECK(ncclSocketAccept(&sock, &listenSockRoot));
     NCCLCHECK(socketRecv(&sock, &nextPeer, sizeof(nextPeer)));
@@ -808,8 +808,8 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   // accept and connect the ring network
   if (ncclParamBootstrapNetEnable()) {
     NCCLCHECK(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.handle,
-                             &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
-                             &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag));
+      &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
+      &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag));
   } else {
     NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
@@ -863,11 +863,11 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_TOTAL]);
   TRACE(NCCL_BOOTSTRAP, "rank %d nranks %d - DONE", rank, nranks);
   INFO(NCCL_BOOTSTRAP | NCCL_PROFILE, "Bootstrap timings total %f (create %f, send %f, recv %f, ring %f, delay %f)", timers[BOOTSTRAP_INIT_TIME_TOTAL] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_CREATE] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_SEND] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_RECV] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_RING] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_DELAY] / 1e9);
+    timers[BOOTSTRAP_INIT_TIME_CREATE] / 1e9,
+    timers[BOOTSTRAP_INIT_TIME_SEND] / 1e9,
+    timers[BOOTSTRAP_INIT_TIME_RECV] / 1e9,
+    timers[BOOTSTRAP_INIT_TIME_RING] / 1e9,
+    timers[BOOTSTRAP_INIT_TIME_DELAY] / 1e9);
 exit:
   return result;
 fail:
@@ -875,7 +875,7 @@ fail:
   goto exit;
 }
 
-ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclComm* parent, int color, int key, int* parentRanks) {
+ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclComm* parent, int /*color*/, int /*key*/, int* parentRanks) {
   ncclResult_t ret = ncclSuccess;
   int rank = comm->rank;
   int nranks = comm->nRanks;
@@ -920,9 +920,9 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(union ringConnectInfo)), ret, fail);
   if (ncclParamBootstrapNetEnable()) {
     NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.handle,
-                                 &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
-                                 &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
-                  ret, fail);
+      &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
+      &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
+      ret, fail);
   } else {
     NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
@@ -947,7 +947,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   }
 
   TRACE(NCCL_BOOTSTRAP, "bootstrapSplit: comm %p parent %p rank %d nranks %d color %d key %d prev %d next %d - DONE", comm, parent, rank, nranks,
-        color, key, prev, next);
+      color, key, prev, next);
 
 exit:
   return ret;
@@ -964,7 +964,7 @@ static ncclResult_t socketConnect(void* commState, int peer, int tag, struct ncc
   ncclResult_t ret = ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
 
-  struct socketAckInfo ack = (struct socketAckInfo){.rank = state->rank, .tag = tag};
+  struct socketAckInfo ack = (struct socketAckInfo) {.rank = state->rank, .tag = tag};
   NCCLCHECKGOTO(ncclSocketInit(sock, state->peerP2pAddresses + peer, state->magic, ncclSocketTypeBootstrap, state->abortFlag), ret, fail);
   NCCLCHECKGOTO(ncclSocketConnect(sock), ret, fail);
   NCCLCHECKGOTO(socketSend(sock, &ack, sizeof(struct socketAckInfo)), ret, fail);
@@ -1052,7 +1052,7 @@ static ncclResult_t socketAccept(void* commState, int peer, int tag, struct nccl
 
   // Then look for new connections
   while (1) {
-    struct socketAckInfo ack = {0};
+    struct socketAckInfo ack = {};
     NCCLCHECKGOTO(ncclSocketInit(sock), ret, fail);
     NCCLCHECKGOTO(ncclSocketAccept(sock, &STATE_LISTEN(state, peerSocket)), ret, fail);
     NCCLCHECKGOTO(socketRecv(sock, &ack, sizeof(struct socketAckInfo)), ret, fail);
@@ -1186,7 +1186,7 @@ static ncclResult_t bootstrapP2PBarrier(void* commState, int* ranks, int rank, i
    * Based on the dissemination algorithm by Debra Hensgen, Raphael Finkel, and Udi Manbet,
    * "Two Algorithms for Barrier Synchronization," International Journal of Parallel Programming, 17(1):1-17, 1988"
    */
-  int data[1] = {0};
+  int data[1] = {};
   for (int mask = 1; mask < nranks; mask <<= 1) {
     int src = (rank - mask + nranks) % nranks;
     int dst = (rank + mask) % nranks;

--- a/src/ce_coll.cc
+++ b/src/ce_coll.cc
@@ -78,20 +78,20 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
   return ret;
 }
 
-bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ /*red*/, ncclDataType_t /*ty*/) {
   int driverVersion;
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return false;
 
   // CE is supported in CUDA 12.5 and later
   if (driverVersion >= 12050) {
     switch (coll) {
-    case ncclFuncAllGather:
-    case ncclFuncAlltoAll:
-    case ncclFuncScatter:
-    case ncclFuncGather:
-      return true;
-    default:
-      return false;
+      case ncclFuncAllGather:
+      case ncclFuncAlltoAll:
+      case ncclFuncScatter:
+      case ncclFuncGather:
+        return true;
+      default:
+        return false;
     }
   }
   return false;
@@ -163,8 +163,8 @@ fail:
 }
 
 ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
-                               CUstreamBatchMemOpParams* batchParams,
-                               size_t* opIdx, cudaStream_t stream) {
+    CUstreamBatchMemOpParams* batchParams,
+    size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   uint32_t* readyPtrs    = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
@@ -220,7 +220,7 @@ ncclResult_t ncclMemOpSync(struct ncclComm* comm, struct ncclCeCollArgs* args, c
 
   // Start CE sync profiling
   NCCLCHECKGOTO(ncclProfilerStartCeSyncEvent(comm, args, stream, &ceSyncHandle),
-                ret, fail);
+    ret, fail);
 
   // Prepare batch memory operations for synchronization
   NCCLCHECKGOTO(ncclCalloc(&batchParams, batchSize), ret, fail);
@@ -324,7 +324,7 @@ void ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params) {
 }
 
 ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeCollArgs* args,
-                                  struct ncclCeBatchOpsParams* params, cudaStream_t stream) {
+    struct ncclCeBatchOpsParams* params, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
   bool capturing;
   int driverVersion;
@@ -337,7 +337,7 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeCollArgs* 
 
   // Start CE batch profiling
   NCCLCHECKGOTO(ncclProfilerStartCeBatchEvent(comm, args, params, stream, &ceBatchHandle),
-                ret, fail);
+    ret, fail);
 
   // Check if there are any operations to perform
   if (params->numOps == 0) goto exit;
@@ -367,81 +367,81 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeCollArgs* 
   else {
     if (CUDART_VERSION >= 12080 && driverVersion >= 12080) {
 #if CUDART_VERSION >= 12080
-    // For CUDA 12.8+, use batch memory copy for better performance
-    params->attrs[0] = {};
-    params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
-    params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
-    params->attrIdxs[0] = 0;
-    params->numAttrs = 1;
+      // For CUDA 12.8+, use batch memory copy for better performance
+      params->attrs[0] = {};
+      params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+      params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
+      params->attrIdxs[0] = 0;
+      params->numAttrs = 1;
 
-    if (params->intraBatchSync) {
-      // Find the maximum transfer size to determine number of rounds
-      size_t maxSize = 0;
-      size_t totalSize = 0;
-      for (int i = 0; i < params->numOps; i++) {
-        if (params->sizes[i] > maxSize) {
-          maxSize = params->sizes[i];
-        }
-        totalSize += params->sizes[i];
-      }
-
-      size_t chunkSize = comm->ceColl.intraBatchSyncMsgThreshold / params->numOps;
-      int numRounds = (maxSize + chunkSize - 1) / chunkSize;
-
-      size_t numTmpOps = params->numOps * numRounds;
-
-      // Allocate temporary arrays for all chunked operations
-      // Use ncclUniqueArrayPtr for automatic cleanup on any exit path
-      ncclUniqueArrayPtr<void*> tmpDsts{nullptr};
-      ncclUniqueArrayPtr<void*> tmpSrcs{nullptr};
-      ncclUniqueArrayPtr<size_t> tmpSizes{nullptr};
-
-      NCCLCHECKGOTO(ncclCalloc(tmpDsts, numTmpOps), ret, fail);
-      NCCLCHECKGOTO(ncclCalloc(tmpSrcs, numTmpOps), ret, fail);
-      NCCLCHECKGOTO(ncclCalloc(tmpSizes, numTmpOps), ret, fail);
-
-      int opIdx = 0;
-      for (int round = 0; round < numRounds; round++) {
-        size_t offset = round * chunkSize;
-        // Prepare chunk transfers for this round
+      if (params->intraBatchSync) {
+        // Find the maximum transfer size to determine number of rounds
+        size_t maxSize = 0;
+        size_t totalSize = 0;
         for (int i = 0; i < params->numOps; i++) {
-          int index = (i+round) % params->numOps;
-          if (offset < params->sizes[index]) {
-            size_t remainingSize = params->sizes[index] - offset;
-            size_t currentChunkSize = (remainingSize > chunkSize) ? chunkSize : remainingSize;
+          if (params->sizes[i] > maxSize) {
+            maxSize = params->sizes[i];
+          }
+          totalSize += params->sizes[i];
+        }
 
-            tmpDsts[opIdx] = (void*)((uint8_t*)params->dsts[index] + offset);
-            tmpSrcs[opIdx] = (void*)((uint8_t*)params->srcs[index] + offset);
-            tmpSizes[opIdx] = currentChunkSize;
-            opIdx++;
+        size_t chunkSize = comm->ceColl.intraBatchSyncMsgThreshold / params->numOps;
+        int numRounds = (maxSize + chunkSize - 1) / chunkSize;
+
+        size_t numTmpOps = params->numOps * numRounds;
+
+        // Allocate temporary arrays for all chunked operations
+        // Use ncclUniqueArrayPtr for automatic cleanup on any exit path
+        ncclUniqueArrayPtr<void*> tmpDsts{nullptr};
+        ncclUniqueArrayPtr<void*> tmpSrcs{nullptr};
+        ncclUniqueArrayPtr<size_t> tmpSizes{nullptr};
+
+        NCCLCHECKGOTO(ncclCalloc(tmpDsts, numTmpOps), ret, fail);
+        NCCLCHECKGOTO(ncclCalloc(tmpSrcs, numTmpOps), ret, fail);
+        NCCLCHECKGOTO(ncclCalloc(tmpSizes, numTmpOps), ret, fail);
+
+        int opIdx = 0;
+        for (int round = 0; round < numRounds; round++) {
+          size_t offset = round * chunkSize;
+          // Prepare chunk transfers for this round
+          for (int i = 0; i < params->numOps; i++) {
+            int index = (i+round) % params->numOps;
+            if (offset < params->sizes[index]) {
+              size_t remainingSize = params->sizes[index] - offset;
+              size_t currentChunkSize = (remainingSize > chunkSize) ? chunkSize : remainingSize;
+
+              tmpDsts[opIdx] = (void*)((uint8_t*)params->dsts[index] + offset);
+              tmpSrcs[opIdx] = (void*)((uint8_t*)params->srcs[index] + offset);
+              tmpSizes[opIdx] = currentChunkSize;
+              opIdx++;
+            }
           }
         }
-      }
 
-      // Launch a single batch for all chunks
-      if (opIdx > 0) {
-        #if CUDART_VERSION >= 13000
+        // Launch a single batch for all chunks
+        if (opIdx > 0) {
+#if CUDART_VERSION >= 13000
+          CUDACHECKGOTO(cudaMemcpyBatchAsync(
+            tmpDsts.get(), tmpSrcs.get(), tmpSizes.get(), opIdx,
+            params->attrs, params->attrIdxs, params->numAttrs, stream), ret, fail);
+#else
+          CUDACHECKGOTO(cudaMemcpyBatchAsync(
+            tmpDsts.get(), tmpSrcs.get(), tmpSizes.get(), opIdx,
+            params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
+#endif
+        }
+      } else {
+        // Use single batch for all operations
+#if CUDART_VERSION >= 13000
         CUDACHECKGOTO(cudaMemcpyBatchAsync(
-          tmpDsts.get(), tmpSrcs.get(), tmpSizes.get(), opIdx,
+          params->dsts, params->srcs, params->sizes, params->numOps,
           params->attrs, params->attrIdxs, params->numAttrs, stream), ret, fail);
-        #else
+#else
         CUDACHECKGOTO(cudaMemcpyBatchAsync(
-          tmpDsts.get(), tmpSrcs.get(), tmpSizes.get(), opIdx,
+          params->dsts, params->srcs, params->sizes, params->numOps,
           params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-        #endif
+#endif
       }
-    } else {
-      // Use single batch for all operations
-      #if CUDART_VERSION >= 13000
-      CUDACHECKGOTO(cudaMemcpyBatchAsync(
-        params->dsts, params->srcs, params->sizes, params->numOps,
-        params->attrs, params->attrIdxs, params->numAttrs, stream), ret, fail);
-      #else
-      CUDACHECKGOTO(cudaMemcpyBatchAsync(
-        params->dsts, params->srcs, params->sizes, params->numOps,
-        params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-      #endif
-    }
 #endif
     } else {
       // For older CUDA versions, fall back to individual transfers
@@ -470,7 +470,7 @@ fail:
 
 
 ncclResult_t ncclCeAllGather(struct ncclComm* comm, struct ncclCeCollArgs* args,
-                             cudaStream_t stream) {
+    cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
   const size_t chunkBytes = args->nElts * args->eltSize;
   uint8_t* mySendBuff = (uint8_t*)args->sendBuff;
@@ -508,7 +508,7 @@ ncclResult_t ncclCeAllGather(struct ncclComm* comm, struct ncclCeCollArgs* args,
 
   // Launch the batch operations
   NCCLCHECKGOTO(ncclCeLaunchBatchOps(comm, args, &batchOpsParams, stream),
-                ret, fail);
+    ret, fail);
 
   // Ensure all transfers are complete across all ranks
   NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
@@ -689,24 +689,24 @@ ncclResult_t ncclLaunchCeColl(struct ncclComm* comm, struct ncclKernelPlan* plan
 
   // Start CE collective profiling
   NCCLCHECKGOTO(ncclProfilerStartCeCollEvent(comm, args, stream),
-                ret, fail);
+    ret, fail);
 
   switch (args->func) {
     case ncclFuncAllGather:
       NCCLCHECKGOTO(ncclCeAllGather(comm, args, stream),
-                    ret, fail);
+        ret, fail);
       break;
     case ncclFuncAlltoAll:
       NCCLCHECKGOTO(ncclCeAlltoAll(comm, args, stream),
-                    ret, fail);
+        ret, fail);
       break;
     case ncclFuncScatter:
       NCCLCHECKGOTO(ncclCeScatter(comm, args, stream),
-                    ret, fail);
+        ret, fail);
       break;
     case ncclFuncGather:
       NCCLCHECKGOTO(ncclCeGather(comm, args, stream),
-                    ret, fail);
+        ret, fail);
       break;
     default:
       ret = ncclInvalidUsage;

--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -13,71 +13,71 @@
 
 const char* ncclFuncToString(ncclFunc_t fn) {
   switch (fn) {
-  case ncclFuncAllGather: return "AllGather";
-  case ncclFuncAllReduce: return "AllReduce";
-  case ncclFuncAlltoAll: return "AlltoAll";
-  case ncclFuncBroadcast: return "Broadcast";
-  case ncclFuncGather: return "Gather";
-  case ncclFuncRecv: return "Recv";
-  case ncclFuncReduce: return "Reduce";
-  case ncclFuncReduceScatter: return "ReduceScatter";
-  case ncclFuncScatter: return "Scatter";
-  case ncclFuncSendRecv: return "SendRecv";
-  case ncclFuncSend: return "Send";
-  case ncclFuncPutSignal: return "PutSignal";
-  case ncclFuncSignal: return "Signal";
-  case ncclFuncWaitSignal: return "WaitSignal";
-  default: return "Invalid";
+    case ncclFuncAllGather: return "AllGather";
+    case ncclFuncAllReduce: return "AllReduce";
+    case ncclFuncAlltoAll: return "AlltoAll";
+    case ncclFuncBroadcast: return "Broadcast";
+    case ncclFuncGather: return "Gather";
+    case ncclFuncRecv: return "Recv";
+    case ncclFuncReduce: return "Reduce";
+    case ncclFuncReduceScatter: return "ReduceScatter";
+    case ncclFuncScatter: return "Scatter";
+    case ncclFuncSendRecv: return "SendRecv";
+    case ncclFuncSend: return "Send";
+    case ncclFuncPutSignal: return "PutSignal";
+    case ncclFuncSignal: return "Signal";
+    case ncclFuncWaitSignal: return "WaitSignal";
+    default: return "Invalid";
   }
 }
 
 const char* ncclDevRedOpToString(ncclDevRedOp_t op) {
   switch (op) {
-  case ncclDevSum: return "Sum";
-  case ncclDevProd: return "Prod";
-  case ncclDevMinMax: return "MinMax";
-  case ncclDevPreMulSum: return "PreMulSum";
-  case ncclDevSumPostDiv: return "SumPostDiv";
-  default: return "Unknown";
+    case ncclDevSum: return "Sum";
+    case ncclDevProd: return "Prod";
+    case ncclDevMinMax: return "MinMax";
+    case ncclDevPreMulSum: return "PreMulSum";
+    case ncclDevSumPostDiv: return "SumPostDiv";
+    default: return "Unknown";
   }
 }
 
 const char* ncclDatatypeToString(ncclDataType_t type) {
   switch (type) {
-  case ncclInt8: return "ncclInt8";
-  case ncclInt32: return "ncclInt32";
-  case ncclUint32: return "ncclUint32";
-  case ncclInt64: return "ncclInt64";
-  case ncclUint64: return "ncclUint64";
-  case ncclFloat16: return "ncclFloat16";
-  case ncclFloat32: return "ncclFloat32";
-  case ncclFloat64: return "ncclFloat64";
-  case ncclBfloat16: return "ncclBfloat16";
-  case ncclFloat8e4m3: return "ncclFloat8e4m3";
-  case ncclFloat8e5m2: return "ncclFloat8e5m2";
-  default: return "Unknown";
+    case ncclInt8: return "ncclInt8";
+    case ncclInt32: return "ncclInt32";
+    case ncclUint32: return "ncclUint32";
+    case ncclInt64: return "ncclInt64";
+    case ncclUint64: return "ncclUint64";
+    case ncclFloat16: return "ncclFloat16";
+    case ncclFloat32: return "ncclFloat32";
+    case ncclFloat64: return "ncclFloat64";
+    case ncclBfloat16: return "ncclBfloat16";
+    case ncclFloat8e4m3: return "ncclFloat8e4m3";
+    case ncclFloat8e5m2: return "ncclFloat8e5m2";
+    default: return "Unknown";
   }
 }
 
 const char* ncclAlgoToString(int algo) {
   switch (algo) {
-  case NCCL_ALGO_TREE: return "TREE";
-  case NCCL_ALGO_RING: return "RING";
-  case NCCL_ALGO_COLLNET_DIRECT: return "COLLNET_DIRECT";
-  case NCCL_ALGO_COLLNET_CHAIN: return "COLLNET_CHAIN";
-  case NCCL_ALGO_NVLS: return "NVLS";
-  case NCCL_ALGO_NVLS_TREE: return "NVLS_TREE";
-  case NCCL_ALGO_PAT: return "PAT";
-  default: return "Unknown";
+    case NCCL_ALGO_TREE: return "TREE";
+    case NCCL_ALGO_RING: return "RING";
+    case NCCL_ALGO_COLLNET_DIRECT: return "COLLNET_DIRECT";
+    case NCCL_ALGO_COLLNET_CHAIN: return "COLLNET_CHAIN";
+    case NCCL_ALGO_NVLS: return "NVLS";
+    case NCCL_ALGO_NVLS_TREE: return "NVLS_TREE";
+    case NCCL_ALGO_PAT: return "PAT";
+    default: return "Unknown";
   }
 }
 
 const char* ncclProtoToString(int proto) {
   switch (proto) {
-  case NCCL_PROTO_LL: return "LL";
-  case NCCL_PROTO_LL128: return "LL128";
-  case NCCL_PROTO_SIMPLE: return "SIMPLE";
-  default: return "Unknown";
+    case NCCL_PROTO_LL: return "LL";
+    case NCCL_PROTO_LL128: return "LL128";
+    case NCCL_PROTO_SIMPLE: return "SIMPLE";
+    default: return "Unknown";
   }
 }
 
@@ -87,11 +87,13 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
   // Just pass the size of one message and not the total bytes sent/received.
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
 
   struct ncclInfo info = { ncclFuncAllGather, "AllGather",
     sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream, /* Args */
-    ALLGATHER_CHUNKSTEPS, ALLGATHER_SLICESTEPS };
+    ALLGATHER_CHUNKSTEPS, ALLGATHER_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -100,11 +102,13 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */
-    ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS };
+    ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -113,11 +117,13 @@ NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size
 ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(AllReduce, NcclNvtxParamsAllReduce,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op));
 
   struct ncclInfo info = { ncclFuncAllReduce, "AllReduce",
     sendbuff, recvbuff, count, datatype, op, 0, comm, stream, /* Args */
-    ALLREDUCE_CHUNKSTEPS, ALLREDUCE_SLICESTEPS };
+    ALLREDUCE_CHUNKSTEPS, ALLREDUCE_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -126,11 +132,13 @@ NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size
 ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
     ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Broadcast, NcclNvtxParamsBroadcast,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
 
   struct ncclInfo info = { ncclFuncBroadcast, "Broadcast",
     sendbuff, recvbuff, count, datatype, ncclSum, root, comm, stream, /* Args */
-    BROADCAST_CHUNKSTEPS, BROADCAST_SLICESTEPS };
+    BROADCAST_CHUNKSTEPS, BROADCAST_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 /* Deprecated original "in place" function, similar to MPI */
@@ -146,11 +154,13 @@ NCCL_API(ncclResult_t, ncclGather, const void* sendbuff, void* recvbuff, size_t 
 ncclResult_t ncclGather(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
     ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Gather, NcclNvtxParamsGather,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
 
   struct ncclInfo info = { ncclFuncGather, "Gather",
     sendbuff, recvbuff, count, datatype, ncclSum, root, comm, stream, /* Args */
-    GATHER_CHUNKSTEPS, GATHER_SLICESTEPS };
+    GATHER_CHUNKSTEPS, GATHER_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -159,11 +169,13 @@ NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, size_t 
 ncclResult_t ncclReduce(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Reduce, NcclNvtxParamsReduce,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, op));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, op));
 
   struct ncclInfo info = { ncclFuncReduce, "Reduce",
     sendbuff, recvbuff, count, datatype, op, root, comm, stream, /* Args */
-    REDUCE_CHUNKSTEPS, REDUCE_SLICESTEPS };
+    REDUCE_CHUNKSTEPS, REDUCE_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -172,11 +184,13 @@ NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, 
 ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(ReduceScatter, NcclNvtxParamsReduceScatter,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, recvcount * ncclTypeSize(datatype), op));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, recvcount * ncclTypeSize(datatype), op));
 
   struct ncclInfo info = { ncclFuncReduceScatter, "ReduceScatter",
     sendbuff, recvbuff, recvcount, datatype, op, 0, comm, stream, /* Args */
-    REDUCESCATTER_CHUNKSTEPS, REDUCESCATTER_SLICESTEPS };
+    REDUCESCATTER_CHUNKSTEPS, REDUCESCATTER_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -185,11 +199,13 @@ NCCL_API(ncclResult_t, ncclScatter, const void* sendbuff, void* recvbuff, size_t
 ncclResult_t ncclScatter(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, int root, ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Scatter, NcclNvtxParamsScatter,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
 
   struct ncclInfo info = { ncclFuncScatter, "Scatter",
     sendbuff, recvbuff, count, datatype, ncclSum, root, comm, stream, /* Args */
-    SCATTER_CHUNKSTEPS, SCATTER_SLICESTEPS };
+    SCATTER_CHUNKSTEPS, SCATTER_SLICESTEPS,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -198,11 +214,13 @@ NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count, ncclDataTyp
 ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
     ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Send, NcclNvtxParamsSendRecv,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer));
 
   struct ncclInfo info = { ncclFuncSend, "Send",
     NULL, (void*)sendbuff, count, datatype, ncclSum, peer, comm, stream, /* Args */
-    1, 1 };
+    1, 1,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
@@ -211,51 +229,56 @@ NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t da
 ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer,
     ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Recv, NcclNvtxParamsSendRecv,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer));
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer));
 
   struct ncclInfo info = { ncclFuncRecv, "Recv",
     NULL, recvbuff, count, datatype, ncclSum, peer, comm, stream, /* Args */
-    1, 1 };
+    1, 1,
+    0, NULL, 0, 0, 0, 0, NULL
+  };
   return ncclEnqueueCheck(&info);
 }
 
 NCCL_API(ncclResult_t, ncclPutSignal, const void* localbuff, size_t count, ncclDataType_t datatype,
     int peer, ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclPutSignal(const void* localbuff, size_t count, ncclDataType_t datatype,
-  int peer, ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream) {
-NVTX3_FUNC_WITH_PARAMS(PutSignal, NcclNvtxParamsPut,
-  NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, ctx));
+    int peer, ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream) {
+  NVTX3_FUNC_WITH_PARAMS(PutSignal, NcclNvtxParamsPut,
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, ctx));
 
-struct ncclInfo info = { ncclFuncPutSignal, "PutSignal",
-  localbuff, NULL, count, datatype, ncclSum, peer, comm, stream, /* Args */
-  1, 1, /* chunkSteps, sliceSteps */
-  peerWinOffset, peerWin, sigIdx, ctx, flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
-  0, NULL }; /* nDesc, signalDescs */
-return ncclEnqueueCheck(&info);
+  struct ncclInfo info = { ncclFuncPutSignal, "PutSignal",
+    localbuff, NULL, count, datatype, ncclSum, peer, comm, stream, /* Args */
+    1, 1, /* chunkSteps, sliceSteps */
+    peerWinOffset, peerWin, sigIdx, ctx, flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
+    0, NULL
+  }; /* nDesc, signalDescs */
+  return ncclEnqueueCheck(&info);
 }
 
 NCCL_API(ncclResult_t, ncclSignal, int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclSignal(int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream) {
-NVTX3_FUNC_WITH_PARAMS(Signal, NcclNvtxParamsSignal,
-  NVTX3_PAYLOAD(comm ? comm->commHash : 0, peer, ctx));
+  NVTX3_FUNC_WITH_PARAMS(Signal, NcclNvtxParamsSignal,
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, peer, ctx));
 
-struct ncclInfo info = { ncclFuncSignal, "Signal",
-  NULL, NULL, 0, ncclInt8, ncclSum, peer, comm, stream, /* Args */
-  1, 1, /* chunkSteps, sliceSteps */
-  0, NULL, sigIdx, ctx, flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
-  0, NULL }; /* nDesc, signalDescs */
-return ncclEnqueueCheck(&info);
+  struct ncclInfo info = { ncclFuncSignal, "Signal",
+    NULL, NULL, 0, ncclInt8, ncclSum, peer, comm, stream, /* Args */
+    1, 1, /* chunkSteps, sliceSteps */
+    0, NULL, sigIdx, ctx, flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
+    0, NULL
+  }; /* nDesc, signalDescs */
+  return ncclEnqueueCheck(&info);
 }
 
 NCCL_API(ncclResult_t, ncclWaitSignal, int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclWaitSignal(int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm, cudaStream_t stream) {
-NVTX3_FUNC_WITH_PARAMS(WaitSignal, NcclNvtxParamsWaitSignal,
-  NVTX3_PAYLOAD(comm ? comm->commHash : 0, nDesc, 0));
+  NVTX3_FUNC_WITH_PARAMS(WaitSignal, NcclNvtxParamsWaitSignal,
+      NVTX3_PAYLOAD(comm ? comm->commHash : 0, nDesc, 0));
 
-struct ncclInfo info = { ncclFuncWaitSignal, "WaitSignal",
-  NULL, NULL, 0, ncclInt32, ncclSum, 0, comm, stream, /* Args */
-  1, 1, /* chunkSteps, sliceSteps */
-  0, NULL, 0, 0, 0, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
-  nDesc, signalDescs }; /* nDesc, signalDescs */
-return ncclEnqueueCheck(&info);
+  struct ncclInfo info = { ncclFuncWaitSignal, "WaitSignal",
+    NULL, NULL, 0, ncclInt32, ncclSum, 0, comm, stream, /* Args */
+    1, 1, /* chunkSteps, sliceSteps */
+    0, NULL, 0, 0, 0, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
+    nDesc, signalDescs
+  }; /* nDesc, signalDescs */
+  return ncclEnqueueCheck(&info);
 }

--- a/src/dev_runtime.cc
+++ b/src/dev_runtime.cc
@@ -151,19 +151,20 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
 
   symTeamDestroyAll(comm);
-  { // delete windowTable
-    cudaStream_t stream;
-    if (CUDASUCCESS(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking))) {
+  {
+    // delete windowTable
+    cudaStream_t tableStream;
+    if (CUDASUCCESS(cudaStreamCreateWithFlags(&tableStream, cudaStreamNonBlocking))) {
       struct ncclDevCommWindowTable* tableDev = devr->windowTable;
       while (tableDev != nullptr) {
         struct ncclDevCommWindowTable* tableHost;
         if (ncclSuccess != ncclShadowPoolToHost(&devr->shadows, tableDev, &tableHost)) break;
         struct ncclDevCommWindowTable* next = tableHost->next;
-        ncclShadowPoolFree(&devr->shadows, tableDev, stream);
+        ncclShadowPoolFree(&devr->shadows, tableDev, tableStream);
         tableDev = next;
       }
-      cudaStreamSynchronize(stream);
-      cudaStreamDestroy(stream);
+      cudaStreamSynchronize(tableStream);
+      cudaStreamDestroy(tableStream);
     }
   }
   if (devr->lsaFlatBase != nullptr) {
@@ -182,7 +183,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
 
 static ncclResult_t symMemoryMapLsaTeam(
     struct ncclComm* comm, CUmemGenericAllocationHandle memHandle, size_t size, size_t bigOffset
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   CUmemAccessDesc accessDesc = {};
@@ -240,23 +241,23 @@ fail:
 
 static ncclResult_t symBindTeamMemory(
     struct ncclComm* comm, struct ncclDevrTeam* tm, struct ncclDevrMemory* mem
-  ) {
+) {
   if (comm->nvlsSupport && tm->mcBasePtr != nullptr) {
-  #if CUDART_VERSION >= 12010
+#if CUDART_VERSION >= 12010
     INFO(NCCL_NVLS, "Binding multicast memory at big=%lx to team {%d x %d}", mem->bigOffset, tm->team.nRanks, tm->team.stride);
     CUCHECK(cuMulticastBindMem(tm->mcHandle, mem->bigOffset, mem->memHandle, 0, mem->size, 0));
-  #endif
+#endif
   }
   return ncclSuccess;
 }
 
 static ncclResult_t symUnbindTeamMemory(
     struct ncclComm* comm, struct ncclDevrTeam* tm, struct ncclDevrMemory* mem
-  ) {
+) {
   if (comm->nvlsSupport && tm->mcBasePtr != nullptr) {
-  #if CUDART_VERSION >= 12010
+#if CUDART_VERSION >= 12010
     CUCHECK(cuMulticastUnbind(tm->mcHandle, comm->cudaDev, mem->bigOffset, mem->size));
-  #endif
+#endif
   }
   return ncclSuccess;
 }
@@ -265,7 +266,7 @@ static ncclResult_t symUnbindTeamMemory(
 static ncclResult_t symTeamObtain(
     struct ncclComm* comm, struct ncclTeam team, bool multimem,
     struct ncclDevrTeam** outTeam
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclDevrTeam* t = devr->teamHead;
@@ -297,7 +298,7 @@ static ncclResult_t symTeamObtain(
       ret = ncclInvalidArgument;
       goto fail;
     } else {
-    #if CUDART_VERSION >= 12010
+#if CUDART_VERSION >= 12010
       CUmemGenericAllocationHandle mcHandle = 0;
       CUdeviceptr mcAddr = 0;
       CUmulticastObjectProp mcProp = {};
@@ -318,7 +319,8 @@ static ncclResult_t symTeamObtain(
       CUCHECKGOTO(cuMulticastAddDevice(mcHandle, comm->cudaDev), ret, fail_mcHandle);
       CUCHECKGOTO(cuMemAddressReserve(&mcAddr, devr->bigSize, NCCL_MAX_PAGE_SIZE, 0, 0), ret, fail_mcHandle);
       CUCHECKGOTO(cuMemMap(mcAddr, devr->bigSize, 0, mcHandle, 0), ret, fail_mcHandle_mcAddr);
-      { CUmemAccessDesc accessDesc = {};
+      {
+        CUmemAccessDesc accessDesc = {};
         accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
         accessDesc.location.id = comm->cudaDev;
         accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
@@ -333,28 +335,28 @@ static ncclResult_t symTeamObtain(
       }
 
       if (false) { // Error labels:
-      fail_mcHandle_mcAddr_unmap_mems:
+fail_mcHandle_mcAddr_unmap_mems:
         for (struct ncclDevrMemory* mem = devr->memHead; mem != nullptr; mem = mem->next) {
           symUnbindTeamMemory(comm, t, mem);
         }
-      fail_mcHandle_mcAddr_unmap:
+fail_mcHandle_mcAddr_unmap:
         CUCHECKIGNORE(cuMemUnmap(mcAddr, devr->bigSize));
         goto fail_mcHandle_mcAddr; // silence unused label warning
-      fail_mcHandle_mcAddr:
+fail_mcHandle_mcAddr:
         CUCHECKIGNORE(cuMemAddressFree(mcAddr, devr->bigSize));
         goto fail_mcHandle; // silence unused label warning
-      fail_mcHandle:
+fail_mcHandle:
         CUCHECKIGNORE(cuMemRelease(mcHandle));
         goto fail; // silence unused label warning
       }
-    #else
+#else
       goto fail; // silence unused label warning
-    #endif
+#endif
     }
   }
 
   if (teamIsNew) {
-     // Add to list
+    // Add to list
     t->next = devr->teamHead;
     devr->teamHead = t;
   }
@@ -402,7 +404,7 @@ static ncclResult_t symMemoryRegisterRma(struct ncclComm* comm, struct ncclDevrM
 static ncclResult_t symMemoryObtain(
     struct ncclComm* comm, CUmemGenericAllocationHandle memHandle, void* memAddr, size_t size, int winFlags,
     struct ncclDevrMemory** outMem
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   int64_t bigOffset = 0;
@@ -475,7 +477,7 @@ fail_mem:
 
 static void symMemoryDropRef(
     struct ncclComm* comm, struct ncclDevrMemory* mem
-  ) {
+) {
   if (mem != nullptr && 0 == --mem->refCount) {
     struct ncclDevrState* devr = &comm->devrState;
     if (devr->ginEnabled) {
@@ -518,7 +520,7 @@ static ncclResult_t symWindowCreate(
     size_t memOffset, void* userPtr, size_t userSize, int winFlags, void* localReg,
     struct ncclWindow_vidmem** outWinDev, struct ncclDevrWindow** outWin,
     cudaStream_t stream
-  ) {
+) {
   uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclDevrWindow* win;
@@ -575,7 +577,8 @@ static ncclResult_t symWindowCreate(
     tableDev = tableHost->next;
   }
 
-  { // insert into winSorted[]
+  {
+    // insert into winSorted[]
     int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, userAddr);
     struct ncclDevrWindowSorted winSort;
     winSort.userAddr = userAddr;
@@ -600,7 +603,8 @@ static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vi
 
   symMemoryDropRef(comm, winHost->memory);
 
-  { struct ncclDevCommWindowTable* tableDev = devr->windowTable;
+  {
+    struct ncclDevCommWindowTable* tableDev = devr->windowTable;
     while (true) {
       struct ncclDevCommWindowTable* tableHost;
       NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, tableDev, &tableHost), ret, remove_winSorted);
@@ -619,8 +623,8 @@ static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vi
 
   NCCLCHECKGOTO(ncclCommDeregister(comm, winHost->localRegHandle), ret, remove_winSorted);
 
-remove_winSorted:
-  { int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, reinterpret_cast<uintptr_t>(winHost->userPtr));
+remove_winSorted: {
+    int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, reinterpret_cast<uintptr_t>(winHost->userPtr));
     i -= 1; // least upper bound is just after ours.
     listRemove(devr->winSorted, &devr->winSortedCount, i);
   }
@@ -638,7 +642,7 @@ fail:
 ncclResult_t ncclDevrWindowRegisterInGroup(
     struct ncclComm* comm,
     void* userPtr, size_t userSize, int winFlags, ncclWindow_t* outWinDev
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   CUdeviceptr memAddr = 0;
   size_t memSize = 0;
@@ -682,7 +686,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail_locReg_memHandle_mem);
 
   NCCLCHECKGOTO(symWindowCreate(
-      comm, mem, memOffset, userPtr, userSize, winFlags, localRegHandle, outWinDev, &winHost, stream
+    comm, mem, memOffset, userPtr, userSize, winFlags, localRegHandle, outWinDev, &winHost, stream
     ), ret, fail_locReg_memHandle_mem_stream);
   mem = nullptr; // symWindowCreate took our reference
 
@@ -783,7 +787,7 @@ void freeDevCommRequirements(
 
 bool ncclGinResourcesRequested(struct ncclDevCommRequirements const* reqs) {
   bool requestedGinResources = reqs->ginSignalCount > 0 || reqs->ginCounterCount > 0 ||
-                               reqs->barrierCount > 0 || reqs->railGinBarrierCount > 0;
+      reqs->barrierCount > 0 || reqs->railGinBarrierCount > 0;
 
   struct ncclDevResourceRequirements* node = reqs->resourceRequirementsList;
   while (!requestedGinResources && node != nullptr) {
@@ -800,7 +804,7 @@ ncclResult_t ncclDevrCommCreateInternal(
     struct ncclComm* comm,
     struct ncclDevCommRequirements const* reqs, struct ncclDevComm* outDevComm, bool isInternal,
     ncclResult_t (*outDevCommCopyCB)(struct ncclDevComm const* tmpDevComm, void* out)
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclTeam world = ncclTeamWorld(comm);
@@ -828,9 +832,9 @@ ncclResult_t ncclDevrCommCreateInternal(
 
   if (reqs->ginForceEnable) {
     INFO(NCCL_INIT,
-         "ginForceEnable set to true, defaulting ginConnectionType to NCCL_GIN_CONNECTION_FULL");
+        "ginForceEnable set to true, defaulting ginConnectionType to NCCL_GIN_CONNECTION_FULL");
     INFO(NCCL_INIT,
-         "ginForceEnable is being deprecated in favor of explicitly setting ginConnectionType!");
+        "ginForceEnable is being deprecated in favor of explicitly setting ginConnectionType!");
     requestedConnectionType = NCCL_GIN_CONNECTION_FULL;
   }
 
@@ -864,8 +868,8 @@ ncclResult_t ncclDevrCommCreateInternal(
     NCCLCHECKGOTO(ncclGinConnectOnce(comm, requestedConnectionType, reqs->ginContextCount, reqs->ginQueueDepth), ret, fail);
     // Register all preexisting memories with GIN. Update the windows later when
     // we have a stream.
-    for (struct ncclDevrMemory* mem = devr->memHead; mem != nullptr; mem = mem->next) {
-      NCCLCHECKGOTO(symMemoryRegisterGin(comm, mem), ret, fail);
+    for (struct ncclDevrMemory* memIter = devr->memHead; memIter != nullptr; memIter = memIter->next) {
+      NCCLCHECKGOTO(symMemoryRegisterGin(comm, memIter), ret, fail);
     }
   }
   if (devr->ginEnabled) {
@@ -892,8 +896,8 @@ ncclResult_t ncclDevrCommCreateInternal(
       }
       if (nGinContexts < reqs->ginContextCount) {
         INFO(NCCL_INIT|NCCL_NET,
-             "Capping the number of GIN contexts to %d (%d requested). Use NCCL_GIN_NCONTEXTS to increase the limit",
-             nGinContexts, reqs->ginContextCount);
+            "Capping the number of GIN contexts to %d (%d requested). Use NCCL_GIN_NCONTEXTS to increase the limit",
+            nGinContexts, reqs->ginContextCount);
       }
     }
   }
@@ -918,7 +922,8 @@ ncclResult_t ncclDevrCommCreateInternal(
   NCCLCHECKGOTO(symTeamObtain(comm, lsa, /*multicast=*/reqs->lsaMultimem, &tmLsa), ret, fail);
   outDevComm->lsaMultimem.mcBasePtr = tmLsa->mcBasePtr;
 
-  { struct ncclTeamRequirements* tr = reqs->teamRequirementsList;
+  {
+    struct ncclTeamRequirements* tr = reqs->teamRequirementsList;
     while (tr != nullptr) {
       if (tr->multimem) {
         struct ncclDevrTeam* tm;
@@ -939,7 +944,8 @@ ncclResult_t ncclDevrCommCreateInternal(
   railGinBarrierReq.next = resReqsHead;
   resReqsHead = &railGinBarrierReq;
 
-  { struct ncclDevResourceRequirements* rr = resReqsHead;
+  {
+    struct ncclDevResourceRequirements* rr = resReqsHead;
     bufSizeTotal = 0;
     ginSignalTotal = reqs->ginSignalCount;
     ginCounterTotal = reqs->ginCounterCount;
@@ -964,14 +970,14 @@ ncclResult_t ncclDevrCommCreateInternal(
   if (ginActivated) {
     // Now update the GIN handles in all existing windows. Registration of memories happened above.
     for (int i=0; i < devr->winSortedCount; i++) {
-      struct ncclDevrWindow* win = devr->winSorted[i].win;
-      struct ncclWindow_vidmem* winHost;
-      NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, win->vidmem, &winHost), ret, fail_stream);
-      winHost->ginOffset4K = (win->bigOffset - win->memory->bigOffset)>>12;
-      for (int i=0; i < NCCL_GIN_MAX_CONNECTIONS; i++) {
-        winHost->ginWins[i] = win->memory->ginDevWins[i];
+      struct ncclDevrWindow* winIter = devr->winSorted[i].win;
+      struct ncclWindow_vidmem* winHostIter;
+      NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winIter->vidmem, &winHostIter), ret, fail_stream);
+      winHostIter->ginOffset4K = (winIter->bigOffset - winIter->memory->bigOffset)>>12;
+      for (int j=0; j < NCCL_GIN_MAX_CONNECTIONS; j++) {
+        winHostIter->ginWins[j] = winIter->memory->ginDevWins[j];
       }
-      CUDACHECKGOTO(cudaMemcpyAsync(win->vidmem, winHost, sizeof(struct ncclWindow_vidmem), cudaMemcpyHostToDevice, stream), ret, fail_stream);
+      CUDACHECKGOTO(cudaMemcpyAsync(winIter->vidmem, winHostIter, sizeof(struct ncclWindow_vidmem), cudaMemcpyHostToDevice, stream), ret, fail_stream);
     }
   }
 
@@ -1016,7 +1022,7 @@ ncclResult_t ncclDevrCommCreateInternal(
     NCCLCHECKGOTO(ncclGinAllocSignalsCounters(comm,
       ginSignalTotal, &outDevComm->ginSignalBase,
       ginCounterTotal, &outDevComm->ginCounterBase
-    ), ret, fail_stream_mem_win);
+      ), ret, fail_stream_mem_win);
     if (ginExclusiveContexts) {
       comm->sharedRes->ginState.ctxLastExclusive -= nGinContexts;
       outDevComm->ginContextBase = comm->sharedRes->ginState.ctxLastExclusive;
@@ -1025,8 +1031,8 @@ ncclResult_t ncclDevrCommCreateInternal(
       outDevComm->ginContextBase = 0;
     }
     INFO(NCCL_INIT|NCCL_NET, "Initialized a devComm with %d GIN connections, %d %s contexts (base %d), %d signals (base %d), %d counters (base %d)",
-         nGinConnections, nGinContexts, (ginExclusiveContexts ? "exclusive" : "shared"),
-         outDevComm->ginContextBase, ginSignalTotal, outDevComm->ginSignalBase, ginCounterTotal, outDevComm->ginCounterBase);
+      nGinConnections, nGinContexts, (ginExclusiveContexts ? "exclusive" : "shared"),
+      outDevComm->ginContextBase, ginSignalTotal, outDevComm->ginSignalBase, ginCounterTotal, outDevComm->ginCounterBase);
 
     for (int connectionId=0; connectionId < nGinConnections; connectionId++) {
       outDevComm->ginNetDeviceTypes[connectionId] = (int)comm->sharedRes->ginState.ginDevHandles[connectionId]->netDeviceType;
@@ -1045,8 +1051,8 @@ ncclResult_t ncclDevrCommCreateInternal(
 fail_stream_mem_win_signals:
   if (devr->ginEnabled) {
     ncclGinFreeSignalsCounters(comm,
-      outDevComm->ginSignalBase, outDevComm->ginSignalCount,
-      outDevComm->ginCounterBase, outDevComm->ginCounterCount
+        outDevComm->ginSignalBase, outDevComm->ginSignalCount,
+        outDevComm->ginCounterBase, outDevComm->ginCounterCount
     );
   }
 fail_stream_mem_win:
@@ -1131,7 +1137,7 @@ exit:
 
 ncclResult_t ncclDevrFindWindow(
     struct ncclComm* comm, void const* userPtr, struct ncclDevrWindow** outWin
-  ) {
+) {
   struct ncclDevrState* devr = &comm->devrState;
   uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
   int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, userAddr);
@@ -1307,7 +1313,7 @@ static ncclResult_t ncclDevCommCreateCopyCB_v22902(struct ncclDevComm const* tmp
 static ncclResult_t ncclDevCommCreateCommon(
     ncclComm_t comm, struct ncclDevCommRequirements const* reqs,
     struct ncclDevComm* outDevComm, ncclResult_t (*outDevCommCopyCB)(struct ncclDevComm const* tmpDevComm, void* out)
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   int saveDev;
   struct ncclDevrCommCreateTask* task = nullptr;
@@ -1347,7 +1353,7 @@ fail:
 static ncclResult_t ncclDevCommCreate_v22902(
     ncclComm_t comm, struct ncclDevCommRequirements_v22902 const* reqs,
     struct ncclDevComm_v22902* outDevComm
-  ) {
+) {
   ncclDevCommRequirements_t newReqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
 
   bool userRequestedGin = reqs->ginForceEnable || reqs->ginSignalCount > 0 || reqs->ginCounterCount > 0;
@@ -1384,7 +1390,7 @@ NCCL_API(ncclResult_t, ncclDevCommCreate, ncclComm_t comm, ncclDevCommRequiremen
 ncclResult_t ncclDevCommCreate(
     ncclComm_t comm, struct ncclDevCommRequirements const* reqs,
     struct ncclDevComm* outDevComm
-  ) {
+) {
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(reqs, __func__, "reqs"));
   if (reqs->magic != NCCL_API_MAGIC) {
@@ -1396,7 +1402,7 @@ ncclResult_t ncclDevCommCreate(
 
   if (reqs->version >= NCCL_VERSION(2, 29, 2) && reqs->version <= NCCL_VERSION(2, 29, 3)) {
     NCCLCHECK(ncclDevCommCreate_v22902(comm, (const struct ncclDevCommRequirements_v22902*)reqs,
-                                       (struct ncclDevComm_v22902*)outDevComm));
+      (struct ncclDevComm_v22902*)outDevComm));
     return ncclSuccess;
   }
 
@@ -1406,7 +1412,7 @@ ncclResult_t ncclDevCommCreate(
 NCCL_API(ncclResult_t, ncclDevCommDestroy, ncclComm_t comm, ncclDevComm_t const* devComm);
 ncclResult_t ncclDevCommDestroy(
     struct ncclComm* comm, struct ncclDevComm const* devComm
-  ) {
+) {
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(devComm, __func__, "devComm"));
   struct ncclDevrState* devr = &comm->devrState;
@@ -1414,8 +1420,8 @@ ncclResult_t ncclDevCommDestroy(
     NCCLCHECK(ncclGinResetSignalsAndCounters(comm, devComm));
 
     ncclGinFreeSignalsCounters(comm,
-      devComm->ginSignalBase, devComm->ginSignalCount,
-      devComm->ginCounterBase, devComm->ginCounterCount
+        devComm->ginSignalBase, devComm->ginSignalCount,
+        devComm->ginCounterBase, devComm->ginCounterCount
     );
 
     if (devComm->ginContextBase == comm->sharedRes->ginState.ctxLastExclusive) {
@@ -1470,7 +1476,7 @@ ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow*
   }
 
   // Validate offset is within bounds
-  if (offset < 0 || offset >= winHost->size) {
+  if (offset >= winHost->size) {
     return ncclInvalidArgument;
   }
 
@@ -1491,7 +1497,7 @@ ncclGinWindow_t ncclDevrGetRmaDevWin(struct ncclDevrWindow* winHost, int ctx) {
 }
 
 // Get the multicast address for a given team
-ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, struct ncclTeam lsaTeam, void** outPtr){
+ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, struct ncclTeam lsaTeam, void** outPtr) {
   if (winHost == nullptr || outPtr == nullptr) return ncclInternalError;
 
   if (!comm->nvlsSupport) {
@@ -1514,7 +1520,7 @@ static ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow
   NCCLCHECK(ncclIntruAddressMapFind(&ncclWindowMap, devWindow, &winHost));
   if (winHost == nullptr) {
     WARN("Could not find communicator matching window %p (map hbits=%d count=%d)",
-         devWindow, ncclWindowMap.base.hbits, ncclWindowMap.base.count);
+      devWindow, ncclWindowMap.base.hbits, ncclWindowMap.base.count);
     return ncclInvalidArgument;
   }
 
@@ -1581,7 +1587,7 @@ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsa
   devr = &comm->devrState;
   if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
     WARN("The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.",
-         lsaRank, devr->lsaSize, window);
+        lsaRank, devr->lsaSize, window);
     return ncclInvalidArgument; // In this case the user should know what the lsa size is.
   }
 

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -47,11 +47,11 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
     for (int k=0; k < kcount; k++) {
       if (kptrs[k] != nullptr && driverVersion < krequires[k]) {
         INFO(NCCL_INIT, "Skipping %skernel %d which requires driver %d",
-             sym ? "symmetric " : "", k, krequires[k]);
+            sym ? "symmetric " : "", k, krequires[k]);
         kptrs[k] = nullptr;
       }
       void* fn = kptrs[k];
-      cudaFuncAttributes attr = {0};
+      cudaFuncAttributes attr = {};
       if (fn == nullptr) continue;
 
       if (!CUDASUCCESS(cudaFuncGetAttributes(&attr, fn))) continue; // Silently ignore failures
@@ -63,9 +63,10 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
         CUDACHECKGOTO(cudaFuncSetAttribute(fn,
           cudaFuncAttributePreferredSharedMemoryCarveout, carveout),
           result, ignore1);
-      ignore1:;
+ignore1:;
       }
-      { int dynSmem = maxSharedMem - attr.sharedSizeBytes;
+      {
+        int dynSmem = maxSharedMem - attr.sharedSizeBytes;
         if (sym) {
           ncclSymkKernelMaxDynamicSmem[k] = dynSmem;
         } else {
@@ -75,13 +76,13 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
           cudaFuncAttributeMaxDynamicSharedMemorySize, dynSmem),
           result, next_kernel);
       }
-    next_kernel:;
+next_kernel:;
     }
   }
 
   if (ncclShmemDynamicSize(cudaArch) > maxDynamicSmem) {
     WARN("cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d",
-         cudaArch, ncclShmemDynamicSize(cudaArch), maxDynamicSmem);
+        cudaArch, ncclShmemDynamicSize(cudaArch), maxDynamicSmem);
     return ncclSystemError;
   }
   return result;
@@ -92,10 +93,10 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
 
 static inline int ncclFuncTrafficPerByte(ncclFunc_t func, int nRanks) {
   switch (func) {
-  case ncclFuncAllReduce: return 2;
-  case ncclFuncAllGather: return nRanks;
-  case ncclFuncReduceScatter: return nRanks;
-  default: return 1;
+    case ncclFuncAllReduce: return 2;
+    case ncclFuncAllGather: return nRanks;
+    case ncclFuncReduceScatter: return nRanks;
+    default: return 1;
   }
 }
 
@@ -103,7 +104,7 @@ static inline int ncclFuncTrafficPerByte(ncclFunc_t func, int nRanks) {
 /*       Launch system : synchronization and CUDA kernel launch              */
 /*****************************************************************************/
 
-ncclResult_t ncclAddProxyOpIfNeeded(struct ncclComm* comm, struct ncclKernelPlan* plan, struct ncclProxyOp* op) {
+ncclResult_t ncclAddProxyOpIfNeeded(struct ncclComm* comm, struct ncclKernelPlan* /*plan*/, struct ncclProxyOp* op) {
   bool needed = true;
   NCCLCHECK(ncclProxySaveOp(comm, op, &needed));
   if (needed) {
@@ -120,7 +121,7 @@ void ncclAddWorkBatchToPlan(
     struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
     enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset,
     int p2pEpoch, int p2pRound, bool newBatch
-  ) {
+) {
   size_t workSize = ncclDevWorkSize(workType);
   ncclKernelPlanner::WipPlan::Channel* chan = &comm->planner.wipPlan.channels[channelId];
   // Conditions causing us to create a new blank batch.
@@ -277,8 +278,8 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
 NCCL_PARAM(GraphRegister, "GRAPH_REGISTER", 1);
 
 static ncclResult_t calcCollChunking(
-  struct ncclComm* comm, struct ncclTaskColl* task, int nChannels, size_t nBytes,
-  /*outputs*/uint32_t* outChunkSize, uint32_t* outDirectFlags, struct ncclProxyOp* proxyOp
+    struct ncclComm* comm, struct ncclTaskColl* task, int nChannels, size_t nBytes,
+    /*outputs*/uint32_t* outChunkSize, uint32_t* outDirectFlags, struct ncclProxyOp* proxyOp
 );
 
 struct ncclKernelPlanBudget {
@@ -288,7 +289,7 @@ struct ncclKernelPlanBudget {
 
 bool ncclTestBudget(
     struct ncclKernelPlanBudget* budget, int nWorkBatches, ssize_t workBytes
-  ) {
+) {
   ssize_t batchBytes = nWorkBatches*sizeof(struct ncclDevWorkBatch);
   bool ok = false;
   ok |= (batchBytes + workBytes <= budget->inArgsBytes);
@@ -438,15 +439,15 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
 
       int isCollnet=0, isNvls=0;
       switch (agg.algorithm) {
-      case NCCL_ALGO_NVLS:
-      case NCCL_ALGO_NVLS_TREE:
-        isNvls = 1;
-        isCollnet = agg.algorithm == NCCL_ALGO_NVLS && comm->nNodes > 1;
-        break;
-      case NCCL_ALGO_COLLNET_CHAIN:
-      case NCCL_ALGO_COLLNET_DIRECT:
-        isCollnet = 1;
-        break;
+        case NCCL_ALGO_NVLS:
+        case NCCL_ALGO_NVLS_TREE:
+          isNvls = 1;
+          isCollnet = agg.algorithm == NCCL_ALGO_NVLS && comm->nNodes > 1;
+          break;
+        case NCCL_ALGO_COLLNET_CHAIN:
+        case NCCL_ALGO_COLLNET_DIRECT:
+          isCollnet = 1;
+          break;
       }
       // Update the aggregated tasks with the computed values.
       do {
@@ -570,14 +571,15 @@ static ncclResult_t addProfilerProxyOpIfNeeded(struct ncclComm* comm, struct ncc
 
 static ncclResult_t scheduleCollTasksToPlan(
     struct ncclComm* comm, struct ncclKernelPlan* plan, struct ncclKernelPlanBudget* budget
-  ) {
+) {
   struct ncclKernelPlanner* planner = &comm->planner;
   // Estimate number of tasks that will fit in this plan.
   int nPlanColls = 0;
-  size_t trafficBytes[2*2] = {0, 0, 0, 0}; // [collnet][nvls]
-  int nChannels[2*2] = {0, 0, 0, 0}; // [collnet][nvls]
+  size_t trafficBytes[2*2] = {}; // [collnet][nvls]
+  int nChannels[2*2] = {}; // [collnet][nvls]
   int const nMaxChannels[2*2] = {comm->nChannels, comm->nvlsChannels, // [collnet][nvls]
-                                 comm->nChannels, std::min(comm->nChannels, comm->nvlsChannels)};
+          comm->nChannels, std::min(comm->nChannels, comm->nvlsChannels)
+      };
   constexpr size_t MinTrafficPerChannel = 32 << 10; // 32K traffic as minimal
   do {
     size_t workBytes = 0;
@@ -596,7 +598,7 @@ static ncclResult_t scheduleCollTasksToPlan(
       task = task->next;
       workNode = workNode->next;
     }
-  plan_full:;
+plan_full:;
   } while (0);
 
   int kindPrev = -1;
@@ -618,18 +620,18 @@ static ncclResult_t scheduleCollTasksToPlan(
     }
 
     if (task->isCollnet) {
-      int nChannels = task->nMaxChannels;
+      int nCh = task->nMaxChannels;
       // Ensure room for worst case of one new batch per channel
-      if (!ncclTestBudget(budget, plan->nWorkBatches + nChannels, plan->workBytes + workNode->size)) {
+      if (!ncclTestBudget(budget, plan->nWorkBatches + nCh, plan->workBytes + workNode->size)) {
         return ncclSuccess;
       }
 
       size_t globalBytesPerElement = elementSize*ncclFuncMaxSendRecvCount(task->func, comm->nRanks, 1);
       struct ncclProxyOp proxyOp;
       uint32_t chunkSize, directFlags=0;
-      NCCLCHECK(calcCollChunking(comm, task, nChannels, globalBytesPerElement*task->count, &chunkSize, &directFlags, &proxyOp));
+      NCCLCHECK(calcCollChunking(comm, task, nCh, globalBytesPerElement*task->count, &chunkSize, &directFlags, &proxyOp));
       devWork->channelLo = 0;
-      devWork->channelHi = nChannels-1;
+      devWork->channelHi = nCh-1;
       devWork->collnet.count = task->count;
       devWork->collnet.chunkCount = chunkSize/ncclTypeSize(task->datatype);
       devWork->direct = directFlags;
@@ -664,8 +666,8 @@ static ncclResult_t scheduleCollTasksToPlan(
       }
       int nMidChannels = (cells-cellsLo)/cellsPerChannel;
       size_t cellsHi = (cells-cellsLo)%cellsPerChannel;
-      int nChannels = (cellsLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
-      if (nMaxChannels[kind] < channelId + nChannels) { // Overflowed available channels
+      int nCh = (cellsLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
+      if (nMaxChannels[kind] < channelId + nCh) { // Overflowed available channels
         nMidChannels = nMaxChannels[kind] - channelId - 2;
         cellsPerChannel = (cells-cellsLo)/(nMidChannels+1);
         cellsHi = cellsPerChannel + (cells-cellsLo)%(nMidChannels+1);
@@ -684,18 +686,18 @@ static ncclResult_t scheduleCollTasksToPlan(
       size_t countHi = cellsHi*elementsPerCell;
       (countHi != 0 ? countHi : countLo) -= cells*elementsPerCell - task->count;
 
-      nChannels = (countLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
+      nCh = (countLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
 
       // Update number of channels propagated to the profiler
-      task->nChannels = (uint8_t)nChannels;
+      task->nChannels = (uint8_t)nCh;
 
       // Ensure room for worst case of one new batch per channel
-      if (!ncclTestBudget(budget, plan->nWorkBatches + nChannels, plan->workBytes + workNode->size)) {
+      if (!ncclTestBudget(budget, plan->nWorkBatches + nCh, plan->workBytes + workNode->size)) {
         return ncclSuccess;
       }
 
       devWork->channelLo = channelId;
-      devWork->channelHi = channelId + nChannels-1;
+      devWork->channelHi = channelId + nCh-1;
       devWork->cbd.countLo = countLo;
       devWork->cbd.countMid = countMid;
       devWork->cbd.countHi = countHi;
@@ -723,10 +725,10 @@ static ncclResult_t scheduleCollTasksToPlan(
 
       // Update the current channel and vacant traffic budget.
       if (countHi != 0) {
-        channelId += nChannels-1;
+        channelId += nCh-1;
         currentTraffic = cellsHi*elementsPerCell*trafficPerElement;
       } else if (nMidChannels != 0) {
-        channelId += nChannels;
+        channelId += nCh;
         currentTraffic = 0;
       } else {
         currentTraffic += cellsLo*elementsPerCell*trafficPerElement;
@@ -770,7 +772,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         }
         proxyOp->eActivationMask = task->eActivationMask;
         proxyOp->incWorkCounter = true;
-        proxyOp->nChannels = nChannels;
+        proxyOp->nChannels = nCh;
         ncclAddWorkBatchToPlan(comm, plan, c, workNode->workType, task->devFuncId, plan->workBytes);
         // Coverity reports "proxyOp->connection" as being possibly uninitialized.  It's hard to
         // determine if that's actually true but it's also not clear if that would be an issue.
@@ -791,8 +793,8 @@ static ncclResult_t scheduleCollTasksToPlan(
 
     if (comm->rank == 0) {
       INFO(NCCL_TUNING, "%s: %ld Bytes -> Algo %s proto %s channel{Lo..Hi}={%d..%d}",
-        ncclFuncToString(task->func), task->count * ncclTypeSize(task->datatype), ncclAlgoToString(task->algorithm),
-        ncclProtoToString(task->protocol), devWork->channelLo, devWork->channelHi);
+          ncclFuncToString(task->func), task->count * ncclTypeSize(task->datatype), ncclAlgoToString(task->algorithm),
+          ncclProtoToString(task->protocol), devWork->channelLo, devWork->channelHi);
 
       if (task->isCollnet) {
         TRACE(NCCL_COLL, "Collective %s(%s, %s, %s, %s) count=%ld devFuncId=%d channel{Lo..Hi}={%d..%d} count=%ld chunkCount=%d",
@@ -841,7 +843,7 @@ static ncclResult_t addP2pToPlan(
     int sendRank, void* sendAddr, ssize_t sendBytes,
     int recvRank, void* recvAddr, ssize_t recvBytes,
     const int planTotalTasks[], struct ncclTaskP2p** p2pTasks
-  ) {
+) {
   ncclResult_t ret = ncclSuccess;
   constexpr int connIndex = 1;
   bool selfSend = (sendRank == comm->rank);
@@ -862,7 +864,7 @@ static ncclResult_t addP2pToPlan(
       for (int dir=0; dir <= 1; dir++) {
         int peerRank = dir ? sendRank : recvRank;
         struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex]
-                                         : &channelPeers[peerRank]->recv[connIndex];
+              : &channelPeers[peerRank]->recv[connIndex];
         protoLL[dir] &= conn->conn.buffs[NCCL_PROTO_LL] != nullptr;
         network[dir] |= conn->transportComm == (dir ? &netTransport.send : &netTransport.recv);
         proxySameProcess[dir] &= conn->proxyConn.sameProcess;
@@ -934,10 +936,10 @@ static ncclResult_t addP2pToPlan(
             struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
             int peerRank = dir ? sendRank : recvRank;
             struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex]
-              : &channelPeers[peerRank]->recv[connIndex];
-              if (conn->conn.flags & NCCL_DIRECT_NIC)
-                ncclRegisterP2pNetBuffer(comm, addrs[dir], bytes[dir], conn, &regFlag, &handles[dir][part], &plan->cleanupQueue);
-              if (!regFlag) break;
+                  : &channelPeers[peerRank]->recv[connIndex];
+            if (conn->conn.flags & NCCL_DIRECT_NIC)
+              ncclRegisterP2pNetBuffer(comm, addrs[dir], bytes[dir], conn, &regFlag, &handles[dir][part], &plan->cleanupQueue);
+            if (!regFlag) break;
           }
           netRegistered[dir] = regFlag ? true : false;
         }
@@ -947,17 +949,17 @@ static ncclResult_t addP2pToPlan(
         int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, 0);
         struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
         struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex]
-          : &channelPeers[peerRank]->recv[connIndex];
-          void* regAddr = NULL;
-          if (conn->conn.flags & (NCCL_P2P_WRITE | NCCL_P2P_READ)) {
-            // We require users registering buffers on both sides
-            NCCLCHECKGOTO(ncclRegisterP2pIpcBuffer(comm, addrs[dir], bytes[dir], peerRank, &regFlag, &regAddr, &plan->cleanupQueue), ret, cleanup);
-            if (regFlag) {
-              if (dir == 0 && (conn->conn.flags & NCCL_P2P_WRITE)) recvAddr = regAddr;
-              else if (dir == 1 && (conn->conn.flags & NCCL_P2P_READ)) sendAddr = regAddr;
-            }
+              : &channelPeers[peerRank]->recv[connIndex];
+        void* regAddr = NULL;
+        if (conn->conn.flags & (NCCL_P2P_WRITE | NCCL_P2P_READ)) {
+          // We require users registering buffers on both sides
+          NCCLCHECKGOTO(ncclRegisterP2pIpcBuffer(comm, addrs[dir], bytes[dir], peerRank, &regFlag, &regAddr, &plan->cleanupQueue), ret, cleanup);
+          if (regFlag) {
+            if (dir == 0 && (conn->conn.flags & NCCL_P2P_WRITE)) recvAddr = regAddr;
+            else if (dir == 1 && (conn->conn.flags & NCCL_P2P_READ)) sendAddr = regAddr;
           }
-          ipcRegistered[dir] = regFlag ? true : false;
+        }
+        ipcRegistered[dir] = regFlag ? true : false;
       }
     }
   }
@@ -1033,26 +1035,26 @@ static ncclResult_t addP2pToPlan(
       // Partition steps across channels.
       int nParts = dir ? work->nSendChannels : work->nRecvChannels;
       void* addr = dir ? work->sendAddr : work->recvAddr;
-      size_t bytes = dir ? work->sendBytes : work->recvBytes;
+      size_t dirBytes = dir ? work->sendBytes : work->recvBytes;
 
       proxyOps[dir].recvbuff = nullptr;
       if (nParts <= part) {
         proxyOps[dir].nsteps = 0;
-      } else if (bytes == 0) {
+      } else if (dirBytes == 0) {
         proxyOps[dir].nsteps = 1;
         proxyOps[dir].nbytes = 0;
       } else {
-        size_t chunkDataSize = u32fp8Decode(dir ? work->sendChunkSize_u32fp8 : work->recvChunkSize_u32fp8);
+        size_t partChunkDataSize = u32fp8Decode(dir ? work->sendChunkSize_u32fp8 : work->recvChunkSize_u32fp8);
         size_t partBeg, partEnd;
-        ncclP2pPartBounds(nParts, part, bytes, &partBeg, &partEnd);
+        ncclP2pPartBounds(nParts, part, dirBytes, &partBeg, &partEnd);
         if (proxyOps[dir].reg) {
           (dir ? proxyOps[dir].sendbuff : proxyOps[dir].recvbuff) = (uint8_t*)addr + partBeg;
           (dir ? proxyOps[dir].sendMhandle : proxyOps[dir].recvMhandle) = handles[dir][part];
           proxyOps[dir].nbytes = partEnd - partBeg;
           proxyOps[dir].nsteps = DIVUP(proxyOps[dir].nbytes, NCCL_MAX_NET_SIZE);
         } else {
-          proxyOps[dir].nsteps = divUp(partEnd-partBeg, chunkDataSize);
-          proxyOps[dir].nbytes = std::min(partEnd-partBeg, chunkDataSize);
+          proxyOps[dir].nsteps = divUp(partEnd-partBeg, partChunkDataSize);
+          proxyOps[dir].nbytes = std::min(partEnd-partBeg, partChunkDataSize);
         }
         if (proxyOps[dir].protocol == NCCL_PROTO_LL) {
           proxyOps[dir].nbytes *= 2;
@@ -1196,19 +1198,19 @@ static ncclResult_t waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desire
 }
 
 namespace {
-  struct uploadWork_cleanup_t {
-    struct ncclCommEventCallback base;
-    void *hostBuf;
-  };
-  ncclResult_t uploadWork_cleanup_fn(
-      struct ncclComm* comm, struct ncclCommEventCallback* cb
-    ) {
-    struct uploadWork_cleanup_t* me = (struct uploadWork_cleanup_t*)cb;
-    ncclOsAlignedFree(me->hostBuf);
-    CUDACHECK(cudaEventDestroy(me->base.event));
-    free(me);
-    return ncclSuccess;
-  }
+struct uploadWork_cleanup_t {
+  struct ncclCommEventCallback base;
+  void *hostBuf;
+};
+ncclResult_t uploadWork_cleanup_fn(
+    struct ncclComm* /*comm*/, struct ncclCommEventCallback* cb
+) {
+  struct uploadWork_cleanup_t* me = (struct uploadWork_cleanup_t*)cb;
+  ncclOsAlignedFree(me->hostBuf);
+  CUDACHECK(cudaEventDestroy(me->base.event));
+  free(me);
+  return ncclSuccess;
+}
 }
 
 static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* plan) {
@@ -1220,32 +1222,32 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
   uint32_t fifoCursor, fifoMask;
 
   switch (plan->workStorageType) {
-  case ncclDevWorkStorageTypeArgs:
-    plan->kernelArgs->workBuf = nullptr;
-    fifoBufHost = (void*)plan->kernelArgs;
-    fifoCursor = sizeof(ncclDevKernelArgs) + batchBytes;
-    fifoMask = ~0u;
-    break;
-  case ncclDevWorkStorageTypeFifo:
-    fifoBufHost = comm->workFifoBuf;
-    fifoCursor = comm->workFifoProduced;
-    fifoMask = comm->workFifoBytes-1;
-    NCCLCHECK(waitWorkFifoAvailable(comm, fifoCursor + workBytes));
-    plan->kernelArgs->workBuf = comm->workFifoBufDev;
-    break;
-  case ncclDevWorkStorageTypePersistent:
-    // We rely on 16-byte alignment
-    #if __cplusplus >= 201103L
-    fifoBufHost = ncclOsAlignedAlloc(16, ROUNDUP(workBytes, 16));
-    #else
-    static_assert(16 <= alignof(max_align_t), "We rely on 16-byte alignment.");
-    fifoBufHost = malloc(workBytes);
-    #endif
-    fifoCursor = 0;
-    fifoMask = ~0u;
-    break;
-  default:
-    return ncclInternalError;
+    case ncclDevWorkStorageTypeArgs:
+      plan->kernelArgs->workBuf = nullptr;
+      fifoBufHost = (void*)plan->kernelArgs;
+      fifoCursor = sizeof(ncclDevKernelArgs) + batchBytes;
+      fifoMask = ~0u;
+      break;
+    case ncclDevWorkStorageTypeFifo:
+      fifoBufHost = comm->workFifoBuf;
+      fifoCursor = comm->workFifoProduced;
+      fifoMask = comm->workFifoBytes-1;
+      NCCLCHECK(waitWorkFifoAvailable(comm, fifoCursor + workBytes));
+      plan->kernelArgs->workBuf = comm->workFifoBufDev;
+      break;
+    case ncclDevWorkStorageTypePersistent:
+      // We rely on 16-byte alignment
+#if __cplusplus >= 201103L
+      fifoBufHost = ncclOsAlignedAlloc(16, ROUNDUP(workBytes, 16));
+#else
+      static_assert(16 <= alignof(max_align_t), "We rely on 16-byte alignment.");
+      fifoBufHost = malloc(workBytes);
+#endif
+      fifoCursor = 0;
+      fifoMask = ~0u;
+      break;
+    default:
+      return ncclInternalError;
   }
   plan->kernelArgs->workMask = fifoMask;
 
@@ -1266,9 +1268,9 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
     char* src = (char*)(workNode+1);
     for (int n = workNode->size; n != 0; n -= 16) {
       memcpy(
-        COMPILER_ASSUME_ALIGNED(dst + (fifoCursor & fifoMask), 16),
-        COMPILER_ASSUME_ALIGNED(src, 16),
-        16
+          COMPILER_ASSUME_ALIGNED(dst + (fifoCursor & fifoMask), 16),
+          COMPILER_ASSUME_ALIGNED(src, 16),
+          16
       );
       fifoCursor += 16;
       src += 16;
@@ -1277,12 +1279,12 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
   }
 
   switch (plan->workStorageType) {
-  case ncclDevWorkStorageTypeFifo:
-    comm->workFifoProduced = fifoCursor;
-    if (comm->workFifoBufGdrHandle != nullptr) wc_store_fence();
-    break;
-  case ncclDevWorkStorageTypePersistent:
-    { ncclResult_t result = ncclSuccess;
+    case ncclDevWorkStorageTypeFifo:
+      comm->workFifoProduced = fifoCursor;
+      if (comm->workFifoBufGdrHandle != nullptr) wc_store_fence();
+      break;
+    case ncclDevWorkStorageTypePersistent: {
+      ncclResult_t result = ncclSuccess;
       struct uploadWork_cleanup_t* cleanup = nullptr;
       cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
       void* fifoBufDev = nullptr;
@@ -1313,14 +1315,14 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
       NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false), result, fail);
       NCCLCHECKGOTO(ncclCommPollEventCallbacks(comm, /*waitSome=*/false), result, fail);
 
-    finish_scope:
+finish_scope:
       if (mode != cudaStreamCaptureModeRelaxed) (void)cudaThreadExchangeStreamCaptureMode(&mode);
       return result;
-    fail:
+fail:
       if (!cleanup) ncclOsAlignedFree(fifoBufHost);
       goto finish_scope;
     } break;
-  default: break;
+    default: break;
   }
   return ncclSuccess;
 }
@@ -1486,11 +1488,11 @@ static void persistentDestructor(void* plans_) {
 NCCL_PARAM(LaunchOrderImplicit, "LAUNCH_ORDER_IMPLICIT", 0);
 
 namespace {
-  enum ncclImplicitOrder {
-    ncclImplicitOrderNone,
-    ncclImplicitOrderSerial,
-    ncclImplicitOrderLaunch
-  };
+enum ncclImplicitOrder {
+  ncclImplicitOrderNone,
+  ncclImplicitOrderSerial,
+  ncclImplicitOrderLaunch
+};
 }
 
 static ncclResult_t getImplicitOrder(enum ncclImplicitOrder *mode, bool capturing, int driver=-1) {
@@ -1527,7 +1529,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       plan->persistent = persistent;
       // finishPlan() promotes ncclDevWorkStorageType[Fifo|Persistent]->Args if the work can fit.
       plan->workStorageType = persistent ? ncclDevWorkStorageTypePersistent
-                                         : ncclDevWorkStorageTypeFifo;
+          : ncclDevWorkStorageTypeFifo;
 
       if (planner->nTasksRma != 0) {
         NCCLCHECKGOTO(scheduleRmaTasksToPlan(comm, plan), result, failure);
@@ -1553,7 +1555,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
         if (comm->rank == 0) {
           const char* nvlsSync = comm->nvlsSupport ? "; CE synchronization with NVLS" : "";
           INFO(NCCL_TUNING, "%s [Copy Engine]: %ld Bytes -> cudaMemcpy%s",
-            ncclFuncToString(task->func), task->count * ncclTypeSize(task->datatype), nvlsSync);
+              ncclFuncToString(task->func), task->count * ncclTypeSize(task->datatype), nvlsSync);
         }
 
         ncclIntruQueueEnqueue(&planner->planQueue, plan);
@@ -1563,8 +1565,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       } else {
         if (!ncclIntruQueueEmpty(&planner->collSymTaskQueue)) {
           NCCLCHECKGOTO(ncclSymmetricTaskScheduler(comm, &planner->collSymTaskQueue, plan), result, failure);
-        }
-        else {
+        } else {
           struct ncclKernelPlanBudget budget;
           budget.inArgsBytes = comm->workArgsBytes - sizeof(struct ncclDevKernelArgs);
           // Non-persistent kernels fill up at most half of our fifo per kernel.
@@ -1593,9 +1594,9 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
         }
       }
     } while (planner->nTasksColl + planner->nTasksP2p + planner->nTasksBcast != 0 ||
-             !ncclIntruQueueEmpty(&planner->collSymTaskQueue) ||
-             !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
-             planner->nTasksRma != 0);
+        !ncclIntruQueueEmpty(&planner->collSymTaskQueue) ||
+        !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
+        planner->nTasksRma != 0);
 
     struct ncclKernelPlan* planHead = ncclIntruQueueHead(&planner->planQueue);
     planner->unlaunchedPlansHead = planHead;
@@ -1699,11 +1700,11 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   CUDACHECKGOTO(cudaGetFuncBySymbol(&fn, sym), ret, do_return);
 
   if (CUDART_VERSION >= 11080 && driverVersion >= 11080) {
-  #if CUDART_VERSION >= 11080
+#if CUDART_VERSION >= 11080
     int compCap = comm->compCap;
     unsigned int clusterSize = (compCap >= 90) ? comm->config.cgaClusterSize : 0;
 
-    CUlaunchConfig launchConfig = {0};
+    CUlaunchConfig launchConfig = {};
     CUlaunchAttribute launchAttrs[6] = {};
     int attrs = 0;
     /* Cooperative Group Array (CGA)
@@ -1724,14 +1725,14 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
       launchAttrs[attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
       launchAttrs[attrs++].value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
     }
-    #if CUDART_VERSION >= 12000
+#if CUDART_VERSION >= 12000
     if (compCap >= 90 && driverVersion >= 12000) {
       // Set the NCCL Mem Sync domain on CUDA 12.0 and later (sm90)
       launchAttrs[attrs].id = CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN;
       launchAttrs[attrs++].value.memSyncDomain = (CUlaunchMemSyncDomain) ncclParamMemSyncDomain();
     }
-    #endif
-    #if CUDART_VERSION >= 12030
+#endif
+#if CUDART_VERSION >= 12030
     enum ncclImplicitOrder implicitOrder;
     NCCLCHECKGOTO(getImplicitOrder(&implicitOrder, plan->persistent, driverVersion), ret, do_return);
     if (implicitOrder == ncclImplicitOrderLaunch) {
@@ -1745,14 +1746,14 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
       launchAttrs[attrs].value.programmaticStreamSerializationAllowed = 1;
       attrs++;
     }
-    #endif
-    #if CUDART_VERSION >= 13000
+#endif
+#if CUDART_VERSION >= 13000
     if (compCap >= 100 && driverVersion >= 13000) {
       launchAttrs[attrs].id = CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING;
       launchAttrs[attrs].value.nvlinkUtilCentricScheduling = comm->config.nvlinkCentricSched;
       attrs++;
     }
-    #endif
+#endif
     launchConfig.gridDimX = grid.x;
     launchConfig.gridDimY = grid.y;
     launchConfig.gridDimZ = grid.z;
@@ -1764,7 +1765,7 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     launchConfig.numAttrs = attrs;
     launchConfig.hStream = launchStream;
     CUCHECKGOTO(cuLaunchKernelEx(&launchConfig, fn, nullptr, extra), ret, do_return);
-  #endif
+#endif
   } else {
     // Standard kernel launch
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
@@ -1785,19 +1786,19 @@ ncclResult_t ncclLaunchKernelAfter_NoCuda(struct ncclComm* comm, struct ncclKern
 }
 
 namespace {
-  struct KernelFinishCallback {
-    struct ncclCommEventCallback base;
-    uint32_t workFifoConsumed;
-  };
-  ncclResult_t KernelFinishCallback_fn(
-      struct ncclComm* comm, struct ncclCommEventCallback* cb
-    ) {
-    struct KernelFinishCallback* me = (struct KernelFinishCallback*)cb;
-    comm->workFifoConsumed = me->workFifoConsumed;
-    CUDACHECK(cudaEventDestroy(me->base.event));
-    free(me);
-    return ncclSuccess;
-  }
+struct KernelFinishCallback {
+  struct ncclCommEventCallback base;
+  uint32_t workFifoConsumed;
+};
+ncclResult_t KernelFinishCallback_fn(
+    struct ncclComm* comm, struct ncclCommEventCallback* cb
+) {
+  struct KernelFinishCallback* me = (struct KernelFinishCallback*)cb;
+  comm->workFifoConsumed = me->workFifoConsumed;
+  CUDACHECK(cudaEventDestroy(me->base.event));
+  free(me);
+  return ncclSuccess;
+}
 }
 
 ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
@@ -1865,7 +1866,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
 
 ncclResult_t ncclGetCollNetSupport(
     struct ncclComm* comm, struct ncclTaskColl* info, int* collNetSupport
-  ) {
+) {
   // Translate ncclAvg and PreMulSum
   ncclRedOp_t netOp = info->opHost;
   if (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv) {
@@ -1873,13 +1874,13 @@ ncclResult_t ncclGetCollNetSupport(
   }
   *collNetSupport = comm->config.collnetEnable;
   switch (info->func) {
-  case ncclFuncAllReduce:
-  case ncclFuncReduce:
-  case ncclFuncReduceScatter:
-    *collNetSupport &= comm->collNetSupportMatrix[netOp][info->datatype];
-    break;
-  default:
-    break;
+    case ncclFuncAllReduce:
+    case ncclFuncReduce:
+    case ncclFuncReduceScatter:
+      *collNetSupport &= comm->collNetSupportMatrix[netOp][info->datatype];
+      break;
+    default:
+      break;
   }
   return ncclSuccess;
 }
@@ -1934,7 +1935,7 @@ static ncclResult_t updateCollCostTable(
 static ncclResult_t topoGetAlgoInfo(
     struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
     float** collCostTable, ncclSimInfo_t* simInfo
-  ) {
+) {
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
 
   float minTime = FLT_MAX;
@@ -2004,7 +2005,7 @@ static ncclResult_t topoGetAlgoInfo(
   }
 
   if (info->algorithm != NCCL_ALGO_NVLS && info->algorithm != NCCL_ALGO_NVLS_TREE &&
-    info->algorithm != NCCL_ALGO_COLLNET_DIRECT) {
+      info->algorithm != NCCL_ALGO_COLLNET_DIRECT) {
     while (nBytes < nc * nt * threadThreshold) {
       if (nt % 128 == 0) nt /= 2;
       else break;
@@ -2030,7 +2031,7 @@ static ncclResult_t topoGetAlgoInfo(
 ncclResult_t ncclGetAlgoInfo(
     struct ncclComm* comm, struct ncclTaskColl* info,
     int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo/* = NULL*/
-  ) {
+) {
   size_t elementSize = ncclTypeSize(info->datatype);
   size_t nBytes = elementSize * ncclFuncMaxSendRecvCount(info->func, comm->nRanks, info->count);
   struct ncclReg* regSendBuf = NULL;
@@ -2052,9 +2053,9 @@ ncclResult_t ncclGetAlgoInfo(
     NCCLCHECK(ncclRegLocalIsValid(regRecvBuf, &isRecvValid));
     regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) || (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
     NCCLCHECK(comm->tuner->getCollInfo(
-          comm->tunerContext, info->func, nBytes,
-          numPipeOps, (float **)collCostTable, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
-          regBuff, &nMaxChannels));
+      comm->tunerContext, info->func, nBytes,
+      numPipeOps, (float **)collCostTable, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+      regBuff, &nMaxChannels));
     NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float **)collCostTable, simInfo));
   } else {
     NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float **)collCostTable, simInfo));
@@ -2091,43 +2092,43 @@ NCCL_PARAM(NvlsTreeMaxChunkSize, "NVLSTREE_MAX_CHUNKSIZE", -2);
 static ncclResult_t calcCollChunking(
     struct ncclComm* comm, struct ncclTaskColl* info, int nChannels, size_t nBytes,
     /*outputs*/uint32_t* outChunkSize, uint32_t* outDirectFlags, struct ncclProxyOp* proxyOp
-  ) {
+) {
   ncclPattern_t pattern;
   size_t grainSize = ncclProtoGrainSize(info->protocol);
 
   switch (info->func) {
-  case ncclFuncBroadcast:
-    pattern = info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeDown : ncclPatternPipelineFrom;
-    break;
-  case ncclFuncReduce:
-    pattern = info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeUp : ncclPatternPipelineTo;
-    break;
-  case ncclFuncReduceScatter:
-    pattern =
-      info->algorithm == NCCL_ALGO_PAT ? ncclPatternPatUp :
-      info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
-      info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
-      ncclPatternRing;
-    break;
-  case ncclFuncAllGather:
-    pattern =
-      info->algorithm == NCCL_ALGO_PAT ? ncclPatternPatDown :
-      info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
-      info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
-      ncclPatternRing;
-    break;
-  case ncclFuncAllReduce:
-    pattern =
-      info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
-      info->algorithm == NCCL_ALGO_NVLS_TREE ? ncclPatternNvlsTree :
-      info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
-      info->algorithm == NCCL_ALGO_COLLNET_CHAIN ? ncclPatternCollnetChain :
-      info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeUpDown :
-      ncclPatternRingTwice;
-    break;
-  default:
-    WARN("Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
-    return ncclInternalError;
+    case ncclFuncBroadcast:
+      pattern = info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeDown : ncclPatternPipelineFrom;
+      break;
+    case ncclFuncReduce:
+      pattern = info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeUp : ncclPatternPipelineTo;
+      break;
+    case ncclFuncReduceScatter:
+      pattern =
+          info->algorithm == NCCL_ALGO_PAT ? ncclPatternPatUp :
+          info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
+          info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
+          ncclPatternRing;
+      break;
+    case ncclFuncAllGather:
+      pattern =
+          info->algorithm == NCCL_ALGO_PAT ? ncclPatternPatDown :
+          info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
+          info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
+          ncclPatternRing;
+      break;
+    case ncclFuncAllReduce:
+      pattern =
+          info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
+          info->algorithm == NCCL_ALGO_NVLS_TREE ? ncclPatternNvlsTree :
+          info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
+          info->algorithm == NCCL_ALGO_COLLNET_CHAIN ? ncclPatternCollnetChain :
+          info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeUpDown :
+          ncclPatternRingTwice;
+      break;
+    default:
+      WARN("Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
+      return ncclInternalError;
   }
 
   int nstepsPerLoop, nchunksPerLoop;
@@ -2203,36 +2204,36 @@ static ncclResult_t calcCollChunking(
   // Compute nSteps for proxies
   chunkSize = chunkSize / grainSize * grainSize; // align chunkSize to multiple grainSize
   switch (pattern) {
-  case ncclPatternTreeUp:
-  case ncclPatternTreeDown:
-  case ncclPatternTreeUpDown:
-  case ncclPatternPatUp:
-  case ncclPatternPatDown:
-  case ncclPatternPipelineFrom:
-  case ncclPatternPipelineTo:
-  case ncclPatternCollnetChain:
-    nstepsPerLoop = nchunksPerLoop = 1;
-    break;
-  case ncclPatternNvls:
-    nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
-    loopOffset = nChannels * chunkSize * comm->channels[0].nvls.headRank;
-    break;
-  case ncclPatternCollnetDirect:
-    nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].collnetDirect.nHeads;
-    loopOffset = nChannels * chunkSize * comm->channels[0].collnetDirect.headRank;
-    break;
-  case ncclPatternRing:
-    nstepsPerLoop = comm->nRanks-1; nchunksPerLoop = comm->nRanks;
-    break;
-  case ncclPatternRingTwice:
-    nstepsPerLoop = 2*(comm->nRanks-1); nchunksPerLoop = comm->nRanks;
-    break;
-  case ncclPatternNvlsTree:
-    nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
-    break;
-  default:
-    WARN("Unknown pattern %d", pattern);
-    return ncclInternalError;
+    case ncclPatternTreeUp:
+    case ncclPatternTreeDown:
+    case ncclPatternTreeUpDown:
+    case ncclPatternPatUp:
+    case ncclPatternPatDown:
+    case ncclPatternPipelineFrom:
+    case ncclPatternPipelineTo:
+    case ncclPatternCollnetChain:
+      nstepsPerLoop = nchunksPerLoop = 1;
+      break;
+    case ncclPatternNvls:
+      nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
+      loopOffset = nChannels * chunkSize * comm->channels[0].nvls.headRank;
+      break;
+    case ncclPatternCollnetDirect:
+      nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].collnetDirect.nHeads;
+      loopOffset = nChannels * chunkSize * comm->channels[0].collnetDirect.headRank;
+      break;
+    case ncclPatternRing:
+      nstepsPerLoop = comm->nRanks-1; nchunksPerLoop = comm->nRanks;
+      break;
+    case ncclPatternRingTwice:
+      nstepsPerLoop = 2*(comm->nRanks-1); nchunksPerLoop = comm->nRanks;
+      break;
+    case ncclPatternNvlsTree:
+      nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
+      break;
+    default:
+      WARN("Unknown pattern %d", pattern);
+      return ncclInternalError;
   }
 
   // Compute nSteps for proxies
@@ -2322,31 +2323,31 @@ static ncclResult_t calcCollChunking(
 
   // Set peer count hints used by network plugin
   switch (proxyOp->pattern) {
-  case ncclPatternRing:
-  case ncclPatternRingTwice:
-  case ncclPatternPipelineFrom:
-  case ncclPatternPipelineTo:
-  case ncclPatternPatUp:
-  case ncclPatternPatDown:
-    proxyOp->nPeers = 1;
-    break;
-  case ncclPatternTreeUp:
-  case ncclPatternTreeDown:
-  case ncclPatternTreeUpDown:
-  case ncclPatternNvlsTree:
-    proxyOp->nPeers = (NCCL_MAX_TREE_ARITY - 1) * 2;
-    break;
-  case ncclPatternCollnetChain:
-  case ncclPatternCollnetDirect:
-  case ncclPatternNvls:
-  case ncclPatternProfiler:
-    // Peer count hints unused
-    break;
-  case ncclPatternSend:
-  case ncclPatternRecv:
-  default:
-    WARN("Unknown pattern %d", pattern);
-    return ncclInternalError;
+    case ncclPatternRing:
+    case ncclPatternRingTwice:
+    case ncclPatternPipelineFrom:
+    case ncclPatternPipelineTo:
+    case ncclPatternPatUp:
+    case ncclPatternPatDown:
+      proxyOp->nPeers = 1;
+      break;
+    case ncclPatternTreeUp:
+    case ncclPatternTreeDown:
+    case ncclPatternTreeUpDown:
+    case ncclPatternNvlsTree:
+      proxyOp->nPeers = (NCCL_MAX_TREE_ARITY - 1) * 2;
+      break;
+    case ncclPatternCollnetChain:
+    case ncclPatternCollnetDirect:
+    case ncclPatternNvls:
+    case ncclPatternProfiler:
+      // Peer count hints unused
+      break;
+    case ncclPatternSend:
+    case ncclPatternRecv:
+    default:
+      WARN("Unknown pattern %d", pattern);
+      return ncclInternalError;
   }
 
   *outChunkSize = proxyOp->chunkSize;
@@ -2355,18 +2356,18 @@ static ncclResult_t calcCollChunking(
 
 static ncclResult_t hostToDevRedOp(
     ncclDevRedOpFull *opFull, ncclRedOp_t op, ncclDataType_t datatype, ncclComm *comm
-  ) {
+) {
   union {
     int8_t   i8; uint8_t   u8;
     int32_t i32; uint32_t u32;
     int64_t i64; uint64_t u64;
     __half f16; float f32; double f64;
-    #if defined(__CUDA_BF16_TYPES_EXIST__)
-      __nv_bfloat16 bf16;
-    #endif
-    #if defined(__CUDA_FP8_TYPES_EXIST__)
-      __nv_fp8_storage_t f8;
-    #endif
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+    __nv_bfloat16 bf16;
+#endif
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+    __nv_fp8_storage_t f8;
+#endif
     void *ptr;
   };
   u64 = 0;
@@ -2380,70 +2381,70 @@ static ncclResult_t hostToDevRedOp(
   bool datatype_signed = false;
 
   switch (int(op)) {
-  case ncclSum:  opFull->op = ncclDevSum;  break;
-  case ncclProd: opFull->op = ncclDevProd; break;
-  case ncclMin:
-  case ncclMax:
-    opFull->op = ncclDevMinMax;
-    opFull->scalarArg = 0;
-    // The xormask used by ncclFuncMinMax<[u]int> is the XOR of the sign bit
-    // for signed (opposed to unsigned) types and all the bits for max (opposed to min).
-    if (datatype==ncclInt8 || datatype==ncclInt32 || datatype==ncclInt64) {
-      opFull->scalarArg ^= signBit;
-    }
-    opFull->scalarArg ^= (op == ncclMax) ? allBits : 0;
-    break;
-  case ncclAvg:
-    switch ((int)datatype) {
-    case ncclInt8:  case ncclInt32:  case ncclInt64:
-      datatype_signed = true;
-      // no break, we want to fall through...
-    case ncclUint8: case ncclUint32: case ncclUint64:
-      opFull->op = ncclDevSumPostDiv;
-      u64 = comm->nRanks<<1 | datatype_signed;
+    case ncclSum:  opFull->op = ncclDevSum;  break;
+    case ncclProd: opFull->op = ncclDevProd; break;
+    case ncclMin:
+    case ncclMax:
+      opFull->op = ncclDevMinMax;
+      opFull->scalarArg = 0;
+      // The xormask used by ncclFuncMinMax<[u]int> is the XOR of the sign bit
+      // for signed (opposed to unsigned) types and all the bits for max (opposed to min).
+      if (datatype==ncclInt8 || datatype==ncclInt32 || datatype==ncclInt64) {
+        opFull->scalarArg ^= signBit;
+      }
+      opFull->scalarArg ^= (op == ncclMax) ? allBits : 0;
       break;
-    #if defined(__CUDA_FP8_TYPES_EXIST__)
-    case ncclFloat8e4m3:
-      opFull->op = ncclDevPreMulSum;
-      f8 = __nv_cvt_float_to_fp8(float(1.0/comm->nRanks), __NV_SATFINITE, __NV_E4M3);
+    case ncclAvg:
+      switch ((int)datatype) {
+        case ncclInt8:  case ncclInt32:  case ncclInt64:
+          datatype_signed = true;
+          __attribute__((fallthrough));
+        case ncclUint8: case ncclUint32: case ncclUint64:
+          opFull->op = ncclDevSumPostDiv;
+          u64 = comm->nRanks<<1 | datatype_signed;
+          break;
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+        case ncclFloat8e4m3:
+          opFull->op = ncclDevPreMulSum;
+          f8 = __nv_cvt_float_to_fp8(float(1.0/comm->nRanks), __NV_SATFINITE, __NV_E4M3);
+          break;
+        case ncclFloat8e5m2:
+          opFull->op = ncclDevPreMulSum;
+          f8 = __nv_cvt_float_to_fp8(float(1.0/comm->nRanks), __NV_SATFINITE, __NV_E5M2);
+          break;
+#endif
+        case ncclFloat16:
+          opFull->op = ncclDevPreMulSum;
+          f16 = __float2half(float(1.0/comm->nRanks)); // __double2half not supported pre CUDA 11.x
+          break;
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+        case ncclBfloat16:
+          opFull->op = ncclDevPreMulSum;
+          bf16 = __float2bfloat16(float(1.0/comm->nRanks));
+          break;
+#endif
+        case ncclFloat32:
+          opFull->op = ncclDevPreMulSum;
+          f32 = float(1.0/comm->nRanks);
+          break;
+        case ncclFloat64:
+          opFull->op = ncclDevPreMulSum;
+          f64 = 1.0/comm->nRanks;
+          break;
+      }
+      opFull->scalarArgIsPtr = false;
+      opFull->scalarArg = u64;
       break;
-    case ncclFloat8e5m2:
-      opFull->op = ncclDevPreMulSum;
-      f8 = __nv_cvt_float_to_fp8(float(1.0/comm->nRanks), __NV_SATFINITE, __NV_E5M2);
+    default: // user created
+      int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
+      ncclUserRedOp *user = &comm->userRedOps[ix];
+      if (datatype != user->datatype) {
+        WARN("Data type supplied to user-created ncclRedOp_t does not match type "
+             "given to reduction operation");
+        return ncclInvalidArgument;
+      }
+      *opFull = user->opFull;
       break;
-    #endif
-    case ncclFloat16:
-      opFull->op = ncclDevPreMulSum;
-      f16 = __float2half(float(1.0/comm->nRanks)); // __double2half not supported pre CUDA 11.x
-      break;
-    #if defined(__CUDA_BF16_TYPES_EXIST__)
-    case ncclBfloat16:
-      opFull->op = ncclDevPreMulSum;
-      bf16 = __float2bfloat16(float(1.0/comm->nRanks));
-      break;
-    #endif
-    case ncclFloat32:
-      opFull->op = ncclDevPreMulSum;
-      f32 = float(1.0/comm->nRanks);
-      break;
-    case ncclFloat64:
-      opFull->op = ncclDevPreMulSum;
-      f64 = 1.0/comm->nRanks;
-      break;
-    }
-    opFull->scalarArgIsPtr = false;
-    opFull->scalarArg = u64;
-    break;
-  default: // user created
-    int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
-    ncclUserRedOp *user = &comm->userRedOps[ix];
-    if (datatype != user->datatype) {
-      WARN("Data type supplied to user-created ncclRedOp_t does not match type "
-           "given to reduction operation");
-      return ncclInvalidArgument;
-    }
-    *opFull = user->opFull;
-    break;
   }
   return ncclSuccess;
 }
@@ -2516,8 +2517,8 @@ static ncclResult_t p2pTaskAppend(
   p2p->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
   p2p->p2pApiEventHandle = ncclProfilerApiState.p2pApiEventHandle;
   ncclIntruQueueEnqueue(
-    isSendNotRecv ? &planner->peers[peer].sendQueue : &planner->peers[peer].recvQueue,
-    p2p);
+      isSendNotRecv ? &planner->peers[peer].sendQueue : &planner->peers[peer].recvQueue,
+      p2p);
   planner->nTasksP2p += 1;
   if (isSendNotRecv)
     planner->nTasksP2pSend += 1;
@@ -2531,7 +2532,7 @@ static ncclResult_t p2pTaskAppend(
       (isSendNotRecv ? planner->peers[peer].sendSeen : planner->peers[peer].recvSeen) = true;
       int round = 0;
       while (peer != (isSendNotRecv ? comm->p2pSchedule[round].sendRank
-                                    : comm->p2pSchedule[round].recvRank)) {
+        : comm->p2pSchedule[round].recvRank)) {
         round += 1;
       }
       uint8_t base = ncclP2pChannelBaseForRound(comm, round);
@@ -2598,32 +2599,31 @@ static ncclResult_t collTaskAppend(
     // enqueue to peer's bcast queue instead of collSorter
     ncclIntruQueueEnqueue(&planner->peers[info->root].bcastQueue, t);
     planner->nTasksBcast += 1;
-  }
-  else {
-  struct ncclTaskColl* t = ncclMemoryPoolAlloc<struct ncclTaskColl>(&comm->memPool_ncclTaskColl, &comm->memPermanent);
-  t->func = info->coll;
-  t->sendbuff = info->sendbuff;
-  t->recvbuff = info->recvbuff;
-  t->count = info->count;
-  t->root = info->root;
-  t->datatype = info->datatype;
-  size_t elementSize = ncclTypeSize(t->datatype);
-  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast) {
-    t->count *= elementSize;
-    t->datatype = ncclInt8;
-    elementSize = 1;
-  }
-  t->trafficBytes = t->count*elementSize*ncclFuncTrafficPerByte(t->func, comm->nRanks);
-  t->opHost = info->op;
-  t->opDev = opDev; // C++ struct assignment
-  t->chunkSteps = info->chunkSteps;
-  t->sliceSteps = info->sliceSteps;
-  t->eActivationMask = ncclProfilerApiState.eActivationMask;
-  t->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
-  t->collApiEventHandle = ncclProfilerApiState.collApiEventHandle;
+  } else {
+    struct ncclTaskColl* t = ncclMemoryPoolAlloc<struct ncclTaskColl>(&comm->memPool_ncclTaskColl, &comm->memPermanent);
+    t->func = info->coll;
+    t->sendbuff = info->sendbuff;
+    t->recvbuff = info->recvbuff;
+    t->count = info->count;
+    t->root = info->root;
+    t->datatype = info->datatype;
+    size_t elementSize = ncclTypeSize(t->datatype);
+    if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast) {
+      t->count *= elementSize;
+      t->datatype = ncclInt8;
+      elementSize = 1;
+    }
+    t->trafficBytes = t->count*elementSize*ncclFuncTrafficPerByte(t->func, comm->nRanks);
+    t->opHost = info->op;
+    t->opDev = opDev; // C++ struct assignment
+    t->chunkSteps = info->chunkSteps;
+    t->sliceSteps = info->sliceSteps;
+    t->eActivationMask = ncclProfilerApiState.eActivationMask;
+    t->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
+    t->collApiEventHandle = ncclProfilerApiState.collApiEventHandle;
 
-  planner->nTasksColl += 1;
-  ncclTaskCollSorterInsert(&planner->collSorter, t, t->trafficBytes);
+    planner->nTasksColl += 1;
+    ncclTaskCollSorterInsert(&planner->collSorter, t, t->trafficBytes);
   }
   ncclProfilerStopCollApiEvent();
   return ncclSuccess;
@@ -2687,8 +2687,8 @@ static ncclResult_t ceCollTaskAppend(
 }
 
 static ncclResult_t rmaTaskAppend(
-  struct ncclComm* comm,
-  struct ncclInfo* info) {
+    struct ncclComm* comm,
+    struct ncclInfo* info) {
   struct ncclKernelPlanner *planner = &comm->planner;
 
   void const* srcBuff = info->sendbuff;
@@ -2743,15 +2743,13 @@ static ncclResult_t rmaTaskAppend(
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
-  }
-  else if (info->coll == ncclFuncSignal) {
+  } else if (info->coll == ncclFuncSignal) {
     // Check if count is valid
     if (info->count != 0) {
       WARN("ncclSignal: count must be 0");
       return ncclInvalidArgument;
     }
-  }
-  else if (info->coll == ncclFuncWaitSignal) {
+  } else if (info->coll == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (info->signalDescs == NULL || info->nDesc == 0) {
       WARN("ncclWaitSignal: invalid arguments");
@@ -2769,7 +2767,7 @@ static ncclResult_t rmaTaskAppend(
       }
       if (info->signalDescs[i].ctx != 0) {
         WARN("ncclWaitSignal: descriptor %d has invalid context %d (must be 0)",
-             i, info->signalDescs[i].ctx);
+          i, info->signalDescs[i].ctx);
         return ncclInvalidArgument;
       }
     }
@@ -2839,8 +2837,8 @@ static ncclResult_t rmaTaskAppend(
 
       // Calculate chunk-specific size and offsets
       size_t chunkBytes = (chunkIdx == numChunks - 1)
-                          ? (totalBytes - chunkIdx * chunkSize)
-                          : chunkSize;
+          ? (totalBytes - chunkIdx * chunkSize)
+          : chunkSize;
 
       size_t chunkOffset = chunkIdx * chunkSize;
 
@@ -2941,7 +2939,7 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
             NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)((char*)info->sendbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r, allowUB));
             NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r, allowUB));
           }
-        } else if (info->coll == ncclFuncGather){
+        } else if (info->coll == ncclFuncGather) {
           size_t offset = 0;
           allowUB = captured;
           NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count, info->datatype, info->root, allowUB));
@@ -3004,8 +3002,8 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
   NCCLCHECKGOTO(ArgsCheck(info), ret, fail);
 
   INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p count %zu datatype %d op %d root %d comm %p [nranks=%d] stream %p",
-        info->opName, info->comm->opCount, info->sendbuff, info->recvbuff, info->count,
-        info->datatype, info->op, info->root, info->comm, info->comm->nRanks, info->stream);
+      info->opName, info->comm->opCount, info->sendbuff, info->recvbuff, info->count,
+      info->datatype, info->op, info->root, info->comm, info->comm->nRanks, info->stream);
   TRACE_CALL("nccl%s(%" PRIx64 ",%" PRIx64 ",%zu,%d,%d,%d,%p,%p)", info->opName, reinterpret_cast<int64_t>(info->sendbuff), reinterpret_cast<int64_t>(info->recvbuff), info->count, info->datatype, info->op, info->root, info->comm, info->stream);
 
   NCCLCHECKGOTO(taskAppend(info->comm, info), ret, fail);

--- a/src/gin/gin_host_proxy.cc
+++ b/src/gin/gin_host_proxy.cc
@@ -73,7 +73,7 @@ struct ginProxyCtx {
   int nSignalsPerContext;
 };
 static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
-                                bool forceNonDataDirect = false) {
+    bool forceNonDataDirect = false) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 
 #if CUDA_VERSION >= 11070
@@ -84,13 +84,13 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 #if CUDA_VERSION >= 12080
   if (ncclParamIbDataDirect() && !forceNonDataDirect) {
     CUresult status = pfn_cuMemGetHandleForAddressRange(
-      (void *)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
+            (void *)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+            CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
     if (status == CUDA_SUCCESS) return ncclSuccess;
   }
 #endif
   CUresult status = pfn_cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
-                                                      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+    CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
   if (status == CUDA_SUCCESS) return ncclSuccess;
 #endif
 
@@ -98,28 +98,28 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 }
 
 static ncclResult_t proxyGinPollCompletions(ncclGin_t *ginComm, void *collComm,
-                                            struct ginProxyCtx *ctx,
-                                            struct ginProxyHostGpuCtx *hostGpuCtx) {
+    struct ginProxyCtx *ctx,
+    struct ginProxyHostGpuCtx *hostGpuCtx) {
   for (int targetRank = 0; targetRank < ctx->comm->nRanks; targetRank++) {
     // loop on all seen but unconsumed GFDs
     for (uint32_t i = hostGpuCtx->cisShadow[targetRank]; i < hostGpuCtx->sis[targetRank]; i++) {
       uint32_t idx = i & (hostGpuCtx->queueSize - 1);
       struct ginProxyGfdState *state =
-        &hostGpuCtx->states[targetRank * hostGpuCtx->queueSize + idx];
+            &hostGpuCtx->states[targetRank * hostGpuCtx->queueSize + idx];
       // no need to poll if already done
       if (!state->done) {
         ginComm->test(collComm, state->request, &state->done);
         if (state->done) {
           TRACE(NCCL_NET, "GFD completed - contextId: %d, stateIdx: %lu, request: %p", hostGpuCtx->contextId, state - hostGpuCtx->states,
-                state->request);
+              state->request);
           // update the counter specified in the GFD
           if (state->op & ncclGinProxyOpWithCounter) {
             int contextId = hostGpuCtx->contextId;
             uint64_t* counterPtr = &ctx->counters[contextId * ctx->nCountersPerContext + state->counterId];
             COMPILER_ATOMIC_STORE(counterPtr, *counterPtr + 1,
-                              std::memory_order_relaxed);
+                std::memory_order_relaxed);
             TRACE(NCCL_NET, "Updated counter %d to %ld for context %d", state->counterId,
-                  *counterPtr, contextId);
+                *counterPtr, contextId);
           }
         }
       }
@@ -127,7 +127,7 @@ static ncclResult_t proxyGinPollCompletions(ncclGin_t *ginComm, void *collComm,
       if (state->done && i == hostGpuCtx->cisShadow[targetRank]) {
         // tell the GPU that we have consumed the GFD
         COMPILER_ATOMIC_STORE(&hostGpuCtx->cis[targetRank], ++hostGpuCtx->cisShadow[targetRank],
-                          std::memory_order_relaxed);
+            std::memory_order_relaxed);
         TRACE(NCCL_NET, "Updated cis[%u] to %u for context %d", targetRank, hostGpuCtx->cisShadow[targetRank], hostGpuCtx->contextId);
       }
     }
@@ -136,8 +136,8 @@ static ncclResult_t proxyGinPollCompletions(ncclGin_t *ginComm, void *collComm,
   return ncclSuccess;
 }
 
-static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuCtx, int targetRank,
-                           ncclGinProxyGfd_t *gfd, struct ginProxyGfdState **state) {
+static int proxyGinPollGfd(struct ginProxyCtx */*ctx*/, ginProxyHostGpuCtx *hostGpuCtx, int targetRank,
+    ncclGinProxyGfd_t *gfd, struct ginProxyGfdState **state) {
   ncclGinProxyGfd_t *q = hostGpuCtx->queues + targetRank * hostGpuCtx->queueSize;
   uint32_t idx = hostGpuCtx->sis[targetRank] & (hostGpuCtx->queueSize - 1);
   ncclGinProxyQword_t qword;
@@ -171,16 +171,16 @@ static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuC
   (*state)->request = NULL;
 
   TRACE(NCCL_NET,
-        "GFD on context %d to target PE %d raw idx: %u, idx: %u - op: %#lx, size: %lu, srcOff: %lu, dstOff: %lu, "
-        "srcHandle: %lu, dstHandle: %lu, counterId: %u, signalId: %u, stateIdx: %u",
-        hostGpuCtx->contextId, targetRank, hostGpuCtx->sis[targetRank], idx, gfd->qword[ncclGinProxyGfdHeader].header.op,
-        gfd->qword[ncclGinProxyGfdHeader].header.size,
-        gfd->qword[ncclGinProxyGfdSrcOff].srcOff.srcOff,
-        gfd->qword[ncclGinProxyGfdDstOff].dstOff.dstOff,
-        gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle,
-        gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle,
-        gfd->qword[ncclGinProxyGfdCompletion].completion.counterId,
-        gfd->qword[ncclGinProxyGfdCompletion].completion.signalId, stateIdx);
+      "GFD on context %d to target PE %d raw idx: %u, idx: %u - op: %#lx, size: %lu, srcOff: %lu, dstOff: %lu, "
+      "srcHandle: %lu, dstHandle: %lu, counterId: %u, signalId: %u, stateIdx: %u",
+      hostGpuCtx->contextId, targetRank, hostGpuCtx->sis[targetRank], idx, gfd->qword[ncclGinProxyGfdHeader].header.op,
+      gfd->qword[ncclGinProxyGfdHeader].header.size,
+      gfd->qword[ncclGinProxyGfdSrcOff].srcOff.srcOff,
+      gfd->qword[ncclGinProxyGfdDstOff].dstOff.dstOff,
+      gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle,
+      gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle,
+      gfd->qword[ncclGinProxyGfdCompletion].completion.counterId,
+      gfd->qword[ncclGinProxyGfdCompletion].completion.signalId, stateIdx);
 
   hostGpuCtx->sis[targetRank]++;
 
@@ -208,8 +208,8 @@ static inline uint64_t extractSignalVal(ncclGinProxyGfd_t *gfd) {
 }
 
 static ncclResult_t proxyGinProcessGfd(ncclGin_t *ginComm, void *collComm, struct ginProxyCtx *ctx,
-                                       struct ginProxyHostGpuCtx *hostGpuCtx, int targetRank,
-                                       ncclGinProxyGfd_t *gfd, struct ginProxyGfdState *state) {
+    struct ginProxyHostGpuCtx *hostGpuCtx, int targetRank,
+    ncclGinProxyGfd_t *gfd, struct ginProxyGfdState *state) {
   int signalOp;
   uint64_t signalVal;
 
@@ -220,8 +220,8 @@ static ncclResult_t proxyGinProcessGfd(ncclGin_t *ginComm, void *collComm, struc
     signalVal = extractSignalVal(gfd);
     signalOp = mapGfdOpToSignalOp(gfd);
     NCCLCHECK(ginComm->iputSignal(collComm, 0, nullptr, 0, 0, nullptr,
-                                  targetRank, signalOff, signalHandle, signalVal,
-                                  signalOp, hostGpuCtx->contextId, &state->request));
+      targetRank, signalOff, signalHandle, signalVal,
+      signalOp, hostGpuCtx->contextId, &state->request));
     return ncclSuccess;
   }
 
@@ -251,15 +251,15 @@ static ncclResult_t proxyGinProcessGfd(ncclGin_t *ginComm, void *collComm, struc
       if (signalOp == -1) {
         // First cast from 63 bits to 64 bits and then to void * to avoid warnings
         NCCLCHECK(ginComm->iput(collComm, srcOff, srcHandle, size, dstOff, dstHandle,
-                                targetRank, hostGpuCtx->contextId, &state->request));
+          targetRank, hostGpuCtx->contextId, &state->request));
       } else {
         // Reconstruct the signal value
         signalVal = extractSignalVal(gfd);
         uint64_t signalOff = (gfd->qword[ncclGinProxyGfdCompletion].completion.signalId +
-                              hostGpuCtx->contextId * ctx->nSignalsPerContext) * sizeof(uint64_t);
+                hostGpuCtx->contextId * ctx->nSignalsPerContext) * sizeof(uint64_t);
         NCCLCHECK(ginComm->iputSignal(collComm, srcOff, srcHandle, size, dstOff, dstHandle,
-                                      targetRank, signalOff, ctx->signalsGinHandle, signalVal,
-                                      signalOp, hostGpuCtx->contextId, &state->request));
+          targetRank, signalOff, ctx->signalsGinHandle, signalVal,
+          signalOp, hostGpuCtx->contextId, &state->request));
       }
       break;
     default:
@@ -267,7 +267,7 @@ static ncclResult_t proxyGinProcessGfd(ncclGin_t *ginComm, void *collComm, struc
       assert(0);
   }
   TRACE(NCCL_NET, "GFD submitted into GIN plugin - contextId: %d, stateIdx: %lu, request: %p",
-        hostGpuCtx->contextId, state - hostGpuCtx->states, state->request);
+      hostGpuCtx->contextId, state - hostGpuCtx->states, state->request);
   return ncclSuccess;
 }
 
@@ -276,8 +276,8 @@ static uint64_t isPowerOfTwo(uint64_t n) { return (n > 0) && ((n & (n - 1)) == 0
 // Check if the GIN plugin supports DMA-BUF, if so we can try to get the DMA-BUF handle from CUDA,
 // if that fails we fallback to non-DMA-BUF
 static ncclResult_t ncclGinProxyRegMrSym(ncclGin_t *ginComm, struct ginProxyCtx *ctx, void *addr,
-                                         size_t size, int type, int mr_flags, void **mhandle,
-                                         void **ginHandle) {
+    size_t size, int type, int mr_flags, void **mhandle,
+    void **ginHandle) {
   if (type == NCCL_PTR_HOST) {
     NCCLCHECK(ginComm->regMrSym(ctx->collComm, addr, size, type, mr_flags, mhandle, ginHandle));
   } else if (type == NCCL_PTR_CUDA) {
@@ -288,7 +288,7 @@ static ncclResult_t ncclGinProxyRegMrSym(ncclGin_t *ginComm, struct ginProxyCtx 
       dmabufResult = getDmaBufFd(addr, size, &dmabufFd);
       if (dmabufResult == ncclSuccess) {
         registrationResult = ginComm->regMrSymDmaBuf(ctx->collComm, addr, size, type, 0, dmabufFd,
-                                                     mr_flags, mhandle, ginHandle);
+                mr_flags, mhandle, ginHandle);
         close(dmabufFd);
       }
       if (registrationResult != ncclSuccess) {
@@ -296,7 +296,7 @@ static ncclResult_t ncclGinProxyRegMrSym(ncclGin_t *ginComm, struct ginProxyCtx 
         dmabufResult = getDmaBufFd(addr, size, &dmabufFd, true);
         if (dmabufResult == ncclSuccess) {
           NCCLCHECK(ginComm->regMrSymDmaBuf(ctx->collComm, addr, size, type, 0, dmabufFd,
-                                            mr_flags, mhandle, ginHandle));
+            mr_flags, mhandle, ginHandle));
           close(dmabufFd);
         }
       }
@@ -313,8 +313,8 @@ static ncclResult_t ncclGinProxyRegMrSym(ncclGin_t *ginComm, struct ginProxyCtx 
 }
 
 ncclResult_t ncclGinProxyCreateContext(struct ncclComm *comm, void *collComm, int devId,
-                                       int nSignals, int nCounters, int nContexts, void **outGinCtx,
-                                       ncclNetDeviceHandle_t **outDevHandle) {
+    int nSignals, int nCounters, int nContexts, void **outGinCtx,
+    ncclNetDeviceHandle_t **outDevHandle) {
   ncclGin_t *ginComm = (ncclGin_t *)comm->sharedRes->ginState.ncclGin;
   ncclGinProxyGpuCtx_t *devGpuCtxArray_h = nullptr;
 
@@ -337,27 +337,27 @@ ncclResult_t ncclGinProxyCreateContext(struct ncclComm *comm, void *collComm, in
   }
   if (queueSize > maxRequests) {
     INFO(NCCL_NET,
-         "NCCL_GIN_PROXY_QUEUE_SIZE is greater than the maximum outstanding requests in the GIN "
-         "plugin (%d), using the default/maximum value instead",
-         maxRequests);
+        "NCCL_GIN_PROXY_QUEUE_SIZE is greater than the maximum outstanding requests in the GIN "
+        "plugin (%d), using the default/maximum value instead",
+        maxRequests);
     queueSize = maxRequests;
   }
   if (queueSize < 1) {
     INFO(NCCL_NET,
-         "NCCL_GIN_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
+        "NCCL_GIN_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
     queueSize = maxRequests;
   }
   if (!isPowerOfTwo(queueSize)) {
     INFO(
-      NCCL_NET,
-      "NCCL_GIN_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
+        NCCL_NET,
+        "NCCL_GIN_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
     queueSize = maxRequests;
   }
 
   // Allocate the counters on the GPU or CPU depending on GDR
   NCCLCHECK(allocMemCPUAccessible(&proxyCtx->counters, &proxyCtx->countersDev,
-                                  nCounters * nContexts, CU_MEMHOSTALLOC_WRITECOMBINED,
-                                  &proxyCtx->countersGdrHandle, comm->memManager));
+    nCounters * nContexts, CU_MEMHOSTALLOC_WRITECOMBINED,
+    &proxyCtx->countersGdrHandle, comm->memManager));
   proxyCtx->nCountersPerContext = nCounters;
 
   // Allocate the signals on the GPU and then register the memory region with the GIN plugin.
@@ -365,11 +365,11 @@ ncclResult_t ncclGinProxyCreateContext(struct ncclComm *comm, void *collComm, in
   // signals.
   size_t signalsBufSize = nSignals * nContexts * sizeof(uint64_t);
   NCCLCHECK(ncclCuMemAlloc((void **)&proxyCtx->signalsDev, &proxyCtx->signalsCumemhandle,
-                           CU_MEM_HANDLE_TYPE_NONE, signalsBufSize, comm->memManager));
+    CU_MEM_HANDLE_TYPE_NONE, signalsBufSize, comm->memManager));
   CUDACHECK(cudaMemset(proxyCtx->signalsDev, 0, signalsBufSize));
   NCCLCHECK(ncclGinProxyRegMrSym(ginComm, proxyCtx, proxyCtx->signalsDev, signalsBufSize,
-                                 NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
-                                 &proxyCtx->signalsMhandle, &proxyCtx->signalsGinHandle));
+    NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
+    &proxyCtx->signalsMhandle, &proxyCtx->signalsGinHandle));
   proxyCtx->nSignalsPerContext = nSignals;
 
   NCCLCHECK(ncclCalloc(&proxyCtx->hostGpuCtx, nContexts));
@@ -384,8 +384,8 @@ ncclResult_t ncclGinProxyCreateContext(struct ncclComm *comm, void *collComm, in
     NCCLCHECK(ncclCalloc(&hostGpuCtx->sis, comm->nRanks));
     NCCLCHECK(ncclCalloc(&hostGpuCtx->inlines, queuesLength));
     NCCLCHECK(ncclGinProxyRegMrSym(ginComm, proxyCtx, hostGpuCtx->inlines,
-                                   queuesLength * sizeof(uint64_t), NCCL_PTR_HOST, 0,
-                                   &hostGpuCtx->inlinesMhandle, &hostGpuCtx->inlinesGinHandle));
+      queuesLength * sizeof(uint64_t), NCCL_PTR_HOST, 0,
+      &hostGpuCtx->inlinesMhandle, &hostGpuCtx->inlinesGinHandle));
 
     ncclGinProxyGpuCtx_t *devGpuCtx_h = devGpuCtxArray_h + contextId;
     devGpuCtx_h->nranks = comm->nRanks;
@@ -397,9 +397,9 @@ ncclResult_t ncclGinProxyCreateContext(struct ncclComm *comm, void *collComm, in
     // Allocate the GFD queues, CIs, counters, signals and test/wait variables on the either the CPU
     // or GPU.
     NCCLCHECK(allocMemCPUAccessible(&hostGpuCtx->queues, &devGpuCtx_h->queues, queuesLength, 0, NULL,
-                                    comm->memManager, true /*forceHost*/));
+      comm->memManager, true /*forceHost*/));
     NCCLCHECK(allocMemCPUAccessible(&hostGpuCtx->cis, &devGpuCtx_h->cis, comm->nRanks,
-                                    CU_MEMHOSTALLOC_WRITECOMBINED, &hostGpuCtx->cisGdrHandle, comm->memManager));
+      CU_MEMHOSTALLOC_WRITECOMBINED, &hostGpuCtx->cisGdrHandle, comm->memManager));
   }
 
   ncclGinProxyGpuCtx_t *devGpuCtx_d = NULL;
@@ -426,7 +426,7 @@ ncclResult_t ncclGinProxyCreateContext(struct ncclComm *comm, void *collComm, in
 }
 
 ncclResult_t ncclGinProxyRegister(ncclGin_t *ginComm, void *ginCtx, void *addr, size_t size,
-                                  int type, int mr_flags, void **mhandle, void **ginHandle) {
+    int type, int mr_flags, void **mhandle, void **ginHandle) {
   struct ginProxyCtx *ctx = (struct ginProxyCtx *)ginCtx;
   // Register the memory region with the GIN plugin
   NCCLCHECK(ncclGinProxyRegMrSym(ginComm, ctx, addr, size, type, mr_flags, mhandle, ginHandle));
@@ -495,7 +495,7 @@ ncclResult_t ncclGinProxyProgress(ncclGin_t *ginComm, void *ginCtx) {
       struct ginProxyGfdState *state = NULL;
       if (proxyGinPollGfd(ctx, hostGpuCtx, targetRank, &gfd, &state)) {
         ncclResult_t ret =
-          proxyGinProcessGfd(ginComm, ctx->collComm, ctx, hostGpuCtx, targetRank, &gfd, state);
+            proxyGinProcessGfd(ginComm, ctx->collComm, ctx, hostGpuCtx, targetRank, &gfd, state);
         if (ret) ctx->hasError = ret;
         NCCLCHECK(ret);
       }
@@ -506,7 +506,7 @@ ncclResult_t ncclGinProxyProgress(ncclGin_t *ginComm, void *ginCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinProxyQueryLastError(ncclGin_t *ginComm, void *ginCtx, bool *hasError) {
+ncclResult_t ncclGinProxyQueryLastError(ncclGin_t */*ginComm*/, void *ginCtx, bool *hasError) {
   struct ginProxyCtx *ctx = (struct ginProxyCtx *)ginCtx;
   *hasError = ctx->hasError;
   return ncclSuccess;

--- a/src/graph/connect.cc
+++ b/src/graph/connect.cc
@@ -113,8 +113,8 @@ static ncclResult_t connectRings(struct ncclComm* comm, int* ringRecv, int* ring
 }
 
 static ncclResult_t getIndexes(int* ranks, int* indexes, int nNodes) {
- for (int n=0; n<nNodes; n++) indexes[n] = ranks[n];
- return ncclSuccess;
+  for (int n=0; n<nNodes; n++) indexes[n] = ranks[n];
+  return ncclSuccess;
 }
 
 static ncclResult_t setTreeUp(struct ncclTree* tree, int* indexes, int u) {
@@ -135,7 +135,7 @@ static ncclResult_t setTreeDown(struct ncclTree* tree, int* indexes, int d) {
   return ncclSuccess;
 }
 
-static ncclResult_t connectTrees(struct ncclComm* comm, int* treeToParent, int* treeToChild0, int* treeToChild1, int* treePatterns) {
+static ncclResult_t connectTrees(struct ncclComm* comm, int* treeToParent, int* treeToChild0, int* treeToChild1, int* /*treePatterns*/) {
   const int nChannels = comm->nChannels, nNodes = comm->nNodes, node = comm->node;
 
   // Compute tree depth. Not an exact value but a good approximation in most
@@ -146,30 +146,30 @@ static ncclResult_t connectTrees(struct ncclComm* comm, int* treeToParent, int* 
   int* ttp, *ttc0, *ttc1;
   NCCLCHECK(ncclGetDtree(nNodes, node, &t0u, &t0d0, &t0d1, &t0ChildType, &t1u, &t1d0, &t1d1, &t1ChildType));
   for (int c=0; c<nChannels; c++) {
-     struct ncclChannel* channel0 = comm->channels+c;
-     struct ncclChannel* channel1 = channel0+nChannels;
-     ttp = treeToParent+c*comm->nNodes;
-     ttc0 = treeToChild0+c*comm->nNodes;
-     ttc1 = treeToChild1+c*comm->nNodes;
-     if (comm->rank == ttp[node]) {
-       NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ttc0 : ttc1, t0u));
-       NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ttc0 : ttc1, t1u));
-     }
-     if (comm->rank == ttc0[node]) {
-       NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d0));
-       NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d0));
-     }
-     if (comm->rank == ttc1[node]) {
-       NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d1));
-       NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d1));
-     }
-     if (comm->rank == ttp[node] ||
-         comm->rank == ttc0[node] ||
-         comm->rank == ttc1[node]) {
-       INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c,           channel0->tree.up, comm->rank, channel0->tree.down[0], channel0->tree.down[1], channel0->tree.down[2]);
-       INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c+nChannels, channel1->tree.up, comm->rank, channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
-     }
-     channel0->tree.depth = channel1->tree.depth = depth;
+    struct ncclChannel* channel0 = comm->channels+c;
+    struct ncclChannel* channel1 = channel0+nChannels;
+    ttp = treeToParent+c*comm->nNodes;
+    ttc0 = treeToChild0+c*comm->nNodes;
+    ttc1 = treeToChild1+c*comm->nNodes;
+    if (comm->rank == ttp[node]) {
+      NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ttc0 : ttc1, t0u));
+      NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ttc0 : ttc1, t1u));
+    }
+    if (comm->rank == ttc0[node]) {
+      NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d0));
+      NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d0));
+    }
+    if (comm->rank == ttc1[node]) {
+      NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d1));
+      NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d1));
+    }
+    if (comm->rank == ttp[node] ||
+        comm->rank == ttc0[node] ||
+        comm->rank == ttc1[node]) {
+      INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c,           channel0->tree.up, comm->rank, channel0->tree.down[0], channel0->tree.down[1], channel0->tree.down[2]);
+      INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c+nChannels, channel1->tree.up, comm->rank, channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
+    }
+    channel0->tree.depth = channel1->tree.depth = depth;
   }
   return ncclSuccess;
 }
@@ -218,7 +218,8 @@ static ncclResult_t connectCollNet(struct ncclComm* comm, struct ncclTopoGraph* 
       sprintf(line+strlen(line), " %d ", heads[h]);
     }
     sprintf(line+strlen(line), "heads ");
-    { // heads[] is the list of heads ordered in head order startubg with self
+    {
+      // heads[] is the list of heads ordered in head order startubg with self
       int h0 = (channel->collnetDirect.headRank == -1) ? 0 : channel->collnetDirect.headRank;
       for (int h1=0; h1 < nHeads; h1++) {
         int h = (h0+h1)%nHeads;
@@ -267,8 +268,8 @@ static ncclResult_t connectNvls(struct ncclComm* comm, int* nvlsHeads, int nHead
   int tree0Parent, tree0Child0, tree0Child1, tree1Parent, tree1Child0, tree1Child1;
   int pc0, pc1; // ignored
   NCCLCHECK(ncclGetDtree(comm->nNodes, comm->node,
-        &tree0Parent, &tree0Child0, &tree0Child1, &pc0,
-        &tree1Parent, &tree1Child0, &tree1Child1, &pc1));
+    &tree0Parent, &tree0Child0, &tree0Child1, &pc0,
+    &tree1Parent, &tree1Child0, &tree1Child1, &pc1));
 
   int* heads = NULL;
   int treeUp[2] = { -1, -1 };
@@ -405,7 +406,7 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
     }
   }
 
-  for (int c=0; c<nChannels;c++) {
+  for (int c=0; c<nChannels; c++) {
     for (int n=0; n<nNodes; n++) {
       int r = firstRanks[n];
       ringRecv[c*nNodes+n] = allTopoRanks[r]->ringRecv[c];
@@ -472,13 +473,13 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
 
   // Use 4 compute channels per search channel to reach peak BW on <8 PPN
   if (comm->minCompCap >= 90 && comm->nNodes > 1 && graphs[NCCL_ALGO_RING]->bwIntra > 45.0 && nChannels < 16) {
-     nChannels = comm->nChannels = copyChannels(comm, nChannels, 2*nChannels, ringPrev, ringNext);
+    nChannels = comm->nChannels = copyChannels(comm, nChannels, 2*nChannels, ringPrev, ringNext);
   }
 
   // Double the number of channels when using unpack networking (greater than 1 node)
   // We won't automatically double past 16 channels, users can specify 32 if they want
   if (comm->netDeviceType == NCCL_NET_DEVICE_UNPACK && comm->nNodes > 1 && nChannels < 16 && ncclParamUnpackDoubleNChannels()) {
-     nChannels = comm->nChannels = copyChannels(comm, nChannels, 2*nChannels, ringPrev, ringNext);
+    nChannels = comm->nChannels = copyChannels(comm, nChannels, 2*nChannels, ringPrev, ringNext);
   }
 
   // Honor NCCL_MIN_NRINGS/NCCL_MAX_NRINGS.

--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -73,15 +73,15 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
 
         if ((remPath->bw == 0 || remPath->count > path->count) && remPath->bw < bw) {
           // Find reverse link
-          for (int l=0; l<remNode->nlinks; l++) {
-            if (remNode->links[l].remNode == node && remNode->links[l].type == link->type) {
-              remPath->list[0] = remNode->links+l;
+          for (int rl=0; rl<remNode->nlinks; rl++) {
+            if (remNode->links[rl].remNode == node && remNode->links[rl].type == link->type) {
+              remPath->list[0] = remNode->links+rl;
               break;
             }
           }
           if (remPath->list[0] == NULL) {
             WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx",
-                 remNode->type, remNode->id, remNode->nlinks, node->type, node->id);
+                remNode->type, remNode->id, remNode->nlinks, node->type, node->id);
             return ncclInternalError;
           }
           // Copy the rest of the path
@@ -179,7 +179,7 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* retCpu
   return ncclSuccess;
 }
 
-static int mergePathType(int type0, int type1){
+static int mergePathType(int type0, int type1) {
   int max = std::max(type0,type1);
   int min = std::min(type0,type1);
   if(max == PATH_PHB && min == PATH_C2C) return PATH_P2C;
@@ -274,7 +274,7 @@ ncclResult_t ncclGetUserP2pLevel(int* level) {
 // *cudaP2p returns 1 if CUDA P2P between the ranks is supported.
 // *p2p returns 1 only if the distance between the ranks is no greater than NCCL_P2P_LEVEL.  The connection may go through an intermediate rank.
 ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* system, int rank1, int rank2,
-                              int* p2p, int *read, int* intermediateRank, int* cudaP2p) {
+    int* p2p, int *read, int* intermediateRank, int* cudaP2p) {
   int mnnvl = 0;
   struct ncclPeerInfo* info1 = NULL;
   struct ncclPeerInfo* info2 = NULL;
@@ -336,8 +336,8 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   // NCCL_IGNORE_DISABLED_P2P=2 is used by unit tests that don't want to
   // validate against NVML at all since they are pretending to be on other hw.
   bool checkNvml = (ncclParamIgnoreDisabledP2p() != 2 && g1 != g2 &&
-                    (comm == NULL || (info1->hostHash == comm->peerInfo[comm->rank].hostHash &&
-                                      info1->hostHash == info2->hostHash)));
+    (comm == NULL || (info1->hostHash == comm->peerInfo[comm->rank].hostHash &&
+    info1->hostHash == info2->hostHash)));
   if (*p2p == 1) {
     if (checkNvml) {
       int indexes[3] = {-1,-1,-1};
@@ -381,7 +381,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
       n1 = system->nodes[GPU].nodes[g1].gpu.dev;
       n2 = system->nodes[GPU].nodes[g2].gpu.dev;
       *cudaP2p = (ncclNvmlDevicePairs[n1][n2].p2pStatusRead == NVML_P2P_STATUS_OK &&
-                  ncclNvmlDevicePairs[n1][n2].p2pStatusWrite == NVML_P2P_STATUS_OK);
+              ncclNvmlDevicePairs[n1][n2].p2pStatusWrite == NVML_P2P_STATUS_OK);
     } else {
       // We assume P2P connectivity in case the ranks are connected using MNNVL or are on the same host.
       *cudaP2p = (mnnvl || comm == NULL || info1->hostHash == info2->hostHash);
@@ -392,7 +392,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 }
 
 // MNNVL: Check whether peers are in the same fabric cluster and clique
-ncclResult_t ncclTopoCheckMNNVL(struct ncclTopoSystem* system, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* ret) {
+ncclResult_t ncclTopoCheckMNNVL(struct ncclTopoSystem* /*system*/, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* ret) {
   *ret = 0;
 
   nvmlGpuFabricInfoV_t *fabricInfo1 = &info1->fabricInfo;
@@ -404,9 +404,9 @@ ncclResult_t ncclTopoCheckMNNVL(struct ncclTopoSystem* system, struct ncclPeerIn
   memcpy(&uuid1, fabricInfo2->clusterUuid + sizeof(uuid0), sizeof(uuid1));
   if ((uuid0 | uuid1) == 0) return ncclSuccess;
   if ((memcmp(fabricInfo1->clusterUuid, fabricInfo2->clusterUuid, NVML_GPU_FABRIC_UUID_LEN) == 0) &&
-      (fabricInfo1->cliqueId == fabricInfo2->cliqueId)) {
+    (fabricInfo1->cliqueId == fabricInfo2->cliqueId)) {
     TRACE(NCCL_NET, "MNNVL matching peer 0x%lx UUID %lx.%lx cliqueId 0x%x",
-         info2->busId, uuid0, uuid1, fabricInfo2->cliqueId);
+        info2->busId, uuid0, uuid1, fabricInfo2->cliqueId);
     *ret = 1;
   }
   return ncclSuccess;
@@ -430,7 +430,7 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t n
   struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
   char gpuNetMsg[1024] = "";
   snprintf(gpuNetMsg, sizeof(gpuNetMsg), "GPU/%ld-%ld (rank %d) - NET/%ld-%ld (", NCCL_TOPO_ID_SYSTEM_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(gpu->id), rank,
-           NCCL_TOPO_ID_SYSTEM_ID(net->id), NCCL_TOPO_ID_LOCAL_ID(net->id));
+    NCCL_TOPO_ID_SYSTEM_ID(net->id), NCCL_TOPO_ID_LOCAL_ID(net->id));
 
   // Check that both the NIC and GPUs support it
   if (net->net.gdrSupport == 0) return ncclSuccess;
@@ -546,7 +546,7 @@ ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank
   // First check the current GPU-to-GPU speed.
   int g1, g2;
   if (ncclTopoRankToIndex(system, rank1, &g1, /*showWarn=*/false) != ncclSuccess ||
-      ncclTopoRankToIndex(system, rank2, &g2, /*showWarn=*/false) != ncclSuccess) {
+    ncclTopoRankToIndex(system, rank2, &g2, /*showWarn=*/false) != ncclSuccess) {
     return ncclSuccess;
   }
 
@@ -682,7 +682,7 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
     for (int p=0; p<system->nodes[GPU].count; p++) {
       int p2p;
       NCCLCHECK(ncclTopoCheckP2p(comm, system, system->nodes[GPU].nodes[p].gpu.rank,
-                                 system->nodes[GPU].nodes[g].gpu.rank, &p2p, NULL, NULL, NULL));
+        system->nodes[GPU].nodes[g].gpu.rank, &p2p, NULL, NULL, NULL));
       if (p2p == 0) {
         // Divert all traffic through the CPU
         int cpu;
@@ -743,13 +743,13 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
           // Only use PXN for NIC n if remote GPU p ...
           int pxnType = ncclParamPxnC2c() ? PATH_P2C : PATH_PXB;
           if (/* (1) is connected to the NIC with PxN type*/
-              peerNode->paths[NET][n].type <= pxnType &&
-              /* and (2) is connected to us through NVLink */
-              peerNode->paths[GPU][g].type <= PATH_NVL &&
-              /* and (3) is on the same node as us */
-              NCCL_TOPO_ID_SYSTEM_ID(peerNode->id) == NCCL_TOPO_ID_SYSTEM_ID(gpu->id) &&
-              /* and (4) has either higher bw to that NIC or avoid going through the CPU (path.type is > PATH_PXN)*/
-              (peerNode->paths[NET][n].bw > gpu->paths[NET][n].bw || gpu->paths[NET][n].type > PATH_PXN))
+            peerNode->paths[NET][n].type <= pxnType &&
+            /* and (2) is connected to us through NVLink */
+            peerNode->paths[GPU][g].type <= PATH_NVL &&
+            /* and (3) is on the same node as us */
+            NCCL_TOPO_ID_SYSTEM_ID(peerNode->id) == NCCL_TOPO_ID_SYSTEM_ID(gpu->id) &&
+            /* and (4) has either higher bw to that NIC or avoid going through the CPU (path.type is > PATH_PXN)*/
+            (peerNode->paths[NET][n].bw > gpu->paths[NET][n].bw || gpu->paths[NET][n].type > PATH_PXN))
             // We can use that GPU as relay to communicate with that NIC.
             // Only enabling it in the GPU->NIC direction for now to favor
             // receiving locally and sending remotely (consistent with net.cc)

--- a/src/graph/rings.cc
+++ b/src/graph/rings.cc
@@ -26,7 +26,7 @@ void dumpLine(int* values, int nranks, const char* prefix) {
   INFO(NCCL_INIT, "%s", line);
 }
 
-ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* prev, int* next) {
+ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* /*prev*/, int* next) {
   ncclResult_t ret = ncclSuccess;
   uint64_t* rankFound;
   int rankFoundSize = DIVUP(nranks, 64);

--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -27,7 +27,7 @@ static float getMaxBw(struct ncclTopoSystem* system, struct ncclTopoNode* gpu, i
   }
   return maxBw;
 }
-static float getTotalBw(struct ncclTopoSystem* system, struct ncclTopoNode* gpu) {
+static float getTotalBw(struct ncclTopoSystem* /*system*/, struct ncclTopoNode* gpu) {
   float nvlinkBw = 0.0, pciBw = 0.0;
   for (int l=0; l<gpu->nlinks; l++) {
     struct ncclTopoLink* link = gpu->links+l;
@@ -141,9 +141,9 @@ static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncc
   if (path->type >= PATH_DIS) return ncclSuccess;
   if (mult == 1 && (path->type > type)) return ncclSuccess;
   if (mult == 1 && (graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE ||
-        graph->pattern == NCCL_TOPO_PATTERN_TREE ||
-        graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) &&
-      (revPath->type > type)) return ncclSuccess;
+    graph->pattern == NCCL_TOPO_PATTERN_TREE ||
+    graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) &&
+    (revPath->type > type)) return ncclSuccess;
 
   bw *= mult;
 
@@ -168,8 +168,8 @@ static int gpuPciBw(struct ncclTopoNode* gpu) {
     struct ncclTopoLink* gpuLink = gpu->links+l;
     if (gpuLink->type != LINK_PCI) continue;
     struct ncclTopoNode* pci = gpuLink->remNode;
-    for (int l=0; l<pci->nlinks; l++) {
-      struct ncclTopoLink* pciLink = pci->links+l;
+    for (int pl=0; pl<pci->nlinks; pl++) {
+      struct ncclTopoLink* pciLink = pci->links+pl;
       if (pciLink->remNode != gpu) continue;
       return std::min(gpuLink->bw, pciLink->bw);
     }
@@ -190,15 +190,15 @@ struct ncclGpuScore {
 };
 
 static int cmpScore(const void * g1, const void * g2) {
-   struct ncclGpuScore *s1 = (struct ncclGpuScore*)g1;
-   struct ncclGpuScore *s2 = (struct ncclGpuScore*)g2;
-   int d;
-   if ((d = (s2->interBw - s1->interBw))) return d;
-   if ((d = (s2->interPciBw - s1->interPciBw))) return d;
-   if ((d = (s1->interNhops - s2->interNhops))) return d;
-   if ((d = (s2->intraBw - s1->intraBw))) return d;
-   if ((d = (s1->intraNhops - s2->intraNhops))) return d;
-   return s1->startIndex - s2->startIndex;
+  struct ncclGpuScore *s1 = (struct ncclGpuScore*)g1;
+  struct ncclGpuScore *s2 = (struct ncclGpuScore*)g2;
+  int d;
+  if ((d = (s2->interBw - s1->interBw))) return d;
+  if ((d = (s2->interPciBw - s1->interPciBw))) return d;
+  if ((d = (s1->interNhops - s2->interNhops))) return d;
+  if ((d = (s2->intraBw - s1->intraBw))) return d;
+  if ((d = (s1->intraNhops - s2->intraNhops))) return d;
+  return s1->startIndex - s2->startIndex;
 }
 
 static int cmpIntraScores(struct ncclGpuScore* scores, int count) {
@@ -327,9 +327,9 @@ ncclResult_t ncclTopoReplayGetGpu(struct ncclTopoSystem* system, struct ncclTopo
   int ngpus = system->nodes[GPU].count;
   int nextRank = graph->intra[(graph->nChannels-1)*ngpus+step+1];
   for (int i=0; i<ngpus; i++) if (system->nodes[GPU].nodes[i].gpu.rank == nextRank) {
-    *g = i;
-    return ncclSuccess;
-  }
+      *g = i;
+      return ncclSuccess;
+    }
   return ncclInternalError;
 }
 
@@ -452,8 +452,8 @@ static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int 
       if (gpuIds[g] == -1) continue;
       int localNet;
       int64_t netId;
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes + gpuIds[g];
-      NCCLCHECK(ncclTopoGetLocalNet(system, gpu->gpu.rank, c, &netId, NULL));
+      struct ncclTopoNode* gpuNode = system->nodes[GPU].nodes + gpuIds[g];
+      NCCLCHECK(ncclTopoGetLocalNet(system, gpuNode->gpu.rank, c, &netId, NULL));
       NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &localNet));
       // store the first net found for each GPU in case of duplicates
       if(c == 0) firstNets[g] = localNet;
@@ -478,10 +478,10 @@ static ncclResult_t ncclTopoPrefNetsChannelFirst(struct ncclTopoSystem* system, 
   for (int g = 0; g < system->nodes[GPU].count; g++) {
     if (gpu != -1 && gpu != g) continue;
     int localNetCount = 0, localNets[MAXCHANNELS];
-    struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
+    struct ncclTopoNode* gpuNode = system->nodes[GPU].nodes + g;
     for (int c = 0; c < MAXCHANNELS; c++) {
       int64_t netId;
-      NCCLCHECK(ncclTopoGetLocalNet(system, gpu->gpu.rank, c, &netId, NULL));
+      NCCLCHECK(ncclTopoGetLocalNet(system, gpuNode->gpu.rank, c, &netId, NULL));
       NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, localNets + localNetCount));
       if (localNetCount > 0 && localNets[localNetCount] == localNets[0]) break;
       localNetCount++;
@@ -534,8 +534,8 @@ ncclResult_t ncclTopoSelectNets(struct ncclTopoSystem* system, int typeInter, in
       // do not consider this GPU is it's not the GPU we asked for
       if (gpu != -1 && gpu != g) continue;
       int localNetCount = 0, localNets[MAXCHANNELS];
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
-      struct ncclTopoLinkList* paths = gpu->paths[NET];
+      struct ncclTopoNode* gpuNode = system->nodes[GPU].nodes+g;
+      struct ncclTopoLinkList* paths = gpuNode->paths[NET];
       for (int n=0; n<system->nodes[NET].count && n<MAXCHANNELS; n++) {
         if (paths[n].type == t) localNets[localNetCount++] = n;
       }
@@ -685,10 +685,10 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
     graph->inter[graph->nChannels*2] = net->id;
     graph->latencyInter = net->net.latency;
 
-    for (int i=0; i<system->nodes[NET].count; i++) {
-      if ((system->nodes[NET].nodes[i].net.asic == net->net.asic) &&
-          (system->nodes[NET].nodes[i].net.port == net->net.port)) {
-        system->nodes[NET].nodes[i].net.bw -= bw;
+    for (int j=0; j<system->nodes[NET].count; j++) {
+      if ((system->nodes[NET].nodes[j].net.asic == net->net.asic) &&
+        (system->nodes[NET].nodes[j].net.port == net->net.port)) {
+        system->nodes[NET].nodes[j].net.bw -= bw;
       }
     }
 
@@ -741,10 +741,10 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
       }
     }
 
-    for (int i=0; i<system->nodes[NET].count; i++) {
-      if ((system->nodes[NET].nodes[i].net.asic == net->net.asic) &&
-          (system->nodes[NET].nodes[i].net.port == net->net.port)) {
-        system->nodes[NET].nodes[i].net.bw += bw;
+    for (int j=0; j<system->nodes[NET].count; j++) {
+      if ((system->nodes[NET].nodes[j].net.asic == net->net.asic) &&
+        (system->nodes[NET].nodes[j].net.port == net->net.port)) {
+        system->nodes[NET].nodes[j].net.bw += bw;
       }
     }
   }
@@ -844,9 +844,9 @@ ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode *xmlChannel, int c, st
       inter[n++] = dev;
     } else if (strcmp(sub->name, "gpu") == 0) {
       int rank = -1;
-      for (int g=0; g<ngpus; g++) {
-        int systemId = NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[g].id);
-        if (NCCL_TOPO_ID(systemId, system->nodes[GPU].nodes[g].gpu.dev) == dev) rank = system->nodes[GPU].nodes[g].gpu.rank;
+      for (int gi=0; gi<ngpus; gi++) {
+        int systemId = NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[gi].id);
+        if (NCCL_TOPO_ID(systemId, system->nodes[GPU].nodes[gi].gpu.dev) == dev) rank = system->nodes[GPU].nodes[gi].gpu.rank;
       }
       if (rank == -1) {
         WARN("XML Import Channel : dev %ld not found.", dev);
@@ -1018,7 +1018,7 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
 
   int ngpus = system->nodes[GPU].count;
   int crossNic = (system->nodes[NET].count > 1) &&
-	 (graph->pattern == NCCL_TOPO_PATTERN_RING ||
+      (graph->pattern == NCCL_TOPO_PATTERN_RING ||
           graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE ||
           graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) ? ncclParamCrossNic() : 0;
   graph->crossNic = crossNic == 1 ? 1 : 0;
@@ -1105,7 +1105,7 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
 
 search:
   int time = tmpGraph.sameChannels ? NCCL_SEARCH_TIMEOUT_SAMECHANNELS :
-    tmpGraph.pattern == NCCL_TOPO_PATTERN_TREE ? NCCL_SEARCH_TIMEOUT_TREE : NCCL_SEARCH_TIMEOUT;
+      tmpGraph.pattern == NCCL_TOPO_PATTERN_TREE ? NCCL_SEARCH_TIMEOUT_TREE : NCCL_SEARCH_TIMEOUT;
   tmpGraph.nChannels = 0;
   globalTimeout -= time;
 

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -41,9 +41,9 @@ static ncclResult_t findLocalCpu(struct ncclTopoNode* node, struct ncclTopoNode*
   for (int l=0; l<node->nlinks; l++) {
     // Go up the PCI tree to find the CPU. Follow only PCI switches.
     if (node->links[l].type == LINK_PCI
-	&& node->links[l].remNode != from
-	&& (node->links[l].remNode->type == PCI
-	    || node->links[l].remNode->type == CPU)) {
+        && node->links[l].remNode != from
+        && (node->links[l].remNode->type == PCI
+            || node->links[l].remNode->type == CPU)) {
       NCCLCHECK(findLocalCpu(node->links[l].remNode, cpu, node));
     }
     if (*cpu != NULL) return ncclSuccess;
@@ -66,10 +66,10 @@ static ncclResult_t ncclTopoGetInterCpuBw(struct ncclTopoNode* cpu, float* bw) {
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_INTEL) {
     *bw =
-      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_ERP ? ERP_QPI_BW :
-      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SRP ? SRP_QPI_BW :
-      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SKL ? SKL_QPI_BW :
-      BDW_QPI_BW;
+        cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_ERP ? ERP_QPI_BW :
+        cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SRP ? SRP_QPI_BW :
+        cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SKL ? SKL_QPI_BW :
+        BDW_QPI_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
     *bw = AMD_BW;
@@ -207,10 +207,10 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
         l--;
       }
 
-      for (int s=0; s<subs; s++) {
+      for (int si=0; si<subs; si++) {
         // Find sub switch (system->nodes[PCI].nodes is changing every time we remove a node)
         int index;
-        NCCLCHECKGOTO(ncclTopoIdToIndex(system, PCI, subSwIds[s], &index), ret, fail);
+        NCCLCHECKGOTO(ncclTopoIdToIndex(system, PCI, subSwIds[si], &index), ret, fail);
         struct ncclTopoNode* sub = system->nodes[PCI].nodes+index;
         // Connect all sub PCI devices to the parent switch
         for (int l=0; l<sub->nlinks; l++) {
@@ -431,7 +431,7 @@ ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* s
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoAddGpu(struct ncclXmlNode* xmlGpu, struct ncclTopoSystem* system, struct ncclTopoNode* gpu) {
+ncclResult_t ncclTopoAddGpu(struct ncclXmlNode* xmlGpu, struct ncclTopoSystem* /*system*/, struct ncclTopoNode* gpu) {
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "sm", &gpu->gpu.cudaCompCap));
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "rank", &gpu->gpu.rank));
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "dev", &gpu->gpu.dev));
@@ -446,7 +446,8 @@ struct kvDict kvDictPciClass[] = { { PCI_BRIDGE_DEVICE_CLASS, PCI }, {"0x080100"
 struct kvDict kvDictPciGen[] = {
   { "2.5 GT/s", 15 }, { "5 GT/s", 30 }, { "8 GT/s", 60 }, { "16 GT/s", 120 }, { "32 GT/s", 240 }, /* Kernel 5.6 and earlier */
   { "2.5 GT/s PCIe", 15 }, { "5.0 GT/s PCIe", 30 }, { "8.0 GT/s PCIe", 60 }, { "16.0 GT/s PCIe", 120 }, { "32.0 GT/s PCIe", 240 }, { "64.0 GT/s PCIe", 480 },
-  { NULL, 60 /* Default fallback */ } }; // x100 Mbps per lane
+  { NULL, 60 /* Default fallback */ }
+}; // x100 Mbps per lane
 ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* system, struct ncclTopoNode* parent, int systemId, int numaId) {
   const char* str;
 
@@ -555,10 +556,10 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
       cpu->cpu.model =
-        (familyId == 6 && modelId >= 0xCF) ? NCCL_TOPO_CPU_MODEL_INTEL_ERP :
-        (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SRP :
-        (familyId == 6 && modelId >= 0x55) ? NCCL_TOPO_CPU_MODEL_INTEL_SKL :
-        NCCL_TOPO_CPU_MODEL_INTEL_BDW;
+          (familyId == 6 && modelId >= 0xCF) ? NCCL_TOPO_CPU_MODEL_INTEL_ERP :
+          (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SRP :
+          (familyId == 6 && modelId >= 0x55) ? NCCL_TOPO_CPU_MODEL_INTEL_SKL :
+          NCCL_TOPO_CPU_MODEL_INTEL_BDW;
     } else if (cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {
       int familyId, modelId;
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
@@ -719,7 +720,7 @@ ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem
   int systemId = 0;
   while (systemId < system->nHosts && system->hostHashes[systemId] != localHostHash) systemId++;
   system->systemId = systemId;
-  if(systemId == system->nHosts){
+  if(systemId == system->nHosts) {
     WARN("localHostHash = 0x%lx not found in the list of system hostHashes",localHostHash);
     return ncclInvalidArgument;
   }
@@ -897,12 +898,12 @@ ncclResult_t ncclTopoGetPath(ncclXmlNode** nodes, int nNodes, int* path, ncclXml
 
     if (c) {
       common = temp;
-      if (common == NULL) TRACE(NCCL_GRAPH, "COMMON IS NULL");
+      if (common == NULL) { TRACE(NCCL_GRAPH, "COMMON IS NULL"); }
       for (int i = 0; i < nNodes; i++) {
         parents[i].pop();
       }
-    // Check multi-port while we still have the mismatched parents
-    // For multi-port to be true, all parents (peers) must have the busId attribute with all but the last character matching
+      // Check multi-port while we still have the mismatched parents
+      // For multi-port to be true, all parents (peers) must have the busId attribute with all but the last character matching
     } else {
       int multiPort = 1;
       const char* tempBusId;
@@ -1020,7 +1021,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps, struct ncclXmlNode** physNetNodes) {
+ncclResult_t ncclTopoMakeVnic(struct ncclXml* /*xml*/, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps, struct ncclXmlNode** physNetNodes) {
   if (vProps->ndevs > NCCL_NET_MAX_DEVS_PER_NIC) {
     WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, NCCL_NET_MAX_DEVS_PER_NIC);
     return ncclInternalError;
@@ -1038,7 +1039,7 @@ ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netIn
   NOWARN(ret = netInfo->makeVDevice(&vDevIndex, vProps), NCCL_GRAPH|NCCL_INIT|NCCL_NET);
   if (ret != ncclSuccess) {
     INFO(NCCL_GRAPH|NCCL_INIT|NCCL_NET, "TOPO/NET : Tried merging multiple devices together and failed. vProps={ndevs=%d, devs=[%d %d %d %d]}. Set NCCL_NET_MERGE_LEVEL=LOC to disable NIC fusion.",
-      vProps->ndevs, vProps->devs[0], vProps->devs[1], vProps->devs[2], vProps->devs[3]);
+        vProps->ndevs, vProps->devs[0], vProps->devs[1], vProps->devs[2], vProps->devs[3]);
     return ret;
   }
 
@@ -1068,11 +1069,11 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     int nUserIfs = parseStringList(semi, userIfs, NCCL_NET_MAX_DEVS_PER_NIC);
     if (nUserIfs == 0) {
       INFO(NCCL_NET, "NET/IB : Invalid NCCL_NET_FORCE_MERGE specified %s. Couldn't parse substring %s. Please provide a semicolon-delimited list of comma-delimited NIC groups.",
-        ncStr, semi);
+          ncStr, semi);
       continue;
     }
 
-    ncclNetVDeviceProps_t vProps = {0};
+    ncclNetVDeviceProps_t vProps = {};
     for (int d = 0; d < nPhysDevs; d++) {
       if (matchIfList(propsList[d].name, propsList[d].port, userIfs, nUserIfs, 1)) {
         vProps.devs[vProps.ndevs++] = d;
@@ -1081,7 +1082,7 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
 
     if (vProps.ndevs != nUserIfs) {
       WARN("TOPO/NET : Only matched %d devices, %d requested from %s",
-        vProps.ndevs, nUserIfs, semi);
+          vProps.ndevs, nUserIfs, semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1114,7 +1115,7 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs, ncclNetProperties_t* propsList, struct ncclXmlNode** physNetNodes, int nPhysDevs) {
+ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs, ncclNetProperties_t* /*propsList*/, struct ncclXmlNode** physNetNodes, int nPhysDevs) {
   // Compute the path type between each device
   int* paths = NULL;
   ncclResult_t res = ncclSuccess;
@@ -1136,7 +1137,7 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
     if (placedDevs[i] == 0) {
       // Init a new vDevice
       ncclNetVDeviceProps_t vProps;
-      vProps = {0};
+      vProps = {};
       vProps.devs[vProps.ndevs++] = i;
       placedDevs[i] = 1;
       TRACE(NCCL_GRAPH, "Placed dev %d", i);
@@ -1145,7 +1146,7 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
       // (Don't merge the same device with itself)
       for (int j = 0; j < nPhysDevs; j++) {
         if (paths[i*nPhysDevs + j] <= netInfo->mergeLevel &&
-        placedDevs[j] == 0 && j != i) {
+            placedDevs[j] == 0 && j != i) {
           vProps.devs[vProps.ndevs++] = j;
           placedDevs[j] = 1;
           TRACE(NCCL_GRAPH, "Placed dev %d path=%d", j, paths[i*nPhysDevs + j] );
@@ -1235,7 +1236,7 @@ ncclResult_t ncclTopoFindLinkWidthRec(ncclXmlNode* node, ncclXmlNode** physNetNo
     *linkWidth = myLinkWidth;
     INFO(NCCL_GRAPH, "Found child net device for %s. Returning link_width=%d totalChildLinkWidth=%d", node->name, *linkWidth, totalChildLinkWidth);
   } else {
-  // Standard recursive accrual of link_width. The link_width is either the bottleneck of this PCI node's width or the sum of its children's width.
+    // Standard recursive accrual of link_width. The link_width is either the bottleneck of this PCI node's width or the sum of its children's width.
     *linkWidth = myLinkWidth > 0 ? std::min(myLinkWidth, totalChildLinkWidth) : totalChildLinkWidth;
     INFO(NCCL_GRAPH, "Found child net device for %s. Returning link_width=%d totalChildLinkWidth=%d", node->name, *linkWidth, totalChildLinkWidth);
   }
@@ -1448,7 +1449,7 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
   int* localRanks = NULL;
   struct ncclXml* rankXml;
   int localRank = -1, nLocalRanks = 0;
-  struct ncclTopoNetInfo netInfo = {0};
+  struct ncclTopoNetInfo netInfo = {};
   NCCLCHECK(xmlAlloc(&xml, NCCL_TOPO_XML_MAX_NODES));
   const char* xmlTopoFile = ncclGetEnv("NCCL_TOPO_FILE");
   if (xmlTopoFile) {
@@ -1489,51 +1490,51 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
   // Auto-detect NICs if needed, net/gin/collnet share the same xml/graph nodes.
   // Start with gin, then with collnet so that they precedence.
   {
-      std::lock_guard<std::mutex> lock(netMutex);
-      INFO(NCCL_GRAPH, "TOPO/NET : Importing network plugins to topology");
-      ncclGin_t* gin = comm->sharedRes->ginState.ncclGin;
-      if (gin) {
-        netInfo.net = 0;
-        netInfo.coll = 0;
-        netInfo.gin = 1;
-        netInfo.netPluginIndex = comm->ginPluginIndex;
-        netInfo.dmaBufSupport = comm->dmaBufSupport;
-        netInfo.getDevCount = ncclGinGetDevCount;
-        netInfo.name = gin->name;
-        netInfo.getProperties = gin->getProperties;
-        netInfo.makeVDevice = NULL;
-        netInfo.devices = gin->devices;
-        NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
-      }
-      if (collNetSupport(comm)) {
-        netInfo.net = 0;
-        netInfo.coll = 1;
-        netInfo.gin = 0;
-        netInfo.netPluginIndex = comm->netPluginIndex;
-        netInfo.dmaBufSupport = comm->dmaBufSupport;
-        netInfo.getDevCount = ncclCollNetGetDevCount;
-        netInfo.setVirtDevCount = ncclCollNetSetVirtDevCount;
-        netInfo.name = comm->ncclCollNet->name;
-        netInfo.getProperties = comm->ncclCollNet->getProperties;
-        netInfo.makeVDevice = comm->ncclCollNet->makeVDevice;
-        netInfo.devices = comm->ncclCollNet->devices;
-        NCCLCHECK(ncclTopoGetFusionEnv(&netInfo.mergeLevel, &netInfo.forceMerge));
-        NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
-      }
-
-      netInfo.net = 1;
+    std::lock_guard<std::mutex> lock(netMutex);
+    INFO(NCCL_GRAPH, "TOPO/NET : Importing network plugins to topology");
+    ncclGin_t* gin = comm->sharedRes->ginState.ncclGin;
+    if (gin) {
+      netInfo.net = 0;
       netInfo.coll = 0;
+      netInfo.gin = 1;
+      netInfo.netPluginIndex = comm->ginPluginIndex;
+      netInfo.dmaBufSupport = comm->dmaBufSupport;
+      netInfo.getDevCount = ncclGinGetDevCount;
+      netInfo.name = gin->name;
+      netInfo.getProperties = gin->getProperties;
+      netInfo.makeVDevice = NULL;
+      netInfo.devices = gin->devices;
+      NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
+    }
+    if (collNetSupport(comm)) {
+      netInfo.net = 0;
+      netInfo.coll = 1;
       netInfo.gin = 0;
       netInfo.netPluginIndex = comm->netPluginIndex;
       netInfo.dmaBufSupport = comm->dmaBufSupport;
-      netInfo.getDevCount = ncclNetGetDevCount;
-      netInfo.setVirtDevCount = ncclNetSetVirtDevCount;
-      netInfo.name = comm->ncclNet->name;
-      netInfo.getProperties = comm->ncclNet->getProperties;
-      netInfo.makeVDevice = comm->ncclNet->makeVDevice;
-      netInfo.devices = comm->ncclNet->devices;
+      netInfo.getDevCount = ncclCollNetGetDevCount;
+      netInfo.setVirtDevCount = ncclCollNetSetVirtDevCount;
+      netInfo.name = comm->ncclCollNet->name;
+      netInfo.getProperties = comm->ncclCollNet->getProperties;
+      netInfo.makeVDevice = comm->ncclCollNet->makeVDevice;
+      netInfo.devices = comm->ncclCollNet->devices;
       NCCLCHECK(ncclTopoGetFusionEnv(&netInfo.mergeLevel, &netInfo.forceMerge));
       NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
+    }
+
+    netInfo.net = 1;
+    netInfo.coll = 0;
+    netInfo.gin = 0;
+    netInfo.netPluginIndex = comm->netPluginIndex;
+    netInfo.dmaBufSupport = comm->dmaBufSupport;
+    netInfo.getDevCount = ncclNetGetDevCount;
+    netInfo.setVirtDevCount = ncclNetSetVirtDevCount;
+    netInfo.name = comm->ncclNet->name;
+    netInfo.getProperties = comm->ncclNet->getProperties;
+    netInfo.makeVDevice = comm->ncclNet->makeVDevice;
+    netInfo.devices = comm->ncclNet->devices;
+    NCCLCHECK(ncclTopoGetFusionEnv(&netInfo.mergeLevel, &netInfo.forceMerge));
+    NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
   }
 
   // Remove XML branches which don't have a node with keep="1" (typically when importing a topology)
@@ -1596,7 +1597,7 @@ fail:
 }
 
 ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index, int resultType,
-                                     int locals[NCCL_TOPO_MAX_NODES], int* localCount, int* pathType) {
+    int locals[NCCL_TOPO_MAX_NODES], int* localCount, int* pathType) {
   int minType = PATH_DIS;
   float maxBw = 0;
   int count = 0;
@@ -1613,7 +1614,7 @@ ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index
       if (count == NCCL_TOPO_MAX_NODES) {
         WARN("Error : ran out of room to store found nodes in ncclTopoGetLocal."
              " Filled %d of type %d, starting from index %d of type %d.",
-             NCCL_TOPO_MAX_NODES, resultType, index, type);
+            NCCL_TOPO_MAX_NODES, resultType, index, type);
         return ncclInternalError;
       }
       locals[count++] = i;
@@ -1634,12 +1635,12 @@ ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *c
   int netCountByBw = 0;
   float totalNetBw = 0;
   int64_t firstNetId = 0;
-  for (int c = 0; c < MAXCHANNELS; c++) {
+  for (int ch = 0; ch < MAXCHANNELS; ch++) {
     int net;
     int64_t netId;
-    NCCLCHECK(ncclTopoGetLocalNet(system, rank, c, &netId, NULL));
+    NCCLCHECK(ncclTopoGetLocalNet(system, rank, ch, &netId, NULL));
     NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &net));
-    if(c == 0) firstNetId = netId;
+    if(ch == 0) firstNetId = netId;
     else if(firstNetId == netId) break;
 
     totalNetBw += system->nodes[GPU].nodes[gpu].paths[NET][net].bw;

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -474,7 +474,7 @@ ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* pat
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* xml) {
+ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* /*xml*/) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(cpuNode, "affinity", &index));
   if (index == -1) {
@@ -566,8 +566,8 @@ int checkBDFFormat(char* bdf) {
   if (strlen(bdf) != 12) return 0;
   if ((bdf[4] != ':') || (bdf[7] != ':') || (bdf[10] != '.')) return 0;
   if ((isHex(bdf[0]) == 0) || (isHex(bdf[1]) == 0) || (isHex(bdf[2]) == 0) || (isHex(bdf[3]) == 0) ||
-      (isHex(bdf[5]) == 0) || (isHex(bdf[6]) == 0) || (isHex(bdf[8]) == 0) || (isHex(bdf[9]) == 0) ||
-      (isHex(bdf[11]) == 0)) return 0;
+    (isHex(bdf[5]) == 0) || (isHex(bdf[6]) == 0) || (isHex(bdf[8]) == 0) || (isHex(bdf[9]) == 0) ||
+    (isHex(bdf[11]) == 0)) return 0;
   return 1;
 }
 
@@ -711,9 +711,9 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
     const char* newBusId;
     NCCLCHECK(xmlGetAttrStr(pciNode, "busid", &newBusId));
     for (int s=0; s<parent->nSubs; s++) {
-      const char* busId;
-      NCCLCHECK(xmlGetAttr(parent->subs[s], "busid", &busId));
-      if (busId != NULL && strcmp(newBusId, busId) < 0) { subIndex = s; break; }
+      const char* existingBusId;
+      NCCLCHECK(xmlGetAttr(parent->subs[s], "busid", &existingBusId));
+      if (existingBusId != NULL && strcmp(newBusId, existingBusId) < 0) { subIndex = s; break; }
     }
     if (parent->nSubs == MAX_SUBS) {
       WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
@@ -825,44 +825,44 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvm
   struct ncclXmlNode* c2cNode = NULL;
   NCCLCHECK(xmlGetSub(gpuNode, "c2c", &c2cNode));
   if (c2cNode == NULL) {
-      if (sm >= 90) {
-        int c2cLinksCount = 0;
-        nvmlFieldValue_t fv;
-        fv.fieldId = NVML_FI_DEV_C2C_LINK_COUNT;
-        if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 1, &fv) == ncclSuccess) && (fv.nvmlReturn == NVML_SUCCESS)) {
-          c2cLinksCount = fv.value.uiVal;
-          int bw = 0;
-	  int count = 0;
-          for (int l=0; l<c2cLinksCount; l++) {
-            nvmlFieldValue_t fvs[2];
-            fvs[0].fieldId = NVML_FI_DEV_C2C_LINK_GET_STATUS;
-            fvs[0].scopeId = l;
-            fvs[1].fieldId = NVML_FI_DEV_C2C_LINK_GET_MAX_BW;
-            fvs[1].scopeId = l;
-            if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 2, fvs) == ncclSuccess) &&
-                (fvs[0].nvmlReturn == NVML_SUCCESS) &&
-                (fvs[0].value.uiVal == 1) &&
-                (fvs[1].nvmlReturn == NVML_SUCCESS)) {
-              bw = fvs[1].value.uiVal;
-	      count++;
-            }
-          }
-          if (count > 0) {
-            NCCLCHECK(xmlAddNode(xml, gpuNode, "c2c", &c2cNode));
-            NCCLCHECK(xmlSetAttrInt(c2cNode, "bw", bw));
-            NCCLCHECK(xmlSetAttrInt(c2cNode, "count", count));
+    if (sm >= 90) {
+      int c2cLinksCount = 0;
+      nvmlFieldValue_t fv;
+      fv.fieldId = NVML_FI_DEV_C2C_LINK_COUNT;
+      if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 1, &fv) == ncclSuccess) && (fv.nvmlReturn == NVML_SUCCESS)) {
+        c2cLinksCount = fv.value.uiVal;
+        int bw = 0;
+        int count = 0;
+        for (int l=0; l<c2cLinksCount; l++) {
+          nvmlFieldValue_t fvs[2];
+          fvs[0].fieldId = NVML_FI_DEV_C2C_LINK_GET_STATUS;
+          fvs[0].scopeId = l;
+          fvs[1].fieldId = NVML_FI_DEV_C2C_LINK_GET_MAX_BW;
+          fvs[1].scopeId = l;
+          if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 2, fvs) == ncclSuccess) &&
+            (fvs[0].nvmlReturn == NVML_SUCCESS) &&
+            (fvs[0].value.uiVal == 1) &&
+            (fvs[1].nvmlReturn == NVML_SUCCESS)) {
+            bw = fvs[1].value.uiVal;
+            count++;
           }
         }
+        if (count > 0) {
+          NCCLCHECK(xmlAddNode(xml, gpuNode, "c2c", &c2cNode));
+          NCCLCHECK(xmlSetAttrInt(c2cNode, "bw", bw));
+          NCCLCHECK(xmlSetAttrInt(c2cNode, "count", count));
+        }
       }
+    }
   }
 #endif
   // Fill target classes
   for (int s=0; s<gpuNode->nSubs; s++) {
     struct ncclXmlNode* sub = gpuNode->subs[s];
     if (strcmp(sub->name, "nvlink") != 0) continue;
-    int index;
-    NCCLCHECK(xmlGetAttrIndex(sub, "tclass", &index));
-    if (index == -1) {
+    int tclassIndex;
+    NCCLCHECK(xmlGetAttrIndex(sub, "tclass", &tclassIndex));
+    if (tclassIndex == -1) {
       const char* busId;
       NCCLCHECK(xmlGetAttr(sub, "target", &busId));
       char* path;

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -229,7 +229,7 @@ static ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, c
   return ncclSuccess;
 }
 
-static ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* name) {
+static ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* /*name*/) {
   while (node) {
     char line[1024*8];
     int cursor = 0;

--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -147,6 +147,7 @@ static inline ncclResult_t ncclCudaHostFree(void* ptr) {
 
 template <typename T>
 ncclResult_t ncclCallocDebug(T** ptr, size_t nelem, const char *filefunc, int line) {
+  (void)filefunc; (void)line;
   if (nelem > 0) {
     T* p = (T*)malloc(nelem*ncclSizeOfT<T>());
     if (p == NULL) {
@@ -206,8 +207,8 @@ ncclResult_t ncclRealloc(T** ptr, size_t oldNelem, size_t nelem) {
 
 // Helper function to map memory and set access permissions for a device
 static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
-  CUmemGenericAllocationHandle handle,
-  int cudaDev) {
+    CUmemGenericAllocationHandle handle,
+    int cudaDev) {
   ncclResult_t result = ncclSuccess;
   // Map the virtual address range to the physical allocation
   CUCHECK(cuMemMap((CUdeviceptr)ptr, size, 0, handle, 0));
@@ -253,9 +254,9 @@ static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, int numSegments = 1) {
 }
 
 static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHandle *handlep,
-                                          CUmemAllocationHandleType type, size_t size,
-                                          struct ncclMemManager* manager,
-                                          ncclMemType_t memType = ncclMemPersist) {
+    CUmemAllocationHandleType type, size_t size,
+    struct ncclMemManager* manager,
+    ncclMemType_t memType = ncclMemPersist) {
   ncclResult_t result = ncclSuccess;
   size_t granularity = 0;
   CUdevice currentDev;
@@ -344,7 +345,7 @@ static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t
 extern int ncclCuMemEnable();
 
 static inline ncclResult_t ncclCuMemAlloc(void **ptr, void *handlep, int type, size_t size,
-                                          struct ncclMemManager* manager, ncclMemType_t memType = ncclMemScratch) {
+    struct ncclMemManager* manager, ncclMemType_t memType = ncclMemScratch) {
   WARN("CUMEM not supported prior to CUDA 11.3");
   return ncclInternalError;
 }
@@ -372,7 +373,7 @@ static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t
 
 template <typename T>
 ncclResult_t ncclCudaMallocDebug(T** ptr, size_t nelem, const char *filefunc, int line,
-                                  struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
+    struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -394,7 +395,7 @@ finish:
 
 template <typename T>
 ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char *filefunc, int line,
-                                  struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
+    struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -422,7 +423,7 @@ finish:
 
 template <typename T>
 ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, cudaStream_t stream, const char *filefunc, int line,
-                                       struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
+    struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -494,7 +495,7 @@ ncclResult_t ncclCudaFree(T* ptr, struct ncclMemManager* manager, int numSegment
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (ncclCuMemEnable()) {
     NCCLCHECKGOTO(ncclCuMemFree((void *)ptr, manager, numSegments), result, finish);
-  } else{
+  } else {
     if (numSegments > 1) {
       result = ncclUnhandledCudaError;
       goto finish;

--- a/src/include/bitops.h
+++ b/src/include/bitops.h
@@ -13,34 +13,34 @@
 #include "compiler.h"
 
 #if !__NVCC__
-  #ifndef __host__
-    #define __host__
-  #endif
-  #ifndef __device__
-    #define __device__
-  #endif
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
 #endif
 
 template<typename Int>
 constexpr static __host__ __device__ Int minval(Int a) { return a; }
 template<typename Int, typename ...More>
 constexpr static __host__ __device__ Int minval(Int a, Int b, More ...more) {
-  #if __CUDA_ARCH__
-    return minval(min(a, b), more...);
-  #else
-    return minval(a < b ? a : b, more...);
-  #endif
+#if __CUDA_ARCH__
+  return minval(min(a, b), more...);
+#else
+  return minval(a < b ? a : b, more...);
+#endif
 }
 
 template<typename Int>
 constexpr static __host__ __device__ Int maxval(Int a) { return a; }
 template<typename Int, typename ...More>
 constexpr static __host__ __device__ Int maxval(Int a, Int b, More ...more) {
-  #if __CUDA_ARCH__
-    return maxval(max(a, b), more...);
-  #else
-    return maxval(a > b ? a : b, more...);
-  #endif
+#if __CUDA_ARCH__
+  return maxval(max(a, b), more...);
+#else
+  return maxval(a > b ? a : b, more...);
+#endif
 }
 
 #define BIT(x) (1UL << (x))
@@ -151,7 +151,7 @@ static __host__ __device__ uint64_t mul64hi(uint64_t a, uint64_t b) {
 
 // Produce the reciprocal of x*y given their respective reciprocals. This incurs
 // no integer division on device.
-static __host__ __device__ uint32_t imulRcp32(uint32_t x, uint32_t xrcp, uint32_t y, uint32_t yrcp) {
+static inline __host__ __device__ uint32_t imulRcp32(uint32_t x, uint32_t xrcp, uint32_t y, uint32_t yrcp) {
   if (xrcp == 0) return yrcp;
   if (yrcp == 0) return xrcp;
   uint32_t rcp = mul32hi(xrcp, yrcp);
@@ -159,7 +159,7 @@ static __host__ __device__ uint32_t imulRcp32(uint32_t x, uint32_t xrcp, uint32_
   if (x*y <= rem) rcp += 1;
   return rcp;
 }
-static __host__ __device__ uint64_t imulRcp64(uint64_t x, uint64_t xrcp, uint64_t y, uint64_t yrcp) {
+static inline __host__ __device__ uint64_t imulRcp64(uint64_t x, uint64_t xrcp, uint64_t y, uint64_t yrcp) {
   if (xrcp == 0) return yrcp;
   if (yrcp == 0) return xrcp;
   uint64_t rcp = mul64hi(xrcp, yrcp);
@@ -191,23 +191,23 @@ static __host__ __device__ void idivmodFast64(uint64_t *quo, uint64_t *rem, uint
   *rem = r;
 }
 
-static __host__ __device__ uint32_t idivFast32(uint32_t x, uint32_t y, uint32_t yrcp) {
+static inline __host__ __device__ uint32_t idivFast32(uint32_t x, uint32_t y, uint32_t yrcp) {
   uint32_t q, r;
   idivmodFast32(&q, &r, x, y, yrcp);
   return q;
 }
-static __host__ __device__ uint32_t idivFast64(uint64_t x, uint64_t y, uint64_t yrcp) {
+static inline __host__ __device__ uint32_t idivFast64(uint64_t x, uint64_t y, uint64_t yrcp) {
   uint64_t q, r;
   idivmodFast64(&q, &r, x, y, yrcp);
   return q;
 }
 
-static __host__ __device__ uint32_t imodFast32(uint32_t x, uint32_t y, uint32_t yrcp) {
+static inline __host__ __device__ uint32_t imodFast32(uint32_t x, uint32_t y, uint32_t yrcp) {
   uint32_t q, r;
   idivmodFast32(&q, &r, x, y, yrcp);
   return r;
 }
-static __host__ __device__ uint32_t imodFast64(uint64_t x, uint64_t y, uint64_t yrcp) {
+static inline __host__ __device__ uint32_t imodFast64(uint64_t x, uint64_t y, uint64_t yrcp) {
   uint64_t q, r;
   idivmodFast64(&q, &r, x, y, yrcp);
   return r;
@@ -352,10 +352,10 @@ template<typename UInt, int nSubBits>
 static __host__ UInt reverseSubBits(UInt x) {
   if (nSubBits >= 16 && 8*sizeof(UInt) == nSubBits) {
     switch (8*sizeof(UInt)) {
-    case 16: x = COMPILER_BSWAP16(x); break;
-    case 32: x = COMPILER_BSWAP32(x); break;
-    case 64: x = COMPILER_BSWAP64(x); break;
-    default: static_assert(8*sizeof(UInt) <= 64, "Unsupported integer type.");
+      case 16: x = COMPILER_BSWAP16(x); break;
+      case 32: x = COMPILER_BSWAP32(x); break;
+      case 64: x = COMPILER_BSWAP64(x); break;
+      default: static_assert(8*sizeof(UInt) <= 64, "Unsupported integer type.");
     }
     return reverseSubBits<UInt, 8>(x);
   } else if (nSubBits <= 1) {
@@ -386,17 +386,17 @@ static __host__ __device__ Int reverseBits(Int x, int nBits) {
   using UInt = typename ncclToUnsigned<Int>::type;
   union { UInt ux; Int sx; };
   sx = x;
-  #if __CUDA_ARCH__
-    if (sizeof(Int) <= sizeof(unsigned int)) {
-      ux = __brev(ux);
-    } else if (sizeof(Int) <= sizeof(unsigned long long)) {
-      ux = __brevll(ux);
-    } else {
-      static_assert(sizeof(Int) <= sizeof(unsigned long long), "Unsupported integer type.");
-    }
-  #else
-    ux = reverseSubBits<UInt, 8*sizeof(UInt)>(ux);
-  #endif
+#if __CUDA_ARCH__
+  if (sizeof(Int) <= sizeof(unsigned int)) {
+    ux = __brev(ux);
+  } else if (sizeof(Int) <= sizeof(unsigned long long)) {
+    ux = __brevll(ux);
+  } else {
+    static_assert(sizeof(Int) <= sizeof(unsigned long long), "Unsupported integer type.");
+  }
+#else
+  ux = reverseSubBits<UInt, 8*sizeof(UInt)>(ux);
+#endif
   ux = nBits==0 ? 0 : ux>>(8*sizeof(UInt)-nBits);
   return sx;
 }
@@ -408,11 +408,11 @@ static __host__ __device__ Int reverseBits(Int x, int nBits) {
 
 static __host__ __device__ uint32_t u32fpEncode(uint32_t x, int bitsPerPow2) {
   int log2x;
-  #if __CUDA_ARCH__
-    log2x = 31-__clz(x|1);
-  #else
-    log2x = 31-COMPILER_CLZ(x|1);
-  #endif
+#if __CUDA_ARCH__
+  log2x = 31-__clz(x|1);
+#else
+  log2x = 31-COMPILER_CLZ(x|1);
+#endif
   uint32_t mantissa = x>>(log2x >= bitsPerPow2 ? log2x-bitsPerPow2 : 0) & ((1u<<bitsPerPow2)-1);
   uint32_t exponent = log2x >= bitsPerPow2 ? log2x-(bitsPerPow2-1) : 0;
   return exponent<<bitsPerPow2 | mantissa;
@@ -427,10 +427,10 @@ static __host__ __device__ uint32_t u32fpDecode(uint32_t x, int bitsPerPow2) {
 
 constexpr uint32_t u32fp8MaxValue() { return 0xf0000000; }
 
-static __host__ __device__ uint8_t u32fp8Encode(uint32_t x) {
+static inline __host__ __device__ uint8_t u32fp8Encode(uint32_t x) {
   return u32fpEncode(x, 3);
 }
-static __host__ __device__ uint32_t u32fp8Decode(uint8_t x) {
+static inline __host__ __device__ uint32_t u32fp8Decode(uint8_t x) {
   return u32fpDecode(x, 3);
 }
 

--- a/src/include/checks.h
+++ b/src/include/checks.h
@@ -23,9 +23,9 @@
 
 #define CUDACHECKGOTO(cmd, RES, label)                                         \
   do {                                                                         \
-    cudaError_t err = cmd;                                                     \
-    if (err != cudaSuccess) {                                                  \
-      WARN("Cuda failure '%s'", cudaGetErrorString(err));                      \
+    cudaError_t _cudaChkErr = cmd;                                             \
+    if (_cudaChkErr != cudaSuccess) {                                          \
+      WARN("Cuda failure '%s'", cudaGetErrorString(_cudaChkErr));              \
       (void)cudaGetLastError();                                                \
       RES = ncclUnhandledCudaError;                                            \
       goto label;                                                              \
@@ -35,10 +35,10 @@
 // Report failure but clear error and continue
 #define CUDACHECKIGNORE(cmd)                                                   \
   do {                                                                         \
-    cudaError_t err = cmd;                                                     \
-    if (err != cudaSuccess) {                                                  \
+    cudaError_t _cudaChkErr = cmd;                                             \
+    if (_cudaChkErr != cudaSuccess) {                                          \
       INFO(NCCL_ALL, "%s:%d Cuda failure '%s'", __FILE__, __LINE__,            \
-           cudaGetErrorString(err));                                           \
+           cudaGetErrorString(_cudaChkErr));                                   \
       (void)cudaGetLastError();                                                \
     }                                                                          \
   } while (false)

--- a/src/include/collectives.h
+++ b/src/include/collectives.h
@@ -43,24 +43,24 @@ const char* ncclProtoToString(int proto);
 
 inline int ncclTypeSize(ncclDataType_t type) {
   switch (type) {
-  case ncclInt8:
-  case ncclUint8:
-  case ncclFloat8e4m3:
-  case ncclFloat8e5m2:
-    return 1;
-  case ncclFloat16:
-  case ncclBfloat16:
-    return 2;
-  case ncclInt32:
-  case ncclUint32:
-  case ncclFloat32:
-    return 4;
-  case ncclInt64:
-  case ncclUint64:
-  case ncclFloat64:
-    return 8;
-  default:
-    return -1;
+    case ncclInt8:
+    case ncclUint8:
+    case ncclFloat8e4m3:
+    case ncclFloat8e5m2:
+      return 1;
+    case ncclFloat16:
+    case ncclBfloat16:
+      return 2;
+    case ncclInt32:
+    case ncclUint32:
+    case ncclFloat32:
+      return 4;
+    case ncclInt64:
+    case ncclUint64:
+    case ncclFloat64:
+      return 8;
+    default:
+      return -1;
   }
 }
 
@@ -79,7 +79,7 @@ struct ncclConnFifo {
 #include <stdio.h>
 
 class RingAlgorithm {
-protected:
+ protected:
   int refCount;
   int nRanks;
   int nStepsPerLoop;
@@ -93,7 +93,7 @@ protected:
   void *sendMhandle;
   void *recvMhandle;
   void *srecvMhandle;
-public:
+ public:
   // this ring class is used by proxy thread to retrieve the send and recv buffer, size as well as corresponding
   // mem handle based on the current step of the proxy args. The derived ring algo class is AR, AG, and BC which
   // would be allocated during enqueue stage and copied to proxy side through shared memory. For each copy, we will
@@ -113,12 +113,12 @@ public:
 };
 
 class RingARAlgorithm : public RingAlgorithm {
-private:
+ private:
   int ringIndex;
   int elemSize;
   ssize_t chunkSize;
   int slicePerChunk;
-public:
+ public:
   void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int curLoopStage = (curStep % nStepsPerLoop) / chunkSteps;
@@ -228,12 +228,12 @@ public:
 };
 
 class RingAGAlgorithm : public RingAlgorithm {
-private:
+ private:
   int *ringRanks;
   int elemSize;
   ssize_t sendSize;
   int slicePerChunk;
-public:
+ public:
   void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int chunkStage = (curStep % nStepsPerLoop) / chunkSteps;
@@ -318,11 +318,11 @@ public:
 };
 
 class RingBCAlgorithm : public RingAlgorithm {
-private:
+ private:
   int root;
   int rank;
   int nextRank;
-public:
+ public:
   void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int sliceStage = (curStep % chunkSteps) / sliceSteps;
@@ -372,7 +372,7 @@ public:
     return;
   }
 
-  RingBCAlgorithm(const void* sendbuff, void* recvbuff, int rank, int root, int nRanks, int *ringRanks, int chunkSteps, int sliceSteps, size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, void *sendMhandle, void *recvMhandle, void *srecvMhandle) {
+  RingBCAlgorithm(const void* sendbuff, void* recvbuff, int rank, int root, int /*nRanks*/, int *ringRanks, int chunkSteps, int sliceSteps, size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, void *sendMhandle, void *recvMhandle, void *srecvMhandle) {
     this->root = root;
     this->rank = rank;
     this->nextRank = ringRanks[1];
@@ -407,15 +407,15 @@ struct ncclPatStep {
 };
 
 struct ncclPatPeer {
-    uint64_t step;
-    struct ncclConnInfo* conn;
-    struct ncclConnFifo* connFifo;
-    void* buff;
-    uint64_t *headPtr;
-    uint64_t *tailPtr;
-    uint64_t stepCache;
-    long long int accSize;
-    int connStepSize;
+  uint64_t step;
+  struct ncclConnInfo* conn;
+  struct ncclConnFifo* connFifo;
+  void* buff;
+  uint64_t *headPtr;
+  uint64_t *tailPtr;
+  uint64_t stepCache;
+  long long int accSize;
+  int connStepSize;
 };
 
 #define NCCL_SHMEM_PAT_STEPS 32
@@ -428,7 +428,7 @@ struct ncclPatShmem {
 };
 
 template<typename T>
-class PatRSAlgorithm{
+class PatRSAlgorithm {
   size_t offset;
   size_t end;
   size_t count;
@@ -468,9 +468,9 @@ class PatRSAlgorithm{
   __device__ __host__ int firstBitSet(int i, int max) {
     int ffs =
 #ifdef __CUDA_ARCH__
-      __ffs(i);
+        __ffs(i);
 #else
-      COMPILER_FFS(i);
+        COMPILER_FFS(i);
 #endif
     return ffs ? ffs-1 : max;
   }
@@ -494,9 +494,9 @@ class PatRSAlgorithm{
   __device__ __host__ int nBitsSet(int i) {
     int nbits =
 #ifdef __CUDA_ARCH__
-      __popc(i);
+        __popc(i);
 #else
-      COMPILER_POPCOUNT32(i);
+        COMPILER_POPCOUNT32(i);
 #endif
     return nbits;
   }
@@ -508,9 +508,9 @@ class PatRSAlgorithm{
     return nBitsSet((i ^ (pow2-1)) + 1) == 1 ? 1 : 0;
   }
 
-public:
-   __device__ __host__ PatRSAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end, size_t count, int chunkCount, int rank, int nranks):
-     offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
+ public:
+  __device__ __host__ PatRSAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end, size_t count, int chunkCount, int rank, int nranks):
+    offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
     parallelFactor = maxParallelFactor;
     aggDelta = nrPow2 = (1<<log2Up(nranks));
 
@@ -653,11 +653,11 @@ public:
       if (p == 1) as--;
       if (p == 3) scale *= 2;
       phase =
-        p == 0 ? as == 1 ? (aggFactor > 1 ? 2 : 4) : 1 :
-        p == 1 ? as % 2 == 1 ? 0 : 1 :
-        p == 2 ? 3 :
-        p == 3 ? scale < aggFactor ? 2 : 4 :
-        5;
+          p == 0 ? as == 1 ? (aggFactor > 1 ? 2 : 4) : 1 :
+          p == 1 ? as % 2 == 1 ? 0 : 1 :
+          p == 2 ? 3 :
+          p == 3 ? scale < aggFactor ? 2 : 4 :
+          5;
       if (p == 4) {
         if (offset >= end) {
           ps->last = 2;
@@ -681,7 +681,7 @@ public:
 };
 
 template<typename T>
-class PatAGAlgorithm{
+class PatAGAlgorithm {
   size_t offset;
   size_t end;
   size_t count;
@@ -725,9 +725,9 @@ class PatAGAlgorithm{
   __device__ __host__ int firstBitSet(int i, int max) {
     int ffs =
 #ifdef __CUDA_ARCH__
-      __ffs(i);
+        __ffs(i);
 #else
-      COMPILER_FFS(i);
+        COMPILER_FFS(i);
 #endif
     return ffs ? ffs-1 : max;
   }
@@ -772,9 +772,9 @@ class PatAGAlgorithm{
   }
 
 
-public:
-   __device__ __host__ PatAGAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end, size_t count, int chunkCount, int rank, int nranks):
-     offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
+ public:
+  __device__ __host__ PatAGAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end, size_t count, int chunkCount, int rank, int nranks):
+    offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
     parallelFactor = maxParallelFactor;
     aggDelta = nrPow2 = (1<<log2Up(nranks));
 
@@ -821,7 +821,7 @@ public:
       ps->stepOffset = 0;
       ps->postRecv = (a % postFreq == postFreq-1) || ((a+1)*aggDelta+as >= nranks) ? 1 : 0;
       ps->postSend = 0;
-   } else if (phase == 1) {
+    } else if (phase == 1) {
       int s = a*aggDelta + as;
       if (s >= nranks) skip = 1;
       ps->sendDim = firstBitSet(s, nrPow2);
@@ -875,9 +875,9 @@ public:
       int p = phase;
       if (p == 2) scale /= 2;
       phase =
-        p == 2 ? scale ? 2 : 1 :
-        p == 1 ? as % 2 == 1 ? 0 : 1 :
-        1;
+          p == 2 ? scale ? 2 : 1 :
+          p == 1 ? as % 2 == 1 ? 0 : 1 :
+          1;
       if (p == 0 || (p == 1 && as % 2 == 0)) as = nextAs();
       if (p == 0 && as == aggDelta/2) {
         offset += chunkCount;

--- a/src/include/cpuset.h
+++ b/src/include/cpuset.h
@@ -25,7 +25,7 @@
 #define CPU_SET_N_U32 (CPU_SETSIZE / U32_LEN)
 
 static ncclResult_t ncclStrToCpuset(const char* maskStr, ncclAffinity* set) {
-  uint32_t cpumasks[CPU_SET_N_U32] = {0};
+  uint32_t cpumasks[CPU_SET_N_U32] = {};
 
   // transform the string into an array of 32 bit masks, starting with the highest mask
   int m = CPU_SET_N_U32;

--- a/src/include/cudawrap.h
+++ b/src/include/cudawrap.h
@@ -29,11 +29,11 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
 
 // Check CUDA PFN driver calls
 #define CUCHECK(cmd) do {				      \
-    CUresult err = pfn_##cmd;				      \
-    if( err != CUDA_SUCCESS ) {				      \
+    CUresult _cudaErr = pfn_##cmd;			      \
+    if( _cudaErr != CUDA_SUCCESS ) {			      \
       const char *errStr;				      \
-      (void) pfn_cuGetErrorString(err, &errStr);	      \
-      WARN("Cuda failure %d '%s'", err, errStr);	      \
+      (void) pfn_cuGetErrorString(_cudaErr, &errStr);	      \
+      WARN("Cuda failure %d '%s'", _cudaErr, errStr);	      \
       return ncclUnhandledCudaError;			      \
     }							      \
 } while(false)
@@ -43,11 +43,11 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
 } while(false)
 
 #define CUCHECKGOTO(cmd, res, label) do {		      \
-    CUresult err = pfn_##cmd;				      \
-    if( err != CUDA_SUCCESS ) {				      \
+    CUresult _cudaErr = pfn_##cmd;			      \
+    if( _cudaErr != CUDA_SUCCESS ) {			      \
       const char *errStr;				      \
-      (void) pfn_cuGetErrorString(err, &errStr);	      \
-      WARN("Cuda failure %d '%s'", err, errStr);	      \
+      (void) pfn_cuGetErrorString(_cudaErr, &errStr);	      \
+      WARN("Cuda failure %d '%s'", _cudaErr, errStr);	      \
       res = ncclUnhandledCudaError;			      \
       goto label;					      \
     }							      \
@@ -55,18 +55,18 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
 
 // Report failure but clear error and continue
 #define CUCHECKIGNORE(cmd) do {						\
-    CUresult err = pfn_##cmd;						\
-    if( err != CUDA_SUCCESS ) {						\
+    CUresult _cudaErr = pfn_##cmd;					\
+    if( _cudaErr != CUDA_SUCCESS ) {					\
       const char *errStr;						\
-      (void) pfn_cuGetErrorString(err, &errStr);			\
-      INFO(NCCL_ALL,"%s:%d Cuda failure %d '%s'", __FILE__, __LINE__, err, errStr); \
+      (void) pfn_cuGetErrorString(_cudaErr, &errStr);			\
+      INFO(NCCL_ALL,"%s:%d Cuda failure %d '%s'", __FILE__, __LINE__, _cudaErr, errStr); \
     }									\
 } while(false)
 
 #define CUCHECKTHREAD(cmd, args) do {					\
-    CUresult err = pfn_##cmd;						\
-    if (err != CUDA_SUCCESS) {						\
-      INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, err); \
+    CUresult _cudaErr = pfn_##cmd;					\
+    if (_cudaErr != CUDA_SUCCESS) {					\
+      INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, _cudaErr); \
       args->ret = ncclUnhandledCudaError;				\
       return args;							\
     }									\
@@ -136,7 +136,7 @@ inline ncclResult_t ncclCudaStreamIsLegacyNull(cudaStream_t stream, bool* isLega
   CUDACHECK(cudaStreamGetId(NULL, &nullStreamId));
   CUDACHECK(cudaStreamGetId(cudaStreamLegacy, &legacyNullStreamId));
   *isLegacy = (stream == cudaStreamLegacy) ||
-              ((stream == NULL) && (nullStreamId == legacyNullStreamId));
+      ((stream == NULL) && (nullStreamId == legacyNullStreamId));
 #else
   *isLegacy = (stream == NULL) || (stream == cudaStreamLegacy);
 #endif

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -40,15 +40,15 @@ extern char ncclLastError[];
 
 #define INFO(FLAGS, ...) \
     do{ \
-        int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
+        int _ncclDbgLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
+        if((_ncclDbgLevel >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (_ncclDbgLevel < 0)) \
             ncclDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
     } while(0)
 
 #define TRACE_CALL(...) \
     do { \
-        int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
+        int _ncclDbgLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
+        if((_ncclDbgLevel >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (_ncclDbgLevel < 0)) { \
             ncclDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
@@ -56,8 +56,8 @@ extern char ncclLastError[];
 #ifdef ENABLE_TRACE
 #define TRACE(FLAGS, ...) \
     do { \
-        int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) { \
+        int _ncclDbgLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
+        if ((_ncclDbgLevel >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMask)) || (_ncclDbgLevel < 0)) { \
             ncclDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -26,33 +26,33 @@ extern const char* ncclProtoStr[NCCL_NUM_PROTOCOLS];
 #define NCCL_STEPS 8
 
 #ifdef __CUDA_ARCH__
-  #define NCCL_CUDA_ARCH __CUDA_ARCH__
+#define NCCL_CUDA_ARCH __CUDA_ARCH__
 #else
-  #define NCCL_CUDA_ARCH 0
+#define NCCL_CUDA_ARCH 0
 #endif
 
 #ifdef __CUDA_ARCH_SPECIFIC__
-  #define NCCL_CUDA_ARCH_SPECIFIC __CUDA_ARCH_SPECIFIC__
+#define NCCL_CUDA_ARCH_SPECIFIC __CUDA_ARCH_SPECIFIC__
 #elif defined(__CUDA_ARCH_HAS_FEATURE__)
-  #if __CUDA_ARCH_HAS_FEATURE__(SM90_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 900
-  #elif __CUDA_ARCH_HAS_FEATURE__(SM100_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 1000
-  #elif __CUDA_ARCH_HAS_FEATURE__(SM101_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 1010
-  #elif __CUDA_ARCH_HAS_FEATURE__(SM120_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 1200
-  #else
-    #define NCCL_CUDA_ARCH_SPECIFIC 0
-  #endif
+#if __CUDA_ARCH_HAS_FEATURE__(SM90_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 900
+#elif __CUDA_ARCH_HAS_FEATURE__(SM100_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 1000
+#elif __CUDA_ARCH_HAS_FEATURE__(SM101_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 1010
+#elif __CUDA_ARCH_HAS_FEATURE__(SM120_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 1200
 #else
-  #define NCCL_CUDA_ARCH_SPECIFIC 0
+#define NCCL_CUDA_ARCH_SPECIFIC 0
+#endif
+#else
+#define NCCL_CUDA_ARCH_SPECIFIC 0
 #endif
 
 #ifdef __CUDA_ARCH_FAMILY_SPECIFIC__
-  #define NCCL_CUDA_ARCH_FAMILY_SPECIFIC __CUDA_ARCH_FAMILY_SPECIFIC__
+#define NCCL_CUDA_ARCH_FAMILY_SPECIFIC __CUDA_ARCH_FAMILY_SPECIFIC__
 #else
-  #define NCCL_CUDA_ARCH_FAMILY_SPECIFIC 0
+#define NCCL_CUDA_ARCH_FAMILY_SPECIFIC 0
 #endif
 
 #include "nccl_device/net_device.h"
@@ -256,13 +256,13 @@ struct alignas(16) ncclDevWorkP2p {
 // Compute the subset of the data transfer corresponding to the given part index.
 inline __host__ __device__ void ncclP2pPartBounds(int nParts, int part, size_t bytes, size_t* partBeg, size_t* partEnd) {
   size_t partBytes = alignUp(divUp(bytes, nParts), 4<<10);
-  #if __CUDA_ARCH__
-    *partBeg = min((part+0)*partBytes, bytes);
-    *partEnd = min((part+1)*partBytes, bytes);
-  #else
-    *partBeg = std::min<size_t>((part+0)*partBytes, bytes);
-    *partEnd = std::min<size_t>((part+1)*partBytes, bytes);
-  #endif
+#if __CUDA_ARCH__
+  *partBeg = min((part+0)*partBytes, bytes);
+  *partEnd = min((part+1)*partBytes, bytes);
+#else
+  *partBeg = std::min<size_t>((part+0)*partBytes, bytes);
+  *partEnd = std::min<size_t>((part+1)*partBytes, bytes);
+#endif
 }
 
 // implemented in channel.h
@@ -321,16 +321,16 @@ struct alignas(16) ncclDevWorkBcast {
 
 __host__ __device__ constexpr int ncclProtoGrainSize(int proto) {
   return proto == NCCL_PROTO_LL ? 16 :
-         proto == NCCL_PROTO_LL128 ? WARP_SIZE*NCCL_LL128_SHMEM_ELEMS_PER_THREAD/NCCL_LL128_LINEELEMS*NCCL_LL128_DATAELEMS*sizeof(uint64_t) :
-         proto == NCCL_PROTO_SIMPLE ? 512 :
-         -1;
+      proto == NCCL_PROTO_LL128 ? WARP_SIZE*NCCL_LL128_SHMEM_ELEMS_PER_THREAD/NCCL_LL128_LINEELEMS*NCCL_LL128_DATAELEMS*sizeof(uint64_t) :
+      proto == NCCL_PROTO_SIMPLE ? 512 :
+      -1;
 }
 
 template<typename Int>
 __host__ __device__ inline void ncclCollCbdPart(
     struct ncclDevWorkColl* work, uint32_t channelId, int proto, int eltSize,
     Int* count, Int* partOffset, Int* partCount, Int* chunkCount
-  ) {
+) {
   int eltPerGrain = ncclProtoGrainSize(proto)/eltSize;
   int nMidChannels = work->channelHi - work->channelLo - 1;
   // We can assum that nMidChannels<0 implies countMid==0, which let's us assume
@@ -370,15 +370,15 @@ enum ncclDevWorkType: uint8_t {
 
 constexpr size_t ncclDevWorkSize(enum ncclDevWorkType type) {
   return type == ncclDevWorkTypeP2p ? sizeof(ncclDevWorkP2p) :
-         type == ncclDevWorkTypeColl ? sizeof(ncclDevWorkColl) :
-         type == ncclDevWorkTypeCollReg ? sizeof(ncclDevWorkCollReg) :
-         type == ncclDevWorkTypeBcast ? sizeof(ncclDevWorkBcast): 0;
+      type == ncclDevWorkTypeColl ? sizeof(ncclDevWorkColl) :
+      type == ncclDevWorkTypeCollReg ? sizeof(ncclDevWorkCollReg) :
+      type == ncclDevWorkTypeBcast ? sizeof(ncclDevWorkBcast): 0;
 }
 
 __host__ __device__ constexpr int ncclMaxDevWorkBatchBytes(int cudaArch = NCCL_CUDA_ARCH) {
   return cudaArch < 800 ? (1<<10) :
-    cudaArch < 900 ? (8<<10) :
-    (16<<10);
+      cudaArch < 900 ? (8<<10) :
+      (16<<10);
 }
 
 #define NCCL_MAX_DEV_WORK_BATCH_BYTES 1024
@@ -474,7 +474,7 @@ struct alignas(16) ncclDevKernelArgs {
   // struct ncclDevWorkBatch batches[];
 };
 
-__host__ __device__ constexpr int ncclMaxKernelArgsSize(/*int cudaDriver, */int cudaArch=NCCL_CUDA_ARCH) {
+__host__ __device__ constexpr int ncclMaxKernelArgsSize(/*int cudaDriver, */int /*cudaArch*/=NCCL_CUDA_ARCH) {
   //return (cudaArch < 700 || cudaDriver < 12010) ? 4<<10 : (32<<10)-4;
   return 4<<10;
 }
@@ -526,8 +526,8 @@ __host__ __device__ constexpr int ncclCollUnroll(int cudaArch = NCCL_CUDA_ARCH) 
   return cudaArch >= 800 ? (cudaArch / 100 == 12 ? 6 : 8) : 4;
 }
 
-__host__ __device__ constexpr int ncclNvlsUnrollBytes(int cudaArch = NCCL_CUDA_ARCH) { return 4*16; }
-__host__ __device__ constexpr int ncclNvlsUnrollInsns(int cudaArch = NCCL_CUDA_ARCH) { return 16; }
+__host__ __device__ constexpr int ncclNvlsUnrollBytes(int /*cudaArch*/ = NCCL_CUDA_ARCH) { return 4*16; }
+__host__ __device__ constexpr int ncclNvlsUnrollInsns(int /*cudaArch*/ = NCCL_CUDA_ARCH) { return 16; }
 
 __host__ __device__ constexpr int ncclNvlsUnroll(int bytePerPack, int cudaArch = NCCL_CUDA_ARCH) {
   return ncclCalcUnroll(bytePerPack, ncclNvlsUnrollInsns(cudaArch), ncclNvlsUnrollBytes(cudaArch));
@@ -536,11 +536,11 @@ __host__ __device__ constexpr int ncclNvlsUnroll(int bytePerPack, int cudaArch =
 // The amount of dynamic shmem per warp
 __host__ __device__ constexpr int ncclShmemScratchWarpSize(int cudaArch = NCCL_CUDA_ARCH) {
   return (max_constexpr<int>(
-      /*LL    */0,
-      /*LL128 */(NCCL_LL128_SHMEM_ELEMS_PER_THREAD*WARP_SIZE)*sizeof(uint64_t),
-      /*SIMPLE*/(ncclCollUnroll(cudaArch)*WARP_SIZE + 1)*16,
-      // NVLS needs an extra 16B to read unaligned data.
-      /*NVLS  */WARP_SIZE*(cudaArch >= 900 ? ncclNvlsUnrollBytes(cudaArch) : 0) + 16
+    /*LL    */0,
+    /*LL128 */(NCCL_LL128_SHMEM_ELEMS_PER_THREAD*WARP_SIZE)*sizeof(uint64_t),
+    /*SIMPLE*/(ncclCollUnroll(cudaArch)*WARP_SIZE + 1)*16,
+    // NVLS needs an extra 16B to read unaligned data.
+    /*NVLS  */WARP_SIZE*(cudaArch >= 900 ? ncclNvlsUnrollBytes(cudaArch) : 0) + 16
     ) + 15) & -16; // pad to 16 bytes
 }
 
@@ -565,18 +565,18 @@ ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct 
 // `ncclNvlsSupported()` needs to be in sync with "func_valid" in "src/device/generate.py"
 inline bool ncclNvlsSupported(int devRedOp, int type) {
   switch (type) {
-  case ncclInt32:
-  case ncclUint32:
-  case ncclInt64:
-  case ncclUint64:
-  case ncclFloat16:
-  case ncclBfloat16:
-    return devRedOp == ncclDevSum || devRedOp == ncclDevMinMax;
-  case ncclFloat:
-  case ncclDouble:
-    return devRedOp == ncclDevSum;
-  default:
-    return false;
+    case ncclInt32:
+    case ncclUint32:
+    case ncclInt64:
+    case ncclUint64:
+    case ncclFloat16:
+    case ncclBfloat16:
+      return devRedOp == ncclDevSum || devRedOp == ncclDevMinMax;
+    case ncclFloat:
+    case ncclDouble:
+      return devRedOp == ncclDevSum;
+    default:
+      return false;
   }
 }
 
@@ -592,9 +592,9 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) 
     int nAlgos = 4;
     if (coll == ncclFuncAllGather) {
       int algo1 = algo == NCCL_ALGO_RING ? 0 :
-                  algo == NCCL_ALGO_COLLNET_DIRECT ? 1 :
-                  algo == NCCL_ALGO_NVLS ? 2 :
-                /*algo == NCCL_ALGO_PAT*/ 3;
+          algo == NCCL_ALGO_COLLNET_DIRECT ? 1 :
+          algo == NCCL_ALGO_NVLS ? 2 :
+          /*algo == NCCL_ALGO_PAT*/ 3;
       row += algo1*NCCL_NUM_PROTOCOLS + proto;
       break;
     }
@@ -631,9 +631,9 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) 
     nAlgos = 4;
     if (coll == ncclFuncReduceScatter) {
       int algo1 = algo == NCCL_ALGO_RING ? 0 :
-                  algo == NCCL_ALGO_COLLNET_DIRECT ? 1 :
-                  algo == NCCL_ALGO_NVLS ? 2 :
-                /*algo == NCCL_ALGO_PAT*/ 3;
+          algo == NCCL_ALGO_COLLNET_DIRECT ? 1 :
+          algo == NCCL_ALGO_NVLS ? 2 :
+          /*algo == NCCL_ALGO_PAT*/ 3;
       row += ((devRedOp*NumTypes + type)*nAlgos + algo1)*NCCL_NUM_PROTOCOLS + proto;
       break;
     }

--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -114,13 +114,13 @@ typedef struct gdr_mh_s {
 } gdr_mh_t;
 
 struct gdr_info {
-    uint64_t va;
-    uint64_t mapped_size;
-    uint32_t page_size;
-    uint64_t tm_cycles;
-    uint32_t cycles_per_ms;
-    unsigned mapped:1;
-    unsigned wc_mapping:1;
+  uint64_t va;
+  uint64_t mapped_size;
+  uint32_t page_size;
+  uint64_t tm_cycles;
+  uint32_t cycles_per_ms;
+  unsigned mapped:1;
+  unsigned wc_mapping:1;
 };
 typedef struct gdr_info gdr_info_t;
 
@@ -174,8 +174,7 @@ static gdr_t ncclGdrInit() {
       // Only support GDRAPI 2.1 and later
       if (libMajor < 2 || (libMajor == 2 && libMinor < 1) || drvMajor < 2 || (drvMajor == 2 && drvMinor < 1)) {
         goto error;
-      }
-      else
+      } else
         INFO(NCCL_INIT, "GDRCOPY enabled library %d.%d driver %d.%d", libMajor, libMinor, drvMajor, drvMinor);
     }
   }
@@ -226,7 +225,7 @@ static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** 
   if (devPtr) *devPtr = (T *)(devMem+off+align);
 
   TRACE(NCCL_INIT, "GDRCOPY : allocated devMem %p gdrMap %p offset %lx mh %lx mapSize %zu at %p",
-       md->gdrDevMem, md->gdrMap, md->gdrOffset, md->gdrMh.h, md->gdrMapSize, *ptr);
+      md->gdrDevMem, md->gdrMap, md->gdrOffset, md->gdrMh.h, md->gdrMapSize, *ptr);
 
   return ncclSuccess;
 }
@@ -250,8 +249,8 @@ static ncclResult_t ncclGdrCudaFree(void* gdrHandle, struct ncclMemManager* mana
 
 // Helper: Allocate memory accessible from CPU (either GDR or host memory)
 template <typename T>
-static ncclResult_t allocMemCPUAccessible(T **ptr, T **devPtr, size_t nelem, int host_flags,
-                                          void **gdrHandle, struct ncclMemManager* manager, bool forceHost = false) {
+static ncclResult_t allocMemCPUAccessible(T **ptr, T **devPtr, size_t nelem, int /*host_flags*/,
+    void **gdrHandle, struct ncclMemManager* manager, bool forceHost = false) {
   if (ncclGdrCopy && !forceHost) {
     NCCLCHECK(ncclGdrCudaCalloc(ptr, devPtr, nelem, gdrHandle, manager));
   } else {

--- a/src/include/nccl_device/core.h
+++ b/src/include/nccl_device/core.h
@@ -139,6 +139,16 @@ struct ncclTeamRequirements {
   sizeof(ncclCommProperties_t),                    /* size */            \
   NCCL_API_MAGIC,                                    /* magic */           \
   NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH),  /* version */         \
+  0,                                                 /* rank */            \
+  0,                                                 /* nRanks */          \
+  0,                                                 /* cudaDev */         \
+  0,                                                 /* nvmlDev */         \
+  false,                                             /* deviceApiSupport */\
+  false,                                             /* multimemSupport */ \
+  NCCL_GIN_TYPE_NONE,                                /* ginType */         \
+  0,                                                 /* nLsaTeams */       \
+  false,                                             /* hostRmaSupport */  \
+  NCCL_GIN_TYPE_NONE,                                /* railedGinType */   \
 }
 
 typedef enum {

--- a/src/include/nvtx.h
+++ b/src/include/nvtx.h
@@ -8,7 +8,10 @@
 #ifndef NCCL_NVTX_H_
 #define NCCL_NVTX_H_
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #include "nvtx3/nvtx3.hpp"
+#pragma GCC diagnostic pop
 
 #include "param.h"
 
@@ -50,7 +53,7 @@
 
 extern const nvtxDomainHandle_t ncclNvtxDomainHandle;
 
-struct nccl_domain{static constexpr char const* name{"NCCL"};};
+struct nccl_domain {static constexpr char const* name{"NCCL"};};
 
 extern int64_t ncclParamNvtxDisable();
 
@@ -58,8 +61,7 @@ extern int64_t ncclParamNvtxDisable();
 class payload_schema {
  public:
   explicit payload_schema(const nvtxPayloadSchemaEntry_t entries[], size_t numEntries,
-    const uint64_t schemaId, const size_t size) noexcept
-  {
+      const uint64_t schemaId, const size_t size) noexcept {
     schema_attr.payloadStaticSize = size;
     schema_attr.entries = entries;
     schema_attr.numEntries = numEntries;
@@ -87,8 +89,7 @@ class payload_schema {
     nullptr, 0, 0, 0, 0, nullptr};
 };
 
-class ncclOptionalNvtxScopedRange
-{
+class ncclOptionalNvtxScopedRange {
  public:
   void push(const nvtx3::event_attributes& attr) noexcept {
     // pushed must not be true already, but it's too expensive to check
@@ -164,8 +165,7 @@ class ncclOptionalNvtxPayloadRange {
     }
   }
 
-  void setPayloadData(const uint64_t schemaId) noexcept
-  {
+  void setPayloadData(const uint64_t schemaId) noexcept {
     payloadData = {schemaId, sizeof(PayloadType), &payload};
   }
 

--- a/src/include/nvtx3/nvtxDetail/nvtxExtPayloadHelperInternal.h
+++ b/src/include/nvtx3/nvtxDetail/nvtxExtPayloadHelperInternal.h
@@ -9,6 +9,10 @@
 #ifndef NVTX_EXT_PAYLOAD_HELPER_INTERNAL_H
 #define NVTX_EXT_PAYLOAD_HELPER_INTERNAL_H
 
+#ifdef __GNUC__
+#pragma GCC system_header
+#endif
+
 /* General helper macros */
 #include "nvtxExtHelperMacros.h"
 

--- a/src/include/nvtx_payload_schemas.h
+++ b/src/include/nvtx_payload_schemas.h
@@ -13,8 +13,11 @@
 
 
 #include "nccl.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #include "nvtx3/nvToolsExtPayload.h"
 #include "nvtx3/nvToolsExtPayloadHelper.h"
+#pragma GCC diagnostic pop
 
 /**
  * \brief Define a C struct together with the matching schema entries.
@@ -35,19 +38,19 @@ static constexpr char const* nccl_nvtxMsgSizeStr = "Message size [bytes]";
 static constexpr char const* nccl_nvtxReductionOpStrpStr = "Reduction operation";
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommInitAll, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, commhash, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, ndev, TYPE_INT, "No. of devices")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, commhash, TYPE_UINT64, nccl_nvtxCommStr),
+        (int, ndev, TYPE_INT, "No. of devices")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommInitRank, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+        (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
+        (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+        (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)
+    )
 )
 // The typedef and payload schema for ncclCommInitRank is also used for,
 // ncclCommInitRankConfig, ncclCommInitRankScalable, ncclCommDestroy, ncclCommAbort, and ncclCommRevoke.
@@ -58,138 +61,138 @@ typedef NcclNvtxParamsCommInitRank NcclNvtxParamsCommDestroy;
 typedef NcclNvtxParamsCommInitRank NcclNvtxParamsCommRevoke;
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommSplit, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr),
-    (int, color, TYPE_INT, "Color"),
-    (int, key, TYPE_INT, "Key")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+        (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
+        (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
+        (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+        (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr),
+        (int, color, TYPE_INT, "Color"),
+        (int, key, TYPE_INT, "Key")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommShrink, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr),
-    (int, num_exclude, TYPE_INT, "num_exclude")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+        (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
+        (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+        (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr),
+        (int, num_exclude, TYPE_INT, "num_exclude")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommGrow, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+        (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
+        (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
+        (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+        (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommFinalize, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAllGather, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAlltoAll, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAllReduce, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsBroadcast, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (int, root, TYPE_INT, "Root")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsGather, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (int, root, TYPE_INT, "Root")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsReduce, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root"),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (int, root, TYPE_INT, "Root"),
+        (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsReduceScatter, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr)
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr)
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsScatter, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (int, root, TYPE_INT, "Root")
+    )
 )
 
 // Used in NCCL APIs `ncclSend` and `ncclRecv`.
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsSendRecv, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, peer, TYPE_INT, "Peer rank")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (int, peer, TYPE_INT, "Peer rank")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsPut, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, peer, TYPE_INT, "Peer rank"),
-    (int, ctx, TYPE_INT, "Context ID")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+        (int, peer, TYPE_INT, "Peer rank"),
+        (int, ctx, TYPE_INT, "Context ID")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsSignal, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, peer, TYPE_INT, "Peer rank"),
-    (int, ctx, TYPE_INT, "Context ID")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (int, peer, TYPE_INT, "Peer rank"),
+        (int, ctx, TYPE_INT, "Context ID")
+    )
 )
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsWaitSignal, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, npeers, TYPE_INT, "Number of peers"),
-    (int, ctx, TYPE_INT, "Context ID")
-  )
+    NCCL_NVTX_PAYLOAD_ENTRIES(
+        (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+        (int, npeers, TYPE_INT, "Number of peers"),
+        (int, ctx, TYPE_INT, "Context ID")
+    )
 )
 
 #endif // end include guard

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -46,14 +46,14 @@ struct netIf {
 int parseStringList(const char* string, struct netIf* ifList, int maxList);
 bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact);
 
-static long log2i(long n) {
+static inline long log2i(long n) {
   return log2Down(n);
 }
 
 // Comparator function for qsort/bsearch to compare integers
-static int compareInts(const void *a, const void *b) {
-    int ia = *(const int*)a, ib = *(const int*)b;
-    return (ia > ib) - (ia < ib);
+static inline int compareInts(const void *a, const void *b) {
+  int ia = *(const int*)a, ib = *(const int*)b;
+  return (ia > ib) - (ia < ib);
 }
 
 inline uint64_t clockNano() {
@@ -649,19 +649,19 @@ static inline void ncclIntruAddressMapDestruct(struct ncclIntruAddressMap<Obj, K
 
 // Internal untyped function prototypes
 ncclResult_t ncclIntruAddressMapInsert_untyped(
-  struct ncclIntruAddressMap_untyped* map,
-  int keySize, int keyFieldOffset, int nextFieldOffset,
-  uintptr_t key, void* object);
+    struct ncclIntruAddressMap_untyped* map,
+    int keySize, int keyFieldOffset, int nextFieldOffset,
+    uintptr_t key, void* object);
 
 ncclResult_t ncclIntruAddressMapFind_untyped(
-  struct ncclIntruAddressMap_untyped* map,
-  int keySize, int keyFieldOffset, int nextFieldOffset,
-  uintptr_t key, void** object);
+    struct ncclIntruAddressMap_untyped* map,
+    int keySize, int keyFieldOffset, int nextFieldOffset,
+    uintptr_t key, void** object);
 
 ncclResult_t ncclIntruAddressMapRemove_untyped(
-  struct ncclIntruAddressMap_untyped* map,
-  int keySize, int keyFieldOffset, int nextFieldOffset,
-  uintptr_t key);
+    struct ncclIntruAddressMap_untyped* map,
+    int keySize, int keyFieldOffset, int nextFieldOffset,
+    uintptr_t key);
 
 // Typed template implementations (type-erasing wrappers)
 template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
@@ -674,8 +674,8 @@ static inline ncclResult_t ncclIntruAddressMapInsert(
   int keyFieldOffset = (char*)&(dummy.*keyField) - (char*)&dummy;
   int nextFieldOffset = (char*)&(dummy.*nextField) - (char*)&dummy;
   return ncclIntruAddressMapInsert_untyped(
-    &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
-    reinterpret_cast<uintptr_t>(key), object);
+          &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
+          reinterpret_cast<uintptr_t>(key), object);
 }
 
 template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
@@ -687,8 +687,8 @@ static inline ncclResult_t ncclIntruAddressMapFind(
   int nextFieldOffset = (char*)&(dummy.*nextField) - (char*)&dummy;
   void* tmp;
   ncclResult_t ret = ncclIntruAddressMapFind_untyped(
-    &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
-    reinterpret_cast<uintptr_t>(key), &tmp);
+          &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
+          reinterpret_cast<uintptr_t>(key), &tmp);
   *object = (Obj*)tmp;
   return ret;
 }
@@ -701,8 +701,8 @@ static inline ncclResult_t ncclIntruAddressMapRemove(
   int keyFieldOffset = (char*)&(dummy.*keyField) - (char*)&dummy;
   int nextFieldOffset = (char*)&(dummy.*nextField) - (char*)&dummy;
   return ncclIntruAddressMapRemove_untyped(
-    &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
-    reinterpret_cast<uintptr_t>(key));
+          &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
+          reinterpret_cast<uintptr_t>(key));
 }
 
 inline ncclResult_t ncclThreadJoin(std::thread& thread) {

--- a/src/init.cc
+++ b/src/init.cc
@@ -71,24 +71,24 @@ static bool ctaPolicyIsValid(int ctaPolicy) {
 }
 
 static int ctaPolicyEnv = NCCL_CONFIG_UNDEF_INT;
-static void getEnvCtaPolicyOnce(){
+static void getEnvCtaPolicyOnce() {
   const char* env = ncclGetEnv("NCCL_CTA_POLICY");
   if (env == NULL) return;
 
   // support the old CTA Policy assignment (only valid for 0-9)
   if (isdigit(env[0])) {
     switch (env[0]) {
-    case '0':
-      ctaPolicyEnv = NCCL_CTA_POLICY_DEFAULT;
-      break;
-    case '1':
-      ctaPolicyEnv = NCCL_CTA_POLICY_EFFICIENCY;
-      break;
-    case '2':
-      ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
-      break;
-    default:
-      INFO(NCCL_ENV, "Unknown CTA policy; the legacy usage of NCCL_CTA_POLICY only supports the value of 0 (DEFAULT), 1 (EFFICIENCY), or 2 (ZERO). Using DEFAULT instead.");
+      case '0':
+        ctaPolicyEnv = NCCL_CTA_POLICY_DEFAULT;
+        break;
+      case '1':
+        ctaPolicyEnv = NCCL_CTA_POLICY_EFFICIENCY;
+        break;
+      case '2':
+        ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
+        break;
+      default:
+        INFO(NCCL_ENV, "Unknown CTA policy; the legacy usage of NCCL_CTA_POLICY only supports the value of 0 (DEFAULT), 1 (EFFICIENCY), or 2 (ZERO). Using DEFAULT instead.");
     };
   } else {
     // newer way allows the user to combine the modes
@@ -472,7 +472,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
     comm->memManager = parent->memManager;
     ncclAtomicRefCountIncrement(&comm->memManager->refCount);
     INFO(NCCL_INIT, "MemManager: Shared from parent, refCount=%d",
-         comm->memManager->refCount);
+        comm->memManager->refCount);
   } else {
     // Create new memory manager
     NCCLCHECK(ncclMemManagerInit(comm));
@@ -706,18 +706,18 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
       memcpy(&uuid0, info->fabricInfo.clusterUuid, sizeof(uuid0));
       memcpy(&uuid1, info->fabricInfo.clusterUuid + sizeof(uuid0), sizeof(uuid1));
       if (ncclParamMNNVLCliqueId() == -2) {
-        nvmlPlatformInfo_t platformInfo = { 0 };
+        nvmlPlatformInfo_t platformInfo = {};
         NCCLCHECK(ncclNvmlDeviceGetPlatformInfo(nvmlDev, &platformInfo));
         INFO(NCCL_INIT, "MNNVL rack serial %s slot %d tray %d hostId %d peerType %d moduleId %d",
-             platformInfo.chassisSerialNumber, platformInfo.slotNumber, platformInfo.trayIndex,
-             platformInfo.hostId, platformInfo.peerType, platformInfo.moduleId);
+            platformInfo.chassisSerialNumber, platformInfo.slotNumber, platformInfo.trayIndex,
+            platformInfo.hostId, platformInfo.peerType, platformInfo.moduleId);
         // Use a hash of the Rack serial number to partition the NVLD clique
         info->fabricInfo.cliqueId = getHash(platformInfo.chassisSerialNumber, sizeof(platformInfo.chassisSerialNumber));
       } else if (ncclParamMNNVLCliqueId() != -1) info->fabricInfo.cliqueId = ncclParamMNNVLCliqueId();
       INFO(NCCL_INIT, "MNNVL busId 0x%lx fabric UUID %lx.%lx cliqueId 0x%x state %d healthMask 0x%x",
-           info->busId,
-           uuid0, uuid1,
-           info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
+          info->busId,
+          uuid0, uuid1,
+          info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
     }
   }
 
@@ -821,7 +821,7 @@ static ncclResult_t initNvlDomainInfo(struct ncclComm* comm) {
   comm->nvlDomainInfo.maxRanksPerNvlDomain = comm->maxLocalRanks;
 
   TRACE(NCCL_INIT, "NVLink domains: %d domains, min ranks per domain: %d, max ranks per domain: %d",
-        comm->nNodes, comm->nvlDomainInfo.minRanksPerNvlDomain, comm->nvlDomainInfo.maxRanksPerNvlDomain);
+      comm->nNodes, comm->nvlDomainInfo.minRanksPerNvlDomain, comm->nvlDomainInfo.maxRanksPerNvlDomain);
 
   return ncclSuccess;
 }
@@ -964,7 +964,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   for (int i = 0; i < nranks; i++) {
     if (comm->peerInfo[i].version != comm->peerInfo[rank].version) {
       WARN("Mismatched NCCL version detected : rank %d version %d rank %d version %d",
-           i, comm->peerInfo[i].version, rank, comm->peerInfo[rank].version);
+          i, comm->peerInfo[i].version, rank, comm->peerInfo[rank].version);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -998,7 +998,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       comm->minCompCap = std::min(comm->minCompCap, comm->peerInfo[i].cudaCompCap);
       comm->maxCompCap = std::max(comm->maxCompCap, comm->peerInfo[i].cudaCompCap);
       if ((comm->peerInfo[i].hostHash == comm->peerInfo[rank].hostHash) &&
-          (comm->peerInfo[i].pidHash == comm->peerInfo[rank].pidHash)) {
+        (comm->peerInfo[i].pidHash == comm->peerInfo[rank].pidHash)) {
         // Rank is in same process
         if (intraProcRanks == 0) intraProcRank0 = i;
         if (i == rank) intraProcRank = intraProcRanks;
@@ -1012,7 +1012,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       if (comm->nvlsRegSupport) {
         for (int j = i + 1; j < nranks; j++) {
           if (comm->peerInfo[i].hostHash == comm->peerInfo[j].hostHash &&
-            comm->peerInfo[i].pidHash == comm->peerInfo[j].pidHash) {
+              comm->peerInfo[i].pidHash == comm->peerInfo[j].pidHash) {
             comm->nvlsRegSupport = 0;
             break;
           }
@@ -1240,17 +1240,17 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   NCCLCHECKGOTO(initNvlDomainInfo(comm), ret, fail);
 
   TRACE(NCCL_INIT,"hostHash[%d] %lx localRank %d localRanks %d localRank0 %d",
-        rank, comm->peerInfo[rank].hostHash, comm->localRank, comm->localRanks, comm->localRankToRank[0]);
+      rank, comm->peerInfo[rank].hostHash, comm->localRank, comm->localRanks, comm->localRankToRank[0]);
   if (comm->localRank == -1 || comm->localRankToRank[0] == -1 || comm->localRanks == 0) {
     WARN("Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
-         rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash,
-         comm->localRank, comm->localRanks, comm->localRankToRank[0]);
+        rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash,
+        comm->localRank, comm->localRanks, comm->localRankToRank[0]);
     ret = ncclInternalError;
     goto fail;
   }
 
   INFO(NCCL_INIT, "comm %p rank %d nRanks %d nNodes %d localRanks %d localRank %d MNNVL %d",
-       comm, rank, comm->nRanks, comm->nNodes, comm->localRanks, comm->localRank, comm->MNNVL);
+      comm, rank, comm->nRanks, comm->nNodes, comm->localRanks, comm->localRank, comm->MNNVL);
 
   nChannelsOrig = comm->nChannels;
   NCCLCHECKGOTO(ncclCalloc(&allTopoRanks, comm->nRanks), ret, fail);
@@ -1302,7 +1302,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   for (int c=0; c<comm->nChannels; c++) {
     struct ncclTree* tree = &comm->channels[c].tree;
     snprintf(line+strlen(line), 1023-strlen(line), " [%d] %d/%d/%d->%d->%d",
-        c, tree->down[0], tree->down[1], tree->down[2], rank, tree->up);
+      c, tree->down[0], tree->down[1], tree->down[2], rank, tree->up);
     INFO(NCCL_GRAPH, "Ring %02d : %d -> %d -> %d", c, comm->channels[c].ring.prev, comm->rank, comm->channels[c].ring.next);
   }
   line[1023] = '\0';
@@ -1402,9 +1402,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
     // Then to remote ones when using PXN
     if (ncclPxnDisable(comm) == 0) {
-      int nranks;
-      NCCLCHECKGOTO(ncclTopoGetPxnRanks(comm, &pxnPeers, &nranks), ret, fail);
-      for (int r=0; r<nranks; r++) {
+      int pxnNranks;
+      NCCLCHECKGOTO(ncclTopoGetPxnRanks(comm, &pxnPeers, &pxnNranks), ret, fail);
+      for (int r=0; r<pxnNranks; r++) {
         NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_NET, 1, pxnPeers[r], &proxyConn), ret, fail);
         NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int), NULL, 0), ret, fail);
       }
@@ -1473,11 +1473,11 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
   comm->globalRmaProxySupport = globalRmaPluginSupport && globalCrossNicSupport && !globalNicFused && globalCuMemGdrSupport;
   comm->symmetricSupport = comm->isAllCudaP2p && ncclParamWinEnable() && ncclCuMemEnable() &&
-    (comm->globalGinSupport != NCCL_GIN_CONNECTION_NONE || (ncclTeamLsa(comm).nRanks == comm->nRanks));
+      (comm->globalGinSupport != NCCL_GIN_CONNECTION_NONE || (ncclTeamLsa(comm).nRanks == comm->nRanks));
   comm->hostRmaSupport = comm->symmetricSupport && ((ncclTeamLsa(comm).nRanks == comm->nRanks) || comm->globalRmaProxySupport);
   if (!comm->symmetricSupport) {
     INFO(NCCL_INIT, "Symmetric memory is not supported. cuMemEnable %d, "
-      "globalGinSupport %d, globalNicFused %d cuMemGdrSupport %d", ncclCuMemEnable(), comm->globalGinSupport, globalNicFused, globalCuMemGdrSupport);
+                    "globalGinSupport %d, globalNicFused %d cuMemGdrSupport %d", ncclCuMemEnable(), comm->globalGinSupport, globalNicFused, globalCuMemGdrSupport);
   }
   comm->devrState.bigSize = 0;
 
@@ -1564,7 +1564,7 @@ typedef struct{
   int key;
   int color;
 } commSplitInfo;
-static ncclResult_t commGetSplitInfo(struct ncclComm* comm, struct ncclComm* parent, int color, int key, int* nRanksRet, int* myRankRet, int* parentRanksRet) {
+static ncclResult_t commGetSplitInfo(struct ncclComm* /*comm*/, struct ncclComm* parent, int color, int key, int* nRanksRet, int* myRankRet, int* parentRanksRet) {
   int nRanks = 0, myRank = 0;
   ncclResult_t ret = ncclSuccess;
 
@@ -1632,7 +1632,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   int cudaArch;
   int maxSharedMem = 0;
   double sum_timers = 0;
-  uint64_t timers[TIMERS_INIT_COUNT] = {0};
+  uint64_t timers[TIMERS_INIT_COUNT] = {};
   unsigned long long commIdHash;
 
   timers[TIMER_INIT_TOTAL] = clockNano();
@@ -1673,7 +1673,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     timers[TIMER_INIT_ALLOC] = clockNano() - timers[TIMER_INIT_ALLOC];
     comm->isGrow = false;
     INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p childCount %d color %d key %d- Init START", job->funcName,
-         comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->childCount, job->color, job->key);
+        comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->childCount, job->color, job->key);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano();
     NCCLCHECKGOTO(bootstrapSplit(comm->commHash, comm, job->parent, job->color, job->key, parentRanks), res, fail);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
@@ -1686,7 +1686,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       uint64_t baseMagic = growHandle ? growHandle->magic : hashCombine(job->parent->magic, job->parent->childCount);
       comm->commHash = commIdHash = hashCombine(baseMagic, job->nranks);
       INFO(NCCL_INIT, "Rank %d: Generated commHash 0x%lx from baseMagic 0x%lx and newNRanks %d",
-           job->myrank, comm->commHash, baseMagic, job->nranks);
+          job->myrank, comm->commHash, baseMagic, job->nranks);
     } else {
       // obtain a unique hash using the first commId
       comm->commHash = commIdHash = getHash(job->commId->internal, NCCL_UNIQUE_ID_BYTES);
@@ -1697,7 +1697,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
     comm->isGrow = job->isGrow;
     INFO(NCCL_INIT, "[Rank %d] %s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init START",
-         job->myrank, job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
+        job->myrank, job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano();
     NCCLCHECKGOTO(bootstrapInit(job->nId, (struct ncclBootstrapHandle*)job->commId, comm, job->parent), res, fail);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
@@ -1720,23 +1720,23 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       TRACE_CALL("ncclCommSplit(%p, %d, %d, %p, %d, %d)", job->parent, job->color, job->key, comm, comm->rank, comm->nRanks);
     }
     INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p childCount %d color %d key %d - Init COMPLETE", job->funcName,
-         comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->childCount, job->color, job->key);
+        comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->childCount, job->color, job->key);
   } else {
     // the name for the replay tool is ncclCommInitRank for all the variations
     TRACE_CALL("ncclCommInitRank(%p, %d, 0x%llx, %d, %d)", comm, comm->nRanks, commIdHash, comm->rank, comm->cudaDev);
     INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE", job->funcName,
-         comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
+        comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
   }
   sum_timers = 0.0;
   for (int it = 1; it < TIMERS_INIT_COUNT; ++it)
     sum_timers += (timers[it] / 1e9);
   INFO(NCCL_INIT | NCCL_PROFILE,
-       "Init timings - %s: rank %d nranks %d total %.2f (kernels %.2f, alloc %.2f, bootstrap %.2f, allgathers %.2f, topo %.2f, graphs %.2f, "
-       "connections %.2f, rest %.2f)",
-       job->funcName, comm->rank, comm->nRanks,
-       timers[TIMER_INIT_TOTAL] / 1e9, timers[TIMER_INIT_KERNELS] / 1e9, timers[TIMER_INIT_ALLOC] / 1e9,
-       timers[TIMER_INIT_BOOTSTRAP] / 1e9, timers[TIMER_INIT_ALLGATHER] / 1e9, timers[TIMER_INIT_TOPO] / 1e9,
-       timers[TIMER_INIT_GRAPHS] / 1e9, timers[TIMER_INIT_CONNECT] / 1e9, timers[TIMER_INIT_TOTAL] / 1e9 - sum_timers);
+      "Init timings - %s: rank %d nranks %d total %.2f (kernels %.2f, alloc %.2f, bootstrap %.2f, allgathers %.2f, topo %.2f, graphs %.2f, "
+      "connections %.2f, rest %.2f)",
+      job->funcName, comm->rank, comm->nRanks,
+      timers[TIMER_INIT_TOTAL] / 1e9, timers[TIMER_INIT_KERNELS] / 1e9, timers[TIMER_INIT_ALLOC] / 1e9,
+      timers[TIMER_INIT_BOOTSTRAP] / 1e9, timers[TIMER_INIT_ALLGATHER] / 1e9, timers[TIMER_INIT_TOPO] / 1e9,
+      timers[TIMER_INIT_GRAPHS] / 1e9, timers[TIMER_INIT_CONNECT] / 1e9, timers[TIMER_INIT_TOTAL] / 1e9 - sum_timers);
 exit:
   if (job->newcomm) {
     /* assign it to user pointer. */
@@ -1946,7 +1946,7 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
 
   // If POLICY_ZERO and POLICY_EFFICIENCY are set in CTAPolicy, unset POLICY_EFFICIENCY.
   if ((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) &&
-      (comm->config.CTAPolicy & NCCL_CTA_POLICY_EFFICIENCY)) {
+    (comm->config.CTAPolicy & NCCL_CTA_POLICY_EFFICIENCY)) {
     WARN("Both NCCL_CTA_POLICY_ZERO and NCCL_CTA_POLICY_EFFICIENCY are set in CTAPolicy (%d). Unsetting POLICY_EFFICIENCY.", comm->config.CTAPolicy);
     comm->config.CTAPolicy &= ~NCCL_CTA_POLICY_EFFICIENCY;
   }
@@ -2045,7 +2045,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   if ((internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT &&
     internalConfigPtr->minCTAs <= 0) ||
     (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT &&
-      internalConfigPtr->maxCTAs <= 0) ||
+        internalConfigPtr->maxCTAs <= 0) ||
     (internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
     WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs, internalConfigPtr->maxCTAs);
     ret = ncclInvalidArgument;
@@ -2122,7 +2122,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   NCCL_CONFIG_DEFAULT(internalConfigPtr, shrinkShare, NCCL_CONFIG_UNDEF_INT, 0, "shrinkShare", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlsCTAs, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "nvlsCTAs", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nChannelsPerNetPeer, NCCL_CONFIG_UNDEF_INT,
-                      NCCL_CONFIG_UNDEF_INT, "nChannelsPerNetPeer", "%d");
+      NCCL_CONFIG_UNDEF_INT, "nChannelsPerNetPeer", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlinkCentricSched, NCCL_CONFIG_UNDEF_INT, 0, "nvlinkCentricSched", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, graphUsageMode, NCCL_CONFIG_UNDEF_INT, 2, "graphUsageMode", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, numRmaCtx, NCCL_CONFIG_UNDEF_INT, 1, "numRmaCtx", "%d");
@@ -2252,7 +2252,7 @@ ncclResult_t ncclCommInitRank(ncclComm_t* newcomm, int nranks, ncclUniqueId comm
   NCCLCHECK(ncclCommInitRankDev(newcomm, nranks, 1, &commId, myrank, cudaDev, &config, __func__));
 
   NVTX3_RANGE_ADD_PAYLOAD(CommInitRank, NcclNvtxParamsCommInitRankSchema,
-    NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+      NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
 
   return ncclSuccess;
 }
@@ -2313,7 +2313,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   NCCLCHECKGOTO(ncclGroupEndInternal(), ret, fail);
 
   NVTX3_RANGE_ADD_PAYLOAD(CommInitAll, NcclNvtxParamsCommInitAllSchema,
-    NVTX3_PAYLOAD(comms[0]->commHash, ndev));
+      NVTX3_PAYLOAD(comms[0]->commHash, ndev));
 
 exit:
   (void)cudaSetDevice(oldDev);
@@ -2362,7 +2362,7 @@ exit:
       (void) ncclCommGetAsyncError(*newcomm, &ret);
     }
     NVTX3_RANGE_ADD_PAYLOAD(CommInitRankConfig, NcclNvtxParamsCommInitRankSchema,
-      NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+        NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
   }
   return ret;
 fail:
@@ -2398,7 +2398,7 @@ exit:
       (void) ncclCommGetAsyncError(*newcomm, &ret);
     }
     NVTX3_RANGE_ADD_PAYLOAD(CommInitRankScalable, NcclNvtxParamsCommInitRankSchema,
-      NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+        NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
   }
   return ret;
 fail:
@@ -2490,7 +2490,7 @@ exit:
       NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
     }
     NVTX3_RANGE_ADD_PAYLOAD(CommFinalize, NcclNvtxParamsCommFinalizeSchema,
-      NVTX3_PAYLOAD(comm->commHash));
+        NVTX3_PAYLOAD(comm->commHash));
   }
   return ret;
 fail:
@@ -2524,10 +2524,10 @@ static ncclResult_t commReclaim(struct ncclAsyncJob* job_) {
         nextIntraComm = nextIntraComm->intraNext;
 
         if (curIntraComm->finalizeCalled == false) {
-          struct ncclCommFinalizeAsyncJob job;
-          job.comm = curIntraComm;
+          struct ncclCommFinalizeAsyncJob finalizeJob;
+          finalizeJob.comm = curIntraComm;
           /* every comm aborts, commDestroySync should not be blocked. */
-          if ((ret = commDestroySync((struct ncclAsyncJob*) &job)) != ncclSuccess)
+          if ((ret = commDestroySync((struct ncclAsyncJob*) &finalizeJob)) != ncclSuccess)
             WARN("commReclaim: comm %p (rank = %d) in commDestroySync, error %d", curIntraComm, curRank, ret);
         }
       }
@@ -2563,7 +2563,7 @@ ncclResult_t ncclCommDestroy(ncclComm_t comm) {
   ncclResult_t res = ncclSuccess;
 
   NVTX3_FUNC_WITH_PARAMS(CommDestroy, NcclNvtxParamsCommInitRank,
-    NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
+      NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
 
   TRACE(NCCL_INIT, "comm %p rank %d nRanks %d cudaDev %d busId %lx", comm, rank, nranks, cudaDev, comm->busId);
   NCCLCHECK(ncclGroupStartInternal());
@@ -2669,7 +2669,7 @@ ncclResult_t ncclCommRevoke(ncclComm_t comm, int revokeFlags) {
   ncclResult_t res = ncclSuccess;
 
   NVTX3_RANGE_ADD_PAYLOAD(CommRevoke, NcclNvtxParamsCommInitRankSchema,
-    NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
+      NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
   TRACE(NCCL_INIT, "comm %p rank %d nRanks %d cudaDev %d busId %lx", comm, rank, nranks, cudaDev, comm->busId);
 
   NEW_NOTHROW_GOTO(job, ncclCommRevokeAsyncJob, res, fail);
@@ -2684,7 +2684,7 @@ exit:
       NCCLCHECK(ncclCommGetAsyncError(comm, &res));
     }
     NVTX3_RANGE_ADD_PAYLOAD(CommRevoke, NcclNvtxParamsCommInitRankSchema,
-      NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
+        NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
   }
   INFO(NCCL_INIT, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Revoke COMPLETE, result %d", comm, rank, nranks, cudaDev, comm->busId, res);
   return res;
@@ -2718,7 +2718,7 @@ ncclResult_t ncclCommAbort(ncclComm_t comm) {
   ncclResult_t res = ncclSuccess;
 
   NVTX3_RANGE_ADD_PAYLOAD(CommAbort, NcclNvtxParamsCommInitRankSchema,
-    NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
+      NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
 
   TRACE(NCCL_INIT, "comm %p rank %d nRanks %d cudaDev %d busId %lx", comm, rank, nranks, cudaDev, comm->busId);
 
@@ -2742,7 +2742,7 @@ static void childCommCleanupJob(void* job) {
 
 // initializing a child communicator (for both split and shrink)
 static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, bool isShrink, int flags, int color, int key, int* excludeRanksList, int excludeRanksCount,
-                                          ncclConfig_t* config, const char* caller) {
+    ncclConfig_t* config, const char* caller) {
   struct ncclCommInitRankAsyncJob *job = NULL;
   struct ncclComm* childComm = NCCL_COMM_NULL;
   ncclResult_t res = ncclSuccess;
@@ -2916,7 +2916,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
       // verify the magic is the same as the one computed by the root
       if (recvHandle.magic != hashCombine(comm->magic, comm->childCount)) {
         WARN("ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx",
-          recvHandle.magic, hashCombine(comm->magic, comm->childCount));
+            recvHandle.magic, hashCombine(comm->magic, comm->childCount));
         res = ncclInvalidArgument;
         goto exit;
       }
@@ -2952,7 +2952,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   }
 
   INFO(NCCL_INIT, "ncclCommGrow: %s rank creating new communicator with %d total ranks",
-       isExistingRank ? "existing" : "new", nRanks);
+      isExistingRank ? "existing" : "new", nRanks);
 
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
@@ -3010,7 +3010,7 @@ exit:
   if (*newcomm) {
     uint64_t parentHash = isExistingRank ? comm->commHash : 0;
     NVTX3_RANGE_ADD_PAYLOAD(CommGrow, NcclNvtxParamsCommGrowSchema,
-      NVTX3_PAYLOAD((*newcomm)->commHash, parentHash, nRanks, (*newcomm)->rank, (*newcomm)->cudaDev));
+        NVTX3_PAYLOAD((*newcomm)->commHash, parentHash, nRanks, (*newcomm)->rank, (*newcomm)->cudaDev));
   }
   (void)ncclGroupErrCheck(res);
   NCCLCHECK(ncclGroupEndInternal());
@@ -3075,7 +3075,7 @@ const char* ncclGetErrorString(ncclResult_t code) {
  * comm is currently unused and can be set to NULL
  */
 NCCL_API(const char*, ncclGetLastError, const ncclComm_t comm);
-const char* ncclGetLastError(ncclComm_t comm) {
+const char* ncclGetLastError(ncclComm_t /*comm*/) {
   return ncclLastError;
 }
 

--- a/src/misc/ipcsocket.cc
+++ b/src/misc/ipcsocket.cc
@@ -105,7 +105,7 @@ ncclResult_t ncclIpcSocketClose(ncclIpcSocket *handle) {
 }
 
 ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, int *recvFd) {
-  struct msghdr msg = {0, 0, 0, 0, 0, 0, 0};
+  struct msghdr msg = {};
   struct iovec iov[1];
 
   // Union to guarantee alignment requirements for control array
@@ -144,7 +144,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) && (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {
       if ((cmptr->cmsg_level != SOL_SOCKET) || (cmptr->cmsg_type != SCM_RIGHTS)) {
         WARN("UDS: Receiving data over socket failed");
-      return ncclSystemError;
+        return ncclSystemError;
       }
 
       memmove(recvFd, CMSG_DATA(cmptr), sizeof(*recvFd));
@@ -163,7 +163,7 @@ ncclResult_t ncclIpcSocketRecvFd(ncclIpcSocket *handle, int *recvFd) {
 }
 
 ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, const int sendFd, int rank, uint64_t hash) {
-  struct msghdr msg = {0, 0, 0, 0, 0, 0, 0};
+  struct msghdr msg = {};
   struct iovec iov[1];
   char temp[NCCL_IPC_SOCKNAME_LEN];
 

--- a/src/nccl_device/gin_barrier.cc
+++ b/src/nccl_device/gin_barrier.cc
@@ -10,9 +10,9 @@
 
 NCCL_API(ncclResult_t, ncclGinBarrierCreateRequirement, ncclComm_t comm, ncclTeam_t team, int nBarriers, ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
 ncclResult_t ncclGinBarrierCreateRequirement(
-    ncclComm_t comm, ncclTeam_t team, int nBarriers,
+    ncclComm_t /*comm*/, ncclTeam_t team, int nBarriers,
     ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq
-  ) {
+) {
   memset(outReq, 0, sizeof(*outReq));
   outReq->ginSignalCount = nBarriers * team.nRanks;
   outReq->outGinSignalStart = &outHandle->signal0;

--- a/src/plugin/env/env_v1.cc
+++ b/src/plugin/env/env_v1.cc
@@ -21,7 +21,7 @@ ncclEnv_t* getNcclEnv_v1(void* lib) {
   return nullptr;
 }
 
-static ncclResult_t ncclEnvInit(uint8_t ncclMajor, uint8_t ncclMinor, uint8_t ncclPatch, const char* suffix) {
+static ncclResult_t ncclEnvInit(uint8_t /*ncclMajor*/, uint8_t /*ncclMinor*/, uint8_t /*ncclPatch*/, const char* /*suffix*/) {
   return ncclSuccess;
 }
 

--- a/src/plugin/gin.cc
+++ b/src/plugin/gin.cc
@@ -48,7 +48,7 @@ typedef struct ginPluginLib {
 } ginPluginLib_t;
 
 static int pluginCount = 0;
-static ginPluginLib_t ginPluginLibs[NCCL_GIN_MAX_PLUGINS] = { 0 };
+static ginPluginLib_t ginPluginLibs[NCCL_GIN_MAX_PLUGINS] = {};
 static std::mutex ginPluginMutex;
 static std::once_flag initPluginLibsOnceFlag;
 
@@ -82,7 +82,7 @@ static ncclResult_t ncclGinPluginLoad(ginPluginLib_t* pluginLib) {
     pluginLib->ncclGinPluginState = ncclGinPluginStateInitReady;
 
   INFO(NCCL_INIT|NCCL_NET, "Successfully loaded external gin plugin %s",
-       (ncclPluginLibPaths[ncclPluginTypeGin] ? ncclPluginLibPaths[ncclPluginTypeGin] : pluginLib->name));
+      (ncclPluginLibPaths[ncclPluginTypeGin] ? ncclPluginLibPaths[ncclPluginTypeGin] : pluginLib->name));
 exit:
   return ncclSuccess;
 fail:
@@ -99,7 +99,7 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
   // Init must be called for each new comm to set the right context
   if (pluginLib->ncclGinPluginState == ncclGinPluginStateInitReady && pluginLib->ncclGin) {
     if (pluginLib->ncclGin->init(&comm->ginContext, comm->commHash, ncclDebugLog) != ncclSuccess ||
-        pluginLib->ncclGin->devices(&ndev) != ncclSuccess || ndev <= 0) {
+      pluginLib->ncclGin->devices(&ndev) != ncclSuccess || ndev <= 0) {
       pluginLib->ncclGinPluginState = ncclGinPluginStateDisabled;
     } else {
       pluginLib->ginPhysDevs = ndev;
@@ -110,7 +110,7 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
   // Initialize RMA plugin
   if (pluginLib->ncclRmaPluginState == ncclGinPluginStateInitReady && pluginLib->ncclRma) {
     if (pluginLib->ncclRma->init(&comm->ginContext, comm->commHash, ncclDebugLog) != ncclSuccess ||
-        pluginLib->ncclRma->devices(&ndev) != ncclSuccess || ndev <= 0) {
+      pluginLib->ncclRma->devices(&ndev) != ncclSuccess || ndev <= 0) {
       pluginLib->ncclRmaPluginState = ncclGinPluginStateDisabled;
     } else {
       pluginLib->ncclRmaPluginState = ncclGinPluginStateEnabled;
@@ -141,7 +141,7 @@ static ncclResult_t ncclGinPluginAssignToComm(struct ncclComm* comm, int pluginI
 static ncclResult_t ncclGinPluginDisableOtherExternal(int pluginIndex) {
   // Only if an external plugin is enabled, disable other external plugins
   if (pluginIndex >= (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS)) return ncclSuccess;
-  char names[MAX_STR_LEN*(NCCL_GIN_MAX_PLUGINS - NCCL_GIN_NUM_INTERNAL_PLUGINS)] = { 0 };
+  char names[MAX_STR_LEN*(NCCL_GIN_MAX_PLUGINS - NCCL_GIN_NUM_INTERNAL_PLUGINS)] = {};
   for (int i = 0; i < (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS); i++) {
     if (i != pluginIndex) {
       // Append all disabled plugin names to a string
@@ -263,9 +263,9 @@ ncclResult_t ncclGinFinalize(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinGetDevCount(int ginPluginIndex, int* nPhysDevs, int* nVirtDevs) {
+ncclResult_t ncclGinGetDevCount(int ginPluginIndex, int* nPhysDevs, int* /*nVirtDevs*/) {
   if (ginPluginLibs[ginPluginIndex].ncclGinPluginState != ncclGinPluginStateEnabled ||
-     ginPluginLibs[ginPluginIndex].ginPhysDevs == 0) goto fail;
+      ginPluginLibs[ginPluginIndex].ginPhysDevs == 0) goto fail;
   // lock not needed as it's called within a lock already in ncclTopoGetSystem
   *nPhysDevs = ginPluginLibs[ginPluginIndex].ginPhysDevs;
   return ncclSuccess;

--- a/src/plugin/net.cc
+++ b/src/plugin/net.cc
@@ -66,7 +66,7 @@ typedef struct netPluginLib {
 } netPluginLib_t;
 
 static int pluginCount = 0;
-static netPluginLib_t netPluginLibs[NCCL_NET_MAX_PLUGINS] = { 0 };
+static netPluginLib_t netPluginLibs[NCCL_NET_MAX_PLUGINS] = {};
 static std::mutex netPluginMutex;
 static std::once_flag initPluginLibsOnceFlag;
 
@@ -97,7 +97,7 @@ static ncclResult_t ncclNetPluginLoad(netPluginLib_t* pluginLib) {
   // if we fail to find a net, exit
   if (pluginLib->ncclNet == nullptr) {
     INFO(NCCL_INIT|NCCL_NET, "External network plugin %s is unsupported",
-         (ncclPluginLibPaths[ncclPluginTypeNet] ? ncclPluginLibPaths[ncclPluginTypeNet] : pluginLib->name));
+        (ncclPluginLibPaths[ncclPluginTypeNet] ? ncclPluginLibPaths[ncclPluginTypeNet] : pluginLib->name));
     goto fail;
   }
 
@@ -115,7 +115,7 @@ static ncclResult_t ncclNetPluginLoad(netPluginLib_t* pluginLib) {
     pluginLib->ncclCollNetPluginState = ncclNetPluginStateInitReady;
 
   INFO(NCCL_INIT|NCCL_NET, "Successfully loaded external network plugin %s",
-       (ncclPluginLibPaths[ncclPluginTypeNet] ? ncclPluginLibPaths[ncclPluginTypeNet] : pluginLib->name));
+      (ncclPluginLibPaths[ncclPluginTypeNet] ? ncclPluginLibPaths[ncclPluginTypeNet] : pluginLib->name));
 exit:
   return ncclSuccess;
 fail:
@@ -128,26 +128,26 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclNetCheckDeviceVersion(struct ncclComm* comm, ncclNet_t* net, int dev) {
+ncclResult_t ncclNetCheckDeviceVersion(struct ncclComm* /*comm*/, ncclNet_t* net, int dev) {
   ncclNetProperties_t props;
 
   NCCLCHECK(net->getProperties(dev, &props));
   ncclNetDeviceType type = props.netDeviceType;
   if (type) switch (type) {
-    case NCCL_NET_DEVICE_UNPACK:
-      if (props.netDeviceVersion == NCCL_NET_DEVICE_UNPACK_VERSION) {
-        INFO(NCCL_INIT, "Using NCCL_NET_DEVICE_UNPACK net plugin version %d",
-          props.netDeviceVersion);
-        return ncclSuccess;
-      } else {
-        WARN("NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
-          props.netDeviceVersion, NCCL_NET_DEVICE_UNPACK_VERSION);
+      case NCCL_NET_DEVICE_UNPACK:
+        if (props.netDeviceVersion == NCCL_NET_DEVICE_UNPACK_VERSION) {
+          INFO(NCCL_INIT, "Using NCCL_NET_DEVICE_UNPACK net plugin version %d",
+              props.netDeviceVersion);
+          return ncclSuccess;
+        } else {
+          WARN("NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
+              props.netDeviceVersion, NCCL_NET_DEVICE_UNPACK_VERSION);
+          return ncclInternalError;
+        }
+      default:
+        WARN("Unknown device code index %d", type);
         return ncclInternalError;
-      }
-    default:
-      WARN("Unknown device code index %d", type);
-      return ncclInternalError;
-  }
+    }
 
   return ncclSuccess;
 }
@@ -219,7 +219,7 @@ static ncclResult_t ncclNetPluginAssignToComm(struct ncclComm* comm, int pluginI
 static ncclResult_t ncclNetPluginDisableOtherExternal(int pluginIndex) {
   // Only if an external plugin is enabled, disable other external plugins
   if (pluginIndex >= (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) return ncclSuccess;
-  char names[MAX_STR_LEN*(NCCL_NET_MAX_PLUGINS - NCCL_NET_NUM_INTERNAL_PLUGINS)] = { 0 };
+  char names[MAX_STR_LEN*(NCCL_NET_MAX_PLUGINS - NCCL_NET_NUM_INTERNAL_PLUGINS)] = {};
   for (int i = 0; i < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS); i++) {
     if (i != pluginIndex) {
       // Append all disabled plugin names to a string
@@ -304,7 +304,7 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
       NCCLCHECK(ncclNetPluginLoad(&netPluginLibs[pluginIndex]));
     }
     if ((netPluginLibs[pluginIndex].ncclNetPluginState >= ncclNetPluginStateInitReady)
-        && (!comm->config.netName || (strcasecmp(comm->config.netName, netPluginLibs[pluginIndex].ncclNet->name) == 0))) {
+      && (!comm->config.netName || (strcasecmp(comm->config.netName, netPluginLibs[pluginIndex].ncclNet->name) == 0))) {
       // plugin init must be done by all comms to setup the context, therefore we use ">="
       NCCLCHECK(ncclNetPluginInit(comm, &netPluginLibs[pluginIndex]));
       if (netPluginLibs[pluginIndex].ncclNetPluginState == ncclNetPluginStateEnabled) {
@@ -315,8 +315,7 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
           ncclNetPluginDisableOtherExternal(pluginIndex);
           ncclNetPluginInitialized = true;
           break;
-        }
-        else {
+        } else {
           ncclNetPluginFinalize(comm, pluginIndex);
         }
       }
@@ -353,7 +352,7 @@ ncclResult_t ncclNetFinalize(struct ncclComm* comm) {
 
 ncclResult_t ncclNetGetDevCount(int netPluginIndex, int* nPhysDevs, int* nVirtDevs) {
   if (netPluginLibs[netPluginIndex].ncclNetPluginState != ncclNetPluginStateEnabled ||
-     netPluginLibs[netPluginIndex].netPhysDevs == NCCL_UNDEF_DEV_COUNT) goto fail;
+      netPluginLibs[netPluginIndex].netPhysDevs == NCCL_UNDEF_DEV_COUNT) goto fail;
   // lock not needed as it's called within a lock already in ncclTopoGetSystem
   *nPhysDevs = netPluginLibs[netPluginIndex].netPhysDevs;
   *nVirtDevs = netPluginLibs[netPluginIndex].netVirtDevs;
@@ -365,7 +364,7 @@ fail:
 
 ncclResult_t ncclCollNetGetDevCount(int netPluginIndex, int* nPhysDevs, int* nVirtDevs) {
   if (netPluginLibs[netPluginIndex].ncclCollNetPluginState != ncclNetPluginStateEnabled ||
-     netPluginLibs[netPluginIndex].collNetPhysDevs == NCCL_UNDEF_DEV_COUNT) goto fail;
+      netPluginLibs[netPluginIndex].collNetPhysDevs == NCCL_UNDEF_DEV_COUNT) goto fail;
   // lock not needed as it's called within a lock already in ncclTopoGetSystem
   *nPhysDevs = netPluginLibs[netPluginIndex].collNetPhysDevs;
   *nVirtDevs = netPluginLibs[netPluginIndex].collNetVirtDevs;
@@ -410,8 +409,9 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
   }
 #endif
   static int gdrSupportMatrix[32] = {
-	  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+  };
   if (gdrSupportMatrix[comm->cudaDev] == -1) {
     int netDevs;
     NCCLCHECK(comm->ncclNet->devices(&netDevs));
@@ -422,47 +422,47 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
       NCCLCHECK(comm->ncclNet->getProperties(dev, &props));
       if ((props.ptrSupport & NCCL_PTR_CUDA) == 0) continue;
 
-    // Allocate memory on the GPU and try to register it on the NIC.
-    void *lComm = NULL, *sComm = NULL, *rComm = NULL;
-    ncclNetHandle_t handle;
-    char* gpuPtr = NULL;
-    void* mHandle = NULL;
-    ncclResult_t ret;
-    NCCLCHECKGOTONOWARN(comm->ncclNet->listen(comm->netContext, dev, &handle, &lComm), ret, cleanup1, NCCL_NET);
+      // Allocate memory on the GPU and try to register it on the NIC.
+      void *lComm = NULL, *sComm = NULL, *rComm = NULL;
+      ncclNetHandle_t handle;
+      char* gpuPtr = NULL;
+      void* mHandle = NULL;
+      ncclResult_t ret;
+      NCCLCHECKGOTONOWARN(comm->ncclNet->listen(comm->netContext, dev, &handle, &lComm), ret, cleanup1, NCCL_NET);
 
-    bool connected;
-    connected = false;
-    while (!connected) {
+      bool connected;
+      connected = false;
+      while (!connected) {
 
-      // If we're aborting now, skip to cleanup
-      if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
-        goto cleanup2;
+        // If we're aborting now, skip to cleanup
+        if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
+          goto cleanup2;
+        }
+
+        if (sComm == NULL)
+          NCCLCHECKGOTONOWARN(comm->ncclNet->connect(comm->netContext, dev, &handle, &sComm, NULL), ret, cleanup2, NCCL_NET);
+
+        if (rComm == NULL)
+          NCCLCHECKGOTONOWARN(comm->ncclNet->accept(lComm, &rComm, NULL), ret, cleanup2, NCCL_NET);
+
+        connected = (rComm != NULL) && (sComm != NULL);
       }
 
-      if (sComm == NULL)
-        NCCLCHECKGOTONOWARN(comm->ncclNet->connect(comm->netContext, dev, &handle, &sComm, NULL), ret, cleanup2, NCCL_NET);
-
-      if (rComm == NULL)
-        NCCLCHECKGOTONOWARN(comm->ncclNet->accept(lComm, &rComm, NULL), ret, cleanup2, NCCL_NET);
-
-      connected = (rComm != NULL) && (sComm != NULL);
-    }
-
-    NCCLCHECKGOTONOWARN(ncclCudaMalloc(&gpuPtr, GPU_BUF_SIZE, comm->memManager), ret, cleanup2, NCCL_NET);
-    NOWARN(ret = comm->ncclNet->regMr(sComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
-    if (ret == ncclSuccess) {
-      NCCLCHECKNOWARN(comm->ncclNet->deregMr(sComm, mHandle), NCCL_NET);
-      NCCLCHECKNOWARN(comm->ncclNet->regMr(rComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
-      NCCLCHECKNOWARN(comm->ncclNet->deregMr(rComm, mHandle), NCCL_NET);
-      gdrSupportMatrix[comm->cudaDev] = 1;
-    }
-    NCCLCHECK(ncclCudaFree(gpuPtr, comm->memManager));
+      NCCLCHECKGOTONOWARN(ncclCudaMalloc(&gpuPtr, GPU_BUF_SIZE, comm->memManager), ret, cleanup2, NCCL_NET);
+      NOWARN(ret = comm->ncclNet->regMr(sComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
+      if (ret == ncclSuccess) {
+        NCCLCHECKNOWARN(comm->ncclNet->deregMr(sComm, mHandle), NCCL_NET);
+        NCCLCHECKNOWARN(comm->ncclNet->regMr(rComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
+        NCCLCHECKNOWARN(comm->ncclNet->deregMr(rComm, mHandle), NCCL_NET);
+        gdrSupportMatrix[comm->cudaDev] = 1;
+      }
+      NCCLCHECK(ncclCudaFree(gpuPtr, comm->memManager));
 cleanup2:
-    if (rComm != NULL)
-      NCCLCHECK(comm->ncclNet->closeRecv(rComm));
-    if (sComm != NULL)
-      NCCLCHECK(comm->ncclNet->closeSend(sComm));
-    NCCLCHECK(comm->ncclNet->closeListen(lComm));
+      if (rComm != NULL)
+        NCCLCHECK(comm->ncclNet->closeRecv(rComm));
+      if (sComm != NULL)
+        NCCLCHECK(comm->ncclNet->closeSend(sComm));
+      NCCLCHECK(comm->ncclNet->closeListen(lComm));
 cleanup1:
       break;
     }

--- a/src/plugin/net/net_v8.cc
+++ b/src/plugin/net/net_v8.cc
@@ -46,13 +46,13 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
 }
 
 static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+  int dev, void* handle, void** listenComm) {
   return ncclNet_v8->listen(dev, handle, listenComm);
 }
 
 static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)),
-    int dev,
-    void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+  int dev,
+  void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
   return ncclNet_v8->connect(dev, handle, sendComm, sendDevComm);
 }
 
@@ -111,23 +111,23 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
 }
 
 static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+  int dev, void* handle, void** listenComm) {
   return ncclCollNet_v8->listen(dev, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_iallreduce(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request) {
+    ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request) {
   int countInt;
   if (count > MAX_NET_SIZE) return ncclInternalError;
   countInt = (int)count;
   ncclResult_t ans = ncclCollNet_v8->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp,
-                 sendMhandle, recvMhandle, request);
+          sendMhandle, recvMhandle, request);
   return ans;
 }
 
 static ncclResult_t ncclCollNet_iallgather (void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
-                           size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                           void* sendMhandle, void** request) {
+    size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+    void* sendMhandle, void** request) {
   ncclNetSGE_v8_t recvPartsInt;
   if (nRecvParts > 1) return ncclInternalError;
   if (recvParts->size > MAX_COLLNET_SIZE) return ncclInternalError;
@@ -135,15 +135,15 @@ static ncclResult_t ncclCollNet_iallgather (void* collComm, void* sendData, int 
   recvPartsInt.address = recvParts->address;
   recvPartsInt.size = (int)recvParts->size;
   ncclResult_t ans = ncclCollNet_v8->iallgather(collComm, sendData, nRecvParts, &recvPartsInt,
-                  bytesPerRank, windowOffset, windowBytes,
-                  sendMhandle, request);
+          bytesPerRank, windowOffset, windowBytes,
+          sendMhandle, request);
   return ans;
 }
 
 static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
-                               size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                               ncclDataType_t dataType, ncclRedOp_t redOp,
-                               void* recvMhandle, void** request) {
+    size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+    ncclDataType_t dataType, ncclRedOp_t redOp,
+    void* recvMhandle, void** request) {
   ncclNetSGE_v8_t sendPartsInt;
   if (nSendParts > 1) return ncclInternalError;
   if (sendParts->size > MAX_COLLNET_SIZE) return ncclInternalError;
@@ -151,9 +151,9 @@ static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, n
   sendPartsInt.address = sendParts->address;
   sendPartsInt.size = (int)sendParts->size;
   ncclResult_t ans = ncclCollNet_v8->ireducescatter(collComm, nSendParts, &sendPartsInt,
-                  recvData, bytesPerRank, windowOffset, windowBytes,
-                  dataType, redOp,
-                  recvMhandle, request);
+          recvData, bytesPerRank, windowOffset, windowBytes,
+          dataType, redOp,
+          recvMhandle, request);
   return ans;
 }
 
@@ -163,9 +163,9 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
 }
 
 static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config __attribute__((unused)),
-    ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
+  uint64_t commId __attribute__((unused)),
+  ncclNetCommConfig_t* config __attribute__((unused)),
+  ncclDebugLogger_t logfn, ncclProfilerCallback_t /*proffn*/) {
   // before ncclNet_v11 the net plugin was initialized only once. With ncclNet_v11 this is no longer the case.
   // The compat layer preserves the ncclNet_v8 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -208,8 +208,8 @@ ncclNet_t* getNcclNet_v8(void* lib) {
 }
 
 static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+  uint64_t commId __attribute__((unused)),
+  ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v8 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.

--- a/src/plugin/net/net_v9.cc
+++ b/src/plugin/net/net_v9.cc
@@ -59,13 +59,13 @@ static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* si
 }
 
 static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+  int dev, void* handle, void** listenComm) {
   return ncclNet_v9->listen(dev, handle, listenComm);
 }
 
 static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)),
-    int dev,
-    void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+  int dev,
+  void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
   return ncclNet_v9->connect(dev, handle, sendComm, sendDevComm);
 }
 
@@ -105,23 +105,23 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
 }
 
 static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int d, void* handle, void** listenComm) {
+  int d, void* handle, void** listenComm) {
   return ncclCollNet_v9->listen(d, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request) {
+    size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+    void* sendMhandle, void** request) {
   return ncclCollNet_v9->iallgather(collComm, sendData, nRecvParts, (ncclNetSGE_v9_t*)recvParts, bytesPerRank,
-                             windowOffset, windowBytes, sendMhandle, request);
+    windowOffset, windowBytes, sendMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request) {
+    size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+    ncclDataType_t dataType, ncclRedOp_t redOp,
+    void* recvMhandle, void** request) {
   return ncclCollNet_v9->ireducescatter(collComm, nSendParts, (ncclNetSGE_v9_t*)sendParts, recvData, bytesPerRank,
-                                 windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
+    windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
@@ -134,9 +134,9 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
 }
 
 static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config __attribute__((unused)),
-    ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
+  uint64_t commId __attribute__((unused)),
+  ncclNetCommConfig_t* config __attribute__((unused)),
+  ncclDebugLogger_t logfn, ncclProfilerCallback_t /*proffn*/) {
   // before ncclNet_v11 the net plugin was initialized only once. With ncclNet_v11 this is no longer the case.
   // The compat layer preserves the ncclNet_v9 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -179,8 +179,8 @@ ncclNet_t* getNcclNet_v9(void* lib) {
 }
 
 static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+  uint64_t commId __attribute__((unused)),
+  ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v9 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.

--- a/src/plugin/plugin_open.cc
+++ b/src/plugin/plugin_open.cc
@@ -63,9 +63,9 @@ static char* getLibPath(void* handle) {
 
 static void* openPluginLib(enum ncclPluginType type, const char* libName) {
   int openErr, len = PATH_MAX;
-  char libName_[MAX_STR_LEN] = { 0 };
-  char openErrStr[MAX_STR_LEN + 1] = { 0 };
-  char eNoEntNameList[PATH_MAX] = { 0 };
+  char libName_[MAX_STR_LEN] = {};
+  char openErrStr[MAX_STR_LEN + 1] = {};
+  char eNoEntNameList[PATH_MAX] = {};
 
   if (libName && strlen(libName)) {
     snprintf(libName_, MAX_STR_LEN, "%s", libName);
@@ -87,8 +87,8 @@ static void* openPluginLib(enum ncclPluginType type, const char* libName) {
 
   // libName can't be a relative or absolute path (start with '.' or contain any '/'). It can't be a library name either (start with 'lib' or end with '.so')
   if (libName && strlen(libName) && strchr(libName, '/') == nullptr &&
-      (strncmp(libName, "lib", strlen("lib")) || strlen(libName) < strlen(".so") ||
-       strncmp(libName + strlen(libName) - strlen(".so"), ".so", strlen(".so")))) {
+    (strncmp(libName, "lib", strlen("lib")) || strlen(libName) < strlen(".so") ||
+    strncmp(libName + strlen(libName) - strlen(".so"), ".so", strlen(".so")))) {
     snprintf(libName_, MAX_STR_LEN, "%s-%s.so", pluginPrefix[type], libName);
 
     libHandles[type] = tryOpenLib(libName_, &openErr, openErrStr);
@@ -106,7 +106,7 @@ static void* openPluginLib(enum ncclPluginType type, const char* libName) {
 
   if (strlen(eNoEntNameList)) {
     INFO(subsys[type], "%s/Plugin: Could not find:%s%s%s", pluginNames[type], eNoEntNameList,
-         (strlen(pluginFallback[type]) > 0 ? ". " : ""), pluginFallback[type]);
+        (strlen(pluginFallback[type]) > 0 ? ". " : ""), pluginFallback[type]);
   } else if (strlen(pluginFallback[type])) {
     INFO(subsys[type], "%s/Plugin: %s", pluginNames[type], pluginFallback[type]);
   }

--- a/src/plugin/profiler.cc
+++ b/src/plugin/profiler.cc
@@ -195,7 +195,7 @@ int ncclProfilerEventMask;       // Set by profiler
 static void printProfilerEventMask(int mask) {
   if (!mask) return;
 
-  char enabled[512] = {0};
+  char enabled[512] = {};
   int pos = 0;
   if (mask & ncclProfileGroup)        pos += sprintf(enabled + pos, "Group ");
   if (mask & ncclProfileColl)         pos += sprintf(enabled + pos, "Coll ");
@@ -244,7 +244,7 @@ ncclResult_t ncclProfilerPluginFinalize(struct ncclComm* comm) {
 }
 
 ncclResult_t ncclProfilerStartGroupApiEvent(struct ncclInfo* info, bool isGraphCaptured) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+  ncclProfilerEventDescr_t eDescr = {};
   eDescr.type = ncclProfileGroupApi;
   eDescr.groupApi.graphCaptured = isGraphCaptured;
 
@@ -290,7 +290,7 @@ ncclResult_t ncclProfilerRecordGroupApiEventState(ncclProfilerEventState_t eStat
 }
 
 ncclResult_t ncclProfilerStartP2pApiEvent(struct ncclInfo *info, bool isGraphCaptured) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+  ncclProfilerEventDescr_t eDescr = {};
   eDescr.type = ncclProfileP2pApi;
   eDescr.parentObj = ncclProfilerApiState.groupApiEventHandle;
   eDescr.p2pApi.func = ncclFuncToString(info->coll);
@@ -317,7 +317,7 @@ ncclResult_t ncclProfilerStopP2pApiEvent() {
 }
 
 ncclResult_t ncclProfilerStartCollApiEvent(struct ncclInfo *info, bool isGraphCaptured) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+  ncclProfilerEventDescr_t eDescr = {};
   eDescr.type = ncclProfileCollApi;
   eDescr.parentObj = ncclProfilerApiState.groupApiEventHandle;
   eDescr.collApi.func = ncclFuncToString(info->coll);
@@ -344,7 +344,7 @@ ncclResult_t ncclProfilerStopCollApiEvent() {
 }
 
 ncclResult_t ncclProfilerStartKernelLaunchEvent(struct ncclKernelPlan* plan, cudaStream_t stream) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+  ncclProfilerEventDescr_t eDescr = {};
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     void* groupApiEventHandle = NULL;
     // Check if any collective in the plan has a set event activation mask
@@ -369,7 +369,7 @@ ncclResult_t ncclProfilerStartKernelLaunchEvent(struct ncclKernelPlan* plan, cud
       pt = pt->next;
     }
 
-  startKernelLaunchEvent:
+startKernelLaunchEvent:
     if (eActivationMask_ & ncclProfileKernelLaunch) {
       eDescr.type = ncclProfileKernelLaunch;
       eDescr.parentObj = groupApiEventHandle;
@@ -410,9 +410,9 @@ ncclResult_t ncclProfilerStartGroupEvent(struct ncclKernelPlan* plan) {
       pt = pt->next;
     }
 
-  startGroup:
+startGroup:
     if (eActivationMask_ & (ncclProfileGroup | ncclProfileColl | ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileGroup;
       ncclProfiler->startEvent(plan->comm->profilerContext, &plan->groupEventHandle, &eDescr);
     }
@@ -437,7 +437,7 @@ ncclResult_t ncclProfilerStartTaskEvents(struct ncclKernelPlan* plan) {
     if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
       int enable = ct->eActivationMask & (ncclProfileColl | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin);
       if (enable) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {};
         eDescr.type = ncclProfileColl;
         eDescr.coll.parentGroup = plan->groupEventHandle;
         eDescr.parentObj = ct->collApiEventHandle;
@@ -463,7 +463,7 @@ ncclResult_t ncclProfilerStartTaskEvents(struct ncclKernelPlan* plan) {
     // made if ncclProfileKernelCh profiler events are active, as they result in proxy events always being added, which
     // gives the consistency.
     if (!plan->persistent || (COMPILER_EXPECT(ncclProfiler != NULL, 0) && (plan->groupEventHandle || ct->collApiEventHandle) &&
-                              (ct->eActivationMask & ncclProfileKernelCh)))
+      (ct->eActivationMask & ncclProfileKernelCh)))
       COMPILER_ATOMIC_FETCH_ADD(&plan->comm->seqNumber[ct->func], 1, std::memory_order_relaxed);
     ct = ct->next;
   }
@@ -472,7 +472,7 @@ ncclResult_t ncclProfilerStartTaskEvents(struct ncclKernelPlan* plan) {
     while (pt) {
       int enable = pt->eActivationMask & (ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin);
       if (enable) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {};
         eDescr.type = ncclProfileP2p;
         eDescr.p2p.parentGroup = plan->groupEventHandle;
         eDescr.parentObj = pt->p2pApiEventHandle;
@@ -520,7 +520,7 @@ ncclResult_t ncclProfilerStartProxyOpEvent(int s, struct ncclProxyArgs* args) {
   struct ncclProxySubArgs* sub = &args->subs[s];
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (sub->eActivationMask & (ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileNetPlugin)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileProxyOp;
       eDescr.parentObj = sub->taskEventHandle;
       eDescr.rank = sub->rank;
@@ -554,7 +554,7 @@ ncclResult_t ncclProfilerStartSendProxyStepEvent(int s, struct ncclProxyArgs* ar
   int step_ = DIVUP(stepId, args->sliceSteps);
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (sub->eActivationMask & (ncclProfileProxyStep | ncclProfileNetPlugin)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileProxyStep;
       eDescr.parentObj = sub->opEventHandle;
       eDescr.rank = sub->rank;
@@ -573,7 +573,7 @@ ncclResult_t ncclProfilerStartRecvProxyStepEvent(int s, struct ncclProxyArgs* ar
   int step_ = DIVUP(stepId, args->sliceSteps);
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (sub->eActivationMask & (ncclProfileProxyStep | ncclProfileNetPlugin)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileProxyStep;
       eDescr.parentObj = sub->opEventHandle;
       eDescr.rank = sub->rank;
@@ -606,7 +606,7 @@ ncclResult_t ncclProfilerStartProxyCtrlEvent(void* profilerContext, void** eHand
     // for proxy control events we allow profiling mode to change on a per event basis
     int eActivationMaskProxy = COMPILER_ATOMIC_LOAD(&ncclProfilerEventMask, std::memory_order_relaxed);
     if (eActivationMaskProxy & ncclProfileProxyCtrl) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileProxyCtrl;
       ncclProfiler->startEvent(profilerContext, eHandle, &eDescr);
       TIME_STOP_EVENT(proxyCtrlStart);
@@ -699,7 +699,7 @@ ncclResult_t ncclProfilerAddPidToProxyOp(struct ncclProxyOp* op) {
 
 static std::mutex proxyProfilerConnectMutex;
 
-static ncclResult_t proxyProfilerConnect(struct ncclComm* comm, struct ncclProxyOp* op) {
+static ncclResult_t proxyProfilerConnect(struct ncclComm* comm, struct ncclProxyOp* /*op*/) {
   ncclResult_t ret = ncclSuccess;
   std::lock_guard<std::mutex> lock(proxyProfilerConnectMutex);
   if (comm->profiler.initialized) goto exit;
@@ -730,7 +730,7 @@ ncclResult_t ncclProfilerCallback(void** eHandle, int type, void* pHandle, int64
       struct ncclProxyEventHandle* p = (struct ncclProxyEventHandle*)pHandle;
       struct ncclProxySubArgs* sub = p->subArgPtr;
       if (sub->eActivationMask & ncclProfileNetPlugin) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {};
         eDescr.type = ncclProfileNetPlugin;
         eDescr.parentObj = p->stepEventHandle;
         eDescr.rank = sub->rank;
@@ -766,7 +766,7 @@ ncclResult_t ncclProfilerStartCeCollEvent(struct ncclComm* comm, struct ncclCeCo
     // Check if CE Coll events are enabled (or child events CeSync/CeBatch which need CeColl)
     int ceCollMask = ncclProfileCeColl | ncclProfileCeSync | ncclProfileCeBatch;
     if (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ceCollMask) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileCeColl;
       eDescr.parentObj = args->collApiEventHandle;
       eDescr.rank = comm->rank;
@@ -794,7 +794,7 @@ ncclResult_t ncclProfilerStartCeCollEvent(struct ncclComm* comm, struct ncclCeCo
 /*
  * CE Collective stop event - calls plugin stopEvent callback
  */
-ncclResult_t ncclProfilerStopCeCollEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
+ncclResult_t ncclProfilerStopCeCollEvent(struct ncclComm* /*comm*/, struct ncclCeCollArgs* args, cudaStream_t /*stream*/) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (args && args->ceCollProfHandle) {
       ncclProfiler->stopEvent(args->ceCollProfHandle);
@@ -807,11 +807,11 @@ ncclResult_t ncclProfilerStopCeCollEvent(struct ncclComm* comm, struct ncclCeCol
  * CE Sync start event - calls plugin startEvent callback
  */
 ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args,
-                                          cudaStream_t stream, void** ceSyncHandle) {
+    cudaStream_t /*stream*/, void** ceSyncHandle) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (args && args->ceCollProfHandle && (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ncclProfileCeSync)) {
       // CeSync only needs to check if it's enabled; parent CeColl is implicitly started via ceCollMask
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileCeSync;
       eDescr.parentObj = args->ceCollProfHandle;
       eDescr.rank = comm->rank;
@@ -828,8 +828,8 @@ ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCo
 /*
  * CE Sync stop event - calls plugin stopEvent callback
  */
-ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHandle,
-                                         cudaStream_t stream) {
+ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* /*comm*/, void* ceSyncHandle,
+    cudaStream_t /*stream*/) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && ceSyncHandle) {
     ncclProfiler->stopEvent(ceSyncHandle);
   }
@@ -840,15 +840,15 @@ ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHand
  * CE Batch start event - calls plugin startEvent callback
  */
 ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm,
-                                           struct ncclCeCollArgs* args,
-                                           struct ncclCeBatchOpsParams* params,
-                                           cudaStream_t stream,
-                                           void** ceBatchHandle) {
+    struct ncclCeCollArgs* args,
+    struct ncclCeBatchOpsParams* params,
+    cudaStream_t /*stream*/,
+    void** ceBatchHandle) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (args && args->ceCollProfHandle) {
       // CeBatch only needs to check if it's enabled; parent CeColl is implicitly started via ceCollMask
       if (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ncclProfileCeBatch) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {};
         eDescr.type = ncclProfileCeBatch;
         eDescr.parentObj = args->ceCollProfHandle;
         eDescr.rank = comm->rank;
@@ -872,7 +872,7 @@ ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm,
 /*
  * CE Batch stop event - calls plugin stopEvent callback
  */
-ncclResult_t ncclProfilerStopCeBatchEvent(struct ncclComm* comm, void* ceBatchHandle, cudaStream_t stream) {
+ncclResult_t ncclProfilerStopCeBatchEvent(struct ncclComm* /*comm*/, void* ceBatchHandle, cudaStream_t /*stream*/) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && ceBatchHandle) {
     ncclProfiler->stopEvent(ceBatchHandle);
   }

--- a/src/plugin/profiler/profiler_v1.cc
+++ b/src/plugin/profiler/profiler_v1.cc
@@ -56,7 +56,7 @@ static uint8_t ncclStringToDatatype(const char* dt) {
 
 static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclProfilerEventDescr_t* eDescr) {
   *eHandle = NULL;
-  ncclProfilerEventDescr_v1_t eDescr_v1 = { 0 };
+  ncclProfilerEventDescr_v1_t eDescr_v1 = {};
   eDescr_v1.type = eDescr->type;
   eDescr_v1.parentObj = eDescr->parentObj;
   eDescr_v1.rank = eDescr->rank;
@@ -137,7 +137,7 @@ static ncclResult_t ncclProfiler_init(void** context,
     int nranks __attribute__((unused)),
     int rank __attribute__((unused)),
     ncclDebugLogger_t logfn __attribute__((unused))
-  ) {
+) {
   NCCLCHECK(ncclProfiler_v1->init(context, eActivationMask));
   ncclProfiler.startEvent = ncclProfiler_startEvent;
   ncclProfiler.stopEvent = ncclProfiler_v1->stopEvent;

--- a/src/plugin/tuner/tuner_v2.cc
+++ b/src/plugin/tuner/tuner_v2.cc
@@ -51,8 +51,8 @@ static ncclResult_t ncclTuner_finalize(void* ctx) {
   return ncclTuner_v2->destroy(ctx);
 }
 
-static ncclResult_t ncclTuner_init(void** ctx, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
-                                   ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_t* /*constants*/) {
+static ncclResult_t ncclTuner_init(void** ctx, uint64_t /*commId*/, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
+    ncclNvlDomainInfo_v5_t* /*nvlDomainInfo*/, ncclTunerConstants_t* /*constants*/) {
   NCCLCHECK(ncclTuner_v2->init(nRanks, nNodes, logfn, ctx));
   ncclTuner.getCollInfo = ncclTuner_getCollInfo;
   ncclTuner.finalize = ncclTuner_finalize;

--- a/src/plugin/tuner/tuner_v3.cc
+++ b/src/plugin/tuner/tuner_v3.cc
@@ -23,8 +23,8 @@ static ncclResult_t ncclTuner_finalize(void* ctx) {
   return ncclTuner_v3->destroy(ctx);
 }
 
-static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
-                                   ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_t* /*constants*/) {
+static ncclResult_t ncclTuner_init(void** context, uint64_t /*commId*/, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
+    ncclNvlDomainInfo_v5_t* /*nvlDomainInfo*/, ncclTunerConstants_t* /*constants*/) {
   NCCLCHECK(ncclTuner_v3->init(nRanks, nNodes, logfn, context));
   ncclTuner.getCollInfo = ncclTuner_getCollInfo;
   ncclTuner.finalize = ncclTuner_finalize;

--- a/src/plugin/tuner/tuner_v4.cc
+++ b/src/plugin/tuner/tuner_v4.cc
@@ -18,8 +18,8 @@ static ncclResult_t ncclTuner_finalize(void* ctx) {
   return ncclTuner_v4->destroy(ctx);
 }
 
-static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
-                                   ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_t* /*constants*/) {
+static ncclResult_t ncclTuner_init(void** context, uint64_t /*commId*/, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
+    ncclNvlDomainInfo_v5_t* /*nvlDomainInfo*/, ncclTunerConstants_t* /*constants*/) {
   NCCLCHECK(ncclTuner_v4->init(nRanks, nNodes, logfn, context));
   ncclTuner.getCollInfo = ncclTuner_v4->getCollInfo;
   ncclTuner.finalize = ncclTuner_finalize;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -394,11 +394,11 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
     args->nChannels = std::min(args->nChannels, op->nChannels);
     args->nPeers = std::min(args->nPeers, op->nPeers);
     if ((args->sliceSteps != op->sliceSteps) ||
-        (args->chunkSteps != op->chunkSteps) ||
-        (args->protocol != op->protocol) ||
-        (args->dtype != op->dtype) ||
-        (args->redOp != op->redOp) ||
-        (args->coll != op->coll)) {
+      (args->chunkSteps != op->chunkSteps) ||
+      (args->protocol != op->protocol) ||
+      (args->dtype != op->dtype) ||
+      (args->redOp != op->redOp) ||
+      (args->coll != op->coll)) {
       WARN("Proxy append mismatch");
       return ncclInternalError;
     }
@@ -524,10 +524,10 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
     int lastOp = -1;
     int toSend = 0;
     int ops = 0;
-    for (int op= proxyOps->nextOps; op != proxyOps->nextOpsEnd; op=pool->ops[op].next) {
+    for (int opIdx = proxyOps->nextOps; opIdx != proxyOps->nextOpsEnd; opIdx=pool->ops[opIdx].next) {
       ops++;
-      if (pool->ops[op].opCount != lastOpCount) {
-        lastOp = op;
+      if (pool->ops[opIdx].opCount != lastOpCount) {
+        lastOp = opIdx;
         toSend = ops;
       }
     }
@@ -592,10 +592,10 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
   bool needProxy = false;
   if (justInquire) *justInquire = false;
   switch (op->pattern) {
-  case ncclPatternRing:
-  case ncclPatternRingTwice:
-  case ncclPatternPipelineFrom:
-  case ncclPatternPipelineTo: {
+    case ncclPatternRing:
+    case ncclPatternRingTwice:
+    case ncclPatternPipelineFrom:
+    case ncclPatternPipelineTo: {
       struct ncclRing* ring = &channel->ring;
       needProxy = NeedProxy(proxyRecv, op->pattern, op->root, ring, comm->nRanks);
       if (op->coll == ncclFuncAllGatherV && op->pattern == ncclPatternRing) {
@@ -611,9 +611,9 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
       }
       if (needProxy) NCCLCHECK(SaveProxy(comm, channel, proxySend, ring->next, op, 0, justInquire));
     } break;
-  case ncclPatternTreeUp:
-  case ncclPatternTreeDown:
-  case ncclPatternTreeUpDown: {
+    case ncclPatternTreeUp:
+    case ncclPatternTreeDown:
+    case ncclPatternTreeUpDown: {
       if (op->pattern != ncclPatternTreeDown) { // Tree up
         struct ncclTree* tree = &channel->tree;
         for (int i=0; i<NCCL_MAX_TREE_ARITY; i++) {
@@ -629,19 +629,19 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
         NCCLCHECK(SaveProxy(comm, channel, proxyRecv, tree->up, op, 0, justInquire));
       }
     } break;
-  case ncclPatternCollnetChain: {
+    case ncclPatternCollnetChain: {
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->collnetChain.up, op, 1, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->collnetChain.up, op, 0, justInquire));
     } break;
-  case ncclPatternCollnetDirect: {
+    case ncclPatternCollnetDirect: {
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->collnetDirect.out, op, 1, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->collnetDirect.out, op, 0, justInquire));
     } break;
-  case ncclPatternNvls: {
+    case ncclPatternNvls: {
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.out, op, 1, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.out, op, 0, justInquire));
     } break;
-  case ncclPatternNvlsTree: {
+    case ncclPatternNvlsTree: {
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.treeDown[1], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.treeDown[2], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.treeUp, op, 0, justInquire));
@@ -649,14 +649,14 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.treeDown[2], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.treeUp, op, 0, justInquire));
     } break;
-  case ncclPatternPatUp: {
+    case ncclPatternPatUp: {
       // Run full algorithm to count the number of steps for each peer.
       ncclResult_t result = ncclSuccess;
       const ssize_t size = op->nbytes/comm->nRanks;
       const int rank = comm->rank, nranks = comm->nRanks;
       int *nstepsSend = NULL, *nstepsRecv = NULL;
       PatRSAlgorithm<char> algo(op->chunkSize, NCCL_STEPS, 16, 0, size, size, op->chunkSize, rank, nranks);
-      struct ncclPatStep ps = {0};
+      struct ncclPatStep ps = {};
       NCCLCHECKGOTO(ncclCalloc(&nstepsSend, log2Up(nranks)), result, exit_pat_up);
       NCCLCHECKGOTO(ncclCalloc(&nstepsRecv, log2Up(nranks)), result, exit_pat_up);
 
@@ -678,19 +678,19 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxyRecv, recvPeer, op, 0, justInquire), result, exit_pat_up);
         }
       }
-    exit_pat_up:
+exit_pat_up:
       free(nstepsSend);
       free(nstepsRecv);
       NCCLCHECK(result);
     } break;
-  case ncclPatternPatDown: {
+    case ncclPatternPatDown: {
       // Run full algorithm to count the number of steps for each peer.
       ncclResult_t result = ncclSuccess;
       const ssize_t size = op->nbytes/comm->nRanks;
       const int rank = comm->rank, nranks = comm->nRanks;
       int *nstepsSend = NULL, *nstepsRecv = NULL;
       PatAGAlgorithm<char> algo(op->chunkSize, NCCL_STEPS, 16, 0, size, size, op->chunkSize, rank, nranks);
-      struct ncclPatStep ps = {0};
+      struct ncclPatStep ps = {};
       NCCLCHECKGOTO(ncclCalloc(&nstepsSend, log2Up(nranks)), result, exit_pat_down);
       NCCLCHECKGOTO(ncclCalloc(&nstepsRecv, log2Up(nranks)), result, exit_pat_down);
 
@@ -712,17 +712,17 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxyRecv, recvPeer, op, 0, justInquire), result, exit_pat_down);
         }
       }
-    exit_pat_down:
+exit_pat_down:
       free(nstepsSend);
       free(nstepsRecv);
       NCCLCHECK(result);
     } break;
-  case ncclPatternSend:
-  case ncclPatternRecv: {
+    case ncclPatternSend:
+    case ncclPatternRecv: {
       if (op->root == comm->rank) return ncclSuccess;
       NCCLCHECK(SaveProxy(comm, channel, op->pattern == ncclPatternSend ? proxySend : proxyRecv, op->root, op, 1, justInquire));
     } break;
-  case ncclPatternProfiler: {
+    case ncclPatternProfiler: {
       if (ncclProfilerNeedsProxy(comm, op)) NCCLCHECK(SaveProxyProfiler(comm, op, justInquire));
       else incWorkCounter(comm, op);
     } break;
@@ -871,7 +871,7 @@ process_nextops:
 
 #include <signal.h>
 static ncclProxyProgressState* ncclLastProxyState;
-void ncclDumpProxyState(int signal) {
+void ncclDumpProxyState(int /*signal*/) {
   dumpProxyState(ncclLastProxyState);
 }
 
@@ -893,7 +893,7 @@ static int setProxyThreadContext(struct ncclProxyState* proxyState) {
   if (createThreadContext) {
     if (proxyState->cudaCtx == NULL) {
       if (CUPFN(cuCtxCreate(&proxyState->cudaCtx,
-                            NULL, 0, CU_CTX_SCHED_SPIN|CU_CTX_MAP_HOST, proxyState->cudaDev)) != CUDA_SUCCESS) {
+        NULL, 0, CU_CTX_SCHED_SPIN|CU_CTX_MAP_HOST, proxyState->cudaDev)) != CUDA_SUCCESS) {
         WARN("Failed to create CUDA context on device %d", proxyState->cudaDev);
         createThreadContext = 0;
         goto exit;
@@ -926,7 +926,7 @@ void proxyCpusetOnceFunc() {
       goto fail;
     }
     // debug info
-    char msg[1024] = {0};
+    char msg[1024] = {};
     ncclAffinity currSet;
     ncclOsGetAffinity(&currSet);
     (void)ncclCpusetToStrList(&currSet, msg, sizeof(msg));
@@ -1131,7 +1131,7 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
   int tpProxyRank = comm->topParentRanks[proxyRank];
 
   proxyConn->sameProcess = ((comm->peerInfo[proxyRank].hostHash == comm->peerInfo[comm->rank].hostHash) &&
-                            (comm->peerInfo[proxyRank].pidHash == comm->peerInfo[comm->rank].pidHash)) ? 1 : 0;
+    (comm->peerInfo[proxyRank].pidHash == comm->peerInfo[comm->rank].pidHash)) ? 1 : 0;
   // Keep one connection per local rank
   proxyConn->connection = NULL;
   proxyConn->tpRank = tpProxyRank;
@@ -1153,14 +1153,14 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
     NCCLCHECK(ncclSocketConnect(sock));
   }
 
-  struct ncclProxyInitReq req = {0};
+  struct ncclProxyInitReq req = {};
   req.transport = transport;
   req.send = send;
   req.tpLocalRank = comm->topParentLocalRanks[comm->localRank];
   req.tpRank = comm->topParentRanks[comm->rank];
   req.sameProcess = proxyConn->sameProcess;
 
-  struct ncclProxyInitResp resp = {0};
+  struct ncclProxyInitResp resp = {};
   // This usually sends proxyConn->connection to identify which connection this is.
   // However, this is part of the response and therefore is ignored
   NCCLCHECK(ncclProxyCallBlocking(comm, proxyConn, ncclProxyMsgInit, &req, sizeof(req), &resp, sizeof(resp)));
@@ -1185,7 +1185,7 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
 // UDS support
 ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff, int reqSize, void* respBuff, int respSize, int* reqFd, int *respFd) {
   ncclResult_t res = ncclSuccess;
-  struct ncclIpcSocket ipcSock = { 0 };
+  struct ncclIpcSocket ipcSock = {};
   void *opId;
   NCCLCHECK(getRandomData(&opId, sizeof(opId)));
   int reqFdtmp = -1;
@@ -1195,7 +1195,7 @@ ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyCon
   uint64_t pidHash = sharedProxyState->peerAddressesUDS[proxyConn->tpRank];
 
   INFO(NCCL_PROXY, "ProxyCall UDS comm %p rank %d tpRank %d(%lx) reqSize %d respSize %d respFd %p opId %p",
-       comm, rank, proxyConn->tpRank, pidHash, reqSize, respSize, respFd, opId);
+    comm, rank, proxyConn->tpRank, pidHash, reqSize, respSize, respFd, opId);
 
   // cuMem: Create a UDS socket to receive the response
   NCCLCHECK(ncclIpcSocketInit(&ipcSock, rank, (uint64_t)opId, comm->abortFlag));
@@ -1222,7 +1222,7 @@ ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyCon
   NCCLCHECKGOTO(ncclIpcSocketClose(&ipcSock), res, error);
 
   INFO(NCCL_PROXY, "ProxyCall UDS comm %p rank %d tpRank %d(%lx) reqSize %d respSize %d respFd %d opId %p - DONE",
-       comm, rank, proxyConn->tpRank, pidHash, reqSize, respSize, (respFd ? *respFd : -1), opId);
+    comm, rank, proxyConn->tpRank, pidHash, reqSize, respSize, (respFd ? *respFd : -1), opId);
 
   return res;
 
@@ -1320,7 +1320,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
   if (found == 0) {
     // Attempt to read in a new response header from the proxy thread
     struct ncclSocket* sock = sharedProxyState->peerSocks + proxyConn->tpLocalRank;
-    ncclProxyRpcResponseHeader resp = {0};
+    ncclProxyRpcResponseHeader resp = {};
     int offset = 0;
     if (ncclSuccess != ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset)) {
       WARN("Socket recv failed while polling for opId=%p", opId);
@@ -1329,7 +1329,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
 
     if (offset == 0) {
       return ncclInProgress;
-    // If we've returned a partial response, block to receive the rest of it
+      // If we've returned a partial response, block to receive the rest of it
     } else if (offset < sizeof(resp)) {
       while (offset < sizeof(resp))
         NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset));
@@ -1459,7 +1459,7 @@ static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclPr
 
 static ncclResult_t proxyQueryFd(struct ncclProxyState* proxyState, int rank, void *opId, int rmtFd) {
 #if CUDART_VERSION >= 11030
-  struct ncclIpcSocket ipcSock = { 0 };
+  struct ncclIpcSocket ipcSock = {};
   uint64_t hash = (uint64_t) opId;
   ncclResult_t ret = ncclSuccess;
 
@@ -1478,7 +1478,7 @@ static ncclResult_t proxyGetFd(struct ncclProxyState* proxyState, int rank, void
 #if CUDART_VERSION >= 11030
   // cuMem API support
   ncclResult_t ret = ncclSuccess;
-  struct ncclIpcSocket ipcSock = { 0 };
+  struct ncclIpcSocket ipcSock = {};
   uint64_t hash = (uint64_t) opId;
   INFO(NCCL_PROXY, "UDS proxyGetFd received handle 0x%lx peer %d opId %lx", handle, rank, hash);
 
@@ -1513,8 +1513,7 @@ static ncclResult_t proxyProgressAsync(struct ncclProxyAsyncOp* op, struct ncclP
     TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgSharedInit opId=%p op.reqBuff=%p nChannels=%d", op->opId, op->reqBuff, nChannels);
     if (op->connection->tcomm->proxySharedInit) res = op->connection->tcomm->proxySharedInit(op->connection, proxyState, nChannels);
     COMPILER_ATOMIC_STORE(&op->connection->state, connSharedInitialized, std::memory_order_release);
-  }
-  else if (op->type == ncclProxyMsgInit) {
+  } else if (op->type == ncclProxyMsgInit) {
     TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgInit opId=%p op.reqBuff=%p", op->opId, op->reqBuff);
     res = proxyConnInit(peer, connectionPool, proxyState, (ncclProxyInitReq*) op->reqBuff, (ncclProxyInitResp*) op->respBuff, &op->connection);
   } else if (op->type == ncclProxyMsgRegister) {
@@ -1782,7 +1781,7 @@ void* ncclProxyService(void* _args) {
 
 
 // Process a request on the UDS socket
-static ncclResult_t proxyUDSRecvReq(struct ncclProxyState* proxyState, int reqFd) {
+static ncclResult_t proxyUDSRecvReq(struct ncclProxyState* proxyState, int /*reqFd*/) {
   ncclIpcHdr hdr;
   int rmtFd = -1;
 

--- a/src/ras/client.cc
+++ b/src/ras/client.cc
@@ -36,23 +36,23 @@ static int sock = -1;
 
 static void printUsage(const char* argv0) {
   fprintf(stderr,
-          "Usage: %s [OPTION]...\n"
-          "Query the state of a running NCCL job.\n"
-          "\nOptions:\n"
-          "  -f, --format=FMT    Output format: text or json (text by default)\n"
-          "  -h, --host=HOST     Host name or IP address of the RAS client socket of the\n"
-          "                      NCCL job to connect to (localhost by default)\n"
-          "  -m, --monitor[=GROUPS] Monitor mode: continuously watch for peer changes.\n"
-          "                      Optional GROUPS: lifecycle, trace, all, or\n"
-          "                      combinations like lifecycle,trace (lifecycle by default)\n"
-          "  -p, --port=PORT     TCP port of the RAS client socket of the NCCL job\n"
-          "                      (" STR(NCCL_RAS_CLIENT_PORT) " by default)\n"
-          "  -t, --timeout=SECS  Maximum time for the local NCCL process to wait for\n"
-          "                      responses from other NCCL processes\n"
-          "                      (" STR(RAS_COLLECTIVE_LEG_TIMEOUT_SEC) " secs by default; 0 disables the timeout)\n"
-          "  -v, --verbose       Increase the verbosity level of the RAS output\n"
-          "      --help          Print this help and exit\n"
-          "      --version       Print the version number and exit\n", argv0);
+      "Usage: %s [OPTION]...\n"
+      "Query the state of a running NCCL job.\n"
+      "\nOptions:\n"
+      "  -f, --format=FMT    Output format: text or json (text by default)\n"
+      "  -h, --host=HOST     Host name or IP address of the RAS client socket of the\n"
+      "                      NCCL job to connect to (localhost by default)\n"
+      "  -m, --monitor[=GROUPS] Monitor mode: continuously watch for peer changes.\n"
+      "                      Optional GROUPS: lifecycle, trace, all, or\n"
+      "                      combinations like lifecycle,trace (lifecycle by default)\n"
+      "  -p, --port=PORT     TCP port of the RAS client socket of the NCCL job\n"
+      "                      (" STR(NCCL_RAS_CLIENT_PORT) " by default)\n"
+      "  -t, --timeout=SECS  Maximum time for the local NCCL process to wait for\n"
+      "                      responses from other NCCL processes\n"
+      "                      (" STR(RAS_COLLECTIVE_LEG_TIMEOUT_SEC) " secs by default; 0 disables the timeout)\n"
+      "  -v, --verbose       Increase the verbosity level of the RAS output\n"
+      "      --help          Print this help and exit\n"
+      "      --version       Print the version number and exit\n", argv0);
 }
 
 static void parseArgs(int argc, char** argv) {
@@ -67,7 +67,7 @@ static void parseArgs(int argc, char** argv) {
     {"timeout", required_argument, NULL, 't'},
     {"verbose", no_argument,       NULL, 'v'},
     {"version", no_argument,       NULL, 'r'},
-    {0}
+    {0, 0, 0, 0}
   };
 
   while ((c = getopt_long(argc, argv, "f:h:m::p:t:v", longOpts, &optIdx)) != -1) {
@@ -108,7 +108,7 @@ static void parseArgs(int argc, char** argv) {
         exit(0);
       case 'r':
         fprintf(stderr, "NCCL RAS client version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "."
-                STR(NCCL_PATCH) NCCL_SUFFIX "\n");
+          STR(NCCL_PATCH) NCCL_SUFFIX "\n");
         exit(0);
       default:
         printUsage(argv[0]);
@@ -157,7 +157,7 @@ static ssize_t rasRead(int fd, void* buf, size_t count, bool untilNewline = true
 }
 
 static int connectToNCCL() {
-  struct addrinfo hints = {0};
+  struct addrinfo hints = {};
   struct addrinfo* addrInfo = nullptr;
   int ret;
   char msgBuf[1024];
@@ -181,7 +181,7 @@ retry:
     }
     // Initially start with a small, 1-sec timeout to quickly eliminate non-responsive processes...
     if (timeout && (setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof tv) != 0 ||
-                    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv) != 0)) {
+      setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv) != 0)) {
       perror("setsockopt");
       // Non-fatal; fall through.
     }
@@ -189,7 +189,7 @@ retry:
       break;
     err = errno;
     if (getnameinfo(ai->ai_addr, ai->ai_addrlen, hostBuf, sizeof(hostBuf), portBuf, sizeof(portBuf),
-                    NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+      NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
       strcpy(hostBuf, hostName);
       strcpy(portBuf, port);
     }
@@ -202,11 +202,11 @@ retry:
 
   if (sock == -1) {
     fprintf(stderr, "Failed to connect to the NCCL RAS service!\n"
-            "Please make sure that the NCCL job has the RAS service enabled and that\n"
-            "%s.\n",
-            (strcmp(hostName, "localhost") || strcmp(port, STR(NCCL_RAS_CLIENT_PORT)) ?
-            "the host/port arguments are correct and match NCCL_RAS_ADDR" :
-            "the RAS client was started on a node where the NCCL job is running"));
+                    "Please make sure that the NCCL job has the RAS service enabled and that\n"
+                    "%s.\n",
+        (strcmp(hostName, "localhost") || strcmp(port, STR(NCCL_RAS_CLIENT_PORT)) ?
+                      "the host/port arguments are correct and match NCCL_RAS_ADDR" :
+                      "the RAS client was started on a node where the NCCL job is running"));
     goto fail;
   }
 
@@ -237,7 +237,7 @@ retry:
   }
   if (strtol(msgBuf+strlen("SERVER PROTOCOL "), nullptr, 10) != NCCL_RAS_CLIENT_PROTOCOL) {
     fprintf(stderr, "NCCL RAS protocol version mismatch (NCCL: %s; RAS client: %d)!\n"
-            "Will try to continue in spite of that...\n", msgBuf+strlen("SERVER PROTOCOL "), NCCL_RAS_CLIENT_PROTOCOL);
+                    "Will try to continue in spite of that...\n", msgBuf+strlen("SERVER PROTOCOL "), NCCL_RAS_CLIENT_PROTOCOL);
   }
 
   if (timeout >= 0) {
@@ -362,7 +362,7 @@ static int getNCCLStatus() {
 static int monitorNCCLEvents() {
   char msgBuf[4096];
   int bytes;
-  struct timeval tv = {0, 0}; // No timeout for monitor mode.
+  struct timeval tv = {}; // No timeout for monitor mode.
 
   // Send the monitor command with optional event levels.
   if (events) {

--- a/src/ras/client_support.cc
+++ b/src/ras/client_support.cc
@@ -105,10 +105,10 @@ static int rasOutBufferSize = 0;
 
 // We use them all over the place; no point in wasting the stack...
 static char lineBuf[1024]; // Temporary buffer used for printing at most 10 (RAS_CLIENT_DETAIL_THRESHOLD) rank numbers
-                           // or for printing the local GPU devices, which can't be more than 64
-                           // small numbers (times two if the NVML mask is different than the CUDA mask).
-                           // Still, 1024 should normally be plenty (verbose output may make things more difficult,
-                           // but we do check for overflows, so it will just be trimmed).
+// or for printing the local GPU devices, which can't be more than 64
+// small numbers (times two if the NVML mask is different than the CUDA mask).
+// Still, 1024 should normally be plenty (verbose output may make things more difficult,
+// but we do check for overflows, so it will just be trimmed).
 
 // CUDA version information - shared across functions.
 static int cudaDriverVersion = -1, cudaRuntimeVersion = -1;
@@ -123,7 +123,7 @@ static ncclResult_t rasClientRunInit(struct rasClient* client);
 static ncclResult_t rasClientRunConns(struct rasClient* client);
 static ncclResult_t rasClientRunComms(struct rasClient* client);
 static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollComms::comm* comm,
-                                     const int* peerIdxConv, int ncclErrors[ncclNumResults], bool isAsync = false);
+    const int* peerIdxConv, int ncclErrors[ncclNumResults], bool isAsync = false);
 
 static void rasOutAppend(const char* format, ...) __attribute__ ((format(printf, 1, 2)));
 static void rasOutExtract(char* buffer);
@@ -142,18 +142,18 @@ static const char* ncclErrorToString(ncclResult_t err);
 static bool rasCountIsOutlier(int count, bool verbose, int totalCount = -1);
 
 // CUDA version information - shared across functions.
-static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* commsData,
-                               struct rasCollective* coll, const int* peerIdxConv);
+static void rasDumpCommsToJSON(struct rasClient* /*client*/, struct rasCollComms* commsData,
+    struct rasCollective* coll, const int* peerIdxConv);
 static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDriver,
-                            const char* timestamp, int commsCount);
+    const char* timestamp, int commsCount);
 static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash, unsigned long pidHash,
-                                  int commSize, int ranksCount, int missingCount, bool firstComm);
+    int commSize, int ranksCount, int missingCount, bool firstComm);
 static void jsonWriteRankData(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                              int initState, int asyncError, bool finalizeCalled, bool destroyFlag,
-                              bool abortFlag, const unsigned long* collCounts, bool firstRank);
+    int initState, int asyncError, bool finalizeCalled, bool destroyFlag,
+    bool abortFlag, const unsigned long* collCounts, bool firstRank);
 static void jsonStartMissingRanks();
 static void jsonWriteMissingRank(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                                 bool unresponsive, bool dead, bool firstMissing);
+    bool unresponsive, bool dead, bool firstMissing);
 static void jsonEndCommunicator();
 static void jsonWriteFooter(double collectionTime, int timeoutsCount);
 
@@ -173,13 +173,13 @@ ncclResult_t rasClientInitSocket() {
   NCCLCHECKGOTO(ncclSocketGetAddrFromString(&addr, clientAddr), ret, fail);
   SYSCHECKGOTO(rasClientListeningSocket = socket(addr.sa.sa_family, SOCK_STREAM, 0), "socket", ret, fail);
   SYSCHECKGOTO(setsockopt(rasClientListeningSocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)),
-               "setsockopt", ret, fail);
+    "setsockopt", ret, fail);
 #if defined(SO_REUSEPORT)
   SYSCHECKGOTO(setsockopt(rasClientListeningSocket, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)),
-               "setsockopt", ret, fail);
+    "setsockopt", ret, fail);
 #endif
   SYSCHECKGOTO(bind(rasClientListeningSocket, &addr.sa, (addr.sa.sa_family == AF_INET ? sizeof(struct sockaddr_in) :
-                                                          sizeof(struct sockaddr_in6))), "bind", ret, fail);
+    sizeof(struct sockaddr_in6))), "bind", ret, fail);
   SYSCHECKGOTO(listen(rasClientListeningSocket, 16384), "listen", ret, fail);
   INFO(NCCL_INIT|NCCL_RAS, "RAS client listening socket at %s", ncclSocketToString(&addr, rasLine));
 exit:
@@ -325,7 +325,7 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
       if (client->recvOffset < sizeof(client->recvBuffer)) {
         ssize_t nRecv;
         nRecv = recv(client->sock, client->recvBuffer+client->recvOffset,
-                     sizeof(client->recvBuffer) - client->recvOffset, MSG_DONTWAIT);
+                sizeof(client->recvBuffer) - client->recvOffset, MSG_DONTWAIT);
         if (nRecv == 0) {
           closed = true;
         } else if (nRecv == -1) {
@@ -484,7 +484,7 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
     while ((meta = ncclIntruQueueHead(&client->sendQ)) != nullptr) {
       ssize_t nSend;
       nSend = send(client->sock, ((char*)&meta->msg)+meta->offset, meta->length-meta->offset,
-                   MSG_DONTWAIT | MSG_NOSIGNAL);
+        MSG_DONTWAIT | MSG_NOSIGNAL);
       if (nSend < 1) {
         if (nSend == -1 && errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
           if (errno == EPIPE)
@@ -547,6 +547,7 @@ static ncclResult_t rasClientRun(struct rasClient* client) {
         ret = ncclSuccess;
         break;
       }
+      __attribute__((fallthrough));
     case RAS_CLIENT_COMMS:
       NCCLCHECKGOTO(rasClientRunComms(client), ret, exit);
       client->status = RAS_CLIENT_FINISHED;
@@ -587,7 +588,7 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
   // It will be included in the structured output later.
   if (client->outputFormat == RAS_OUTPUT_TEXT) {
     rasOutAppend("NCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
-                 " compiled with CUDA " STR(CUDA_MAJOR) "." STR(CUDA_MINOR) "\n");
+      " compiled with CUDA " STR(CUDA_MAJOR) "." STR(CUDA_MINOR) "\n");
     rasOutAppend("CUDA runtime version %d, driver version %d\n\n", cudaRuntimeVersion, cudaDriverVersion);
     msgLen = rasOutLength();
     NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
@@ -638,7 +639,7 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
 
   TRACE(NCCL_RAS, "RAS: totalNodes %d, nRasPeers %d, totalGpus %d", totalNodes, nRasPeers, totalGpus);
   TRACE(NCCL_RAS, "RAS: consistentNPeersGlobal %d, consistentNGpusGlobal %d, consistentNGpusNode %d",
-        consistentNPeersGlobal, consistentNGpusGlobal, consistentNGpusNode);
+      consistentNPeersGlobal, consistentNGpusGlobal, consistentNGpusNode);
   TRACE(NCCL_RAS, "RAS: firstNPeersGlobal %d, firstNGpusGlobal %d", firstNPeersGlobal, firstNGpusGlobal);
 
   // Only output job summary for text format.
@@ -650,102 +651,51 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
       rasOutAppend("  Nodes  Processes         GPUs  Processes     GPUs\n"
                    "(total)   per node  per process    (total)  (total)\n"
                    "%7d"  "  %9d"    "  %11d"     "  %9d"    "  %7d\n",
-                   totalNodes, firstNPeersGlobal, firstNGpusGlobal, nRasPeers, totalGpus);
+          totalNodes, firstNPeersGlobal, firstNGpusGlobal, nRasPeers, totalGpus);
     } else {
-    // Gather the stats on the number of processes per node.  However, that number is not a property of a peer,
-    // but of a group of peers, so calculating it is more involved.  We store the value in a temporary auxRasPeers
-    // array.
-    NCCLCHECKGOTO(ncclCalloc(&auxRasPeers, nRasPeers), ret, fail);
+      // Gather the stats on the number of processes per node.  However, that number is not a property of a peer,
+      // but of a group of peers, so calculating it is more involved.  We store the value in a temporary auxRasPeers
+      // array.
+      NCCLCHECKGOTO(ncclCalloc(&auxRasPeers, nRasPeers), ret, fail);
 
-    firstIdx = 0;
-    nPeers = 0;
-    for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
-      auxRasPeers[peerIdx].peer = rasPeers+peerIdx;
-      if (peerIdx == 0) {
-        nPeers = 1;
-        firstIdx = 0;
-      } else { // peerIdx > 0
-        if (!ncclSocketsSameNode(&auxRasPeers[peerIdx].peer->addr, &auxRasPeers[peerIdx-1].peer->addr)) {
-          TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
+      firstIdx = 0;
+      nPeers = 0;
+      for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+        auxRasPeers[peerIdx].peer = rasPeers+peerIdx;
+        if (peerIdx == 0) {
+          nPeers = 1;
+          firstIdx = 0;
+        } else { // peerIdx > 0
+          if (!ncclSocketsSameNode(&auxRasPeers[peerIdx].peer->addr, &auxRasPeers[peerIdx-1].peer->addr)) {
+            TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
                 ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)), nPeers);
-          for (int i = firstIdx; i < peerIdx; i++) {
-            // Go back and update the number of processes of all the elements of that node.
+            for (int i = firstIdx; i < peerIdx; i++) {
+              // Go back and update the number of processes of all the elements of that node.
+              auxRasPeers[i].value = nPeers;
+            }
+            nPeers = 1;
+            firstIdx = peerIdx;
+          } else {
+            nPeers++;
+          }
+        } // peerIdx > 0
+        if (peerIdx == nRasPeers-1) {
+          // Last iteration of the loop.
+          TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
+              ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)), nPeers);
+          for (int i = firstIdx; i < nRasPeers; i++) {
             auxRasPeers[i].value = nPeers;
           }
-          nPeers = 1;
-          firstIdx = peerIdx;
-        } else {
-          nPeers++;
         }
-      } // peerIdx > 0
-      if (peerIdx == nRasPeers-1) {
-        // Last iteration of the loop.
-        TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
-              ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)), nPeers);
-        for (int i = firstIdx; i < nRasPeers; i++) {
-          auxRasPeers[i].value = nPeers;
-        }
-      }
-    } // for (peerIdx)
+      } // for (peerIdx)
 
-    // Re-sort it now using the number of processes on the node (value) as the primary key, host IP as the
-    // secondary, and process id as the tertiary.
-    qsort(auxRasPeers, nRasPeers, sizeof(*auxRasPeers), rasAuxPeersValueCompare);
-
-    // Calculate the distribution of different numbers of peers per node.
-    nValCounts = 0;
-    for (int peerIdx = 0; peerIdx < nRasPeers;) {
-      if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx-1].value) {
-        valCounts[nValCounts].value = auxRasPeers[peerIdx].value;
-        valCounts[nValCounts].count = 1;
-        valCounts[nValCounts].firstIdx = peerIdx;
-        nValCounts++;
-      } else {
-        valCounts[nValCounts-1].count++;
-      }
-      // Advance peerIdx to the next node.
-      peerIdx += auxRasPeers[peerIdx].value;
-    } // for (peerIdx)
-    // valCounts is currently sorted by value (the number of peers per node).  Sort it by the count (most frequent
-    // number of peers first).
-    qsort(valCounts, nValCounts, sizeof(*valCounts), rasValCountsCompareRev);
-
-    // Print it out, the most frequent peer counts first.
-    if (consistentNGpusNode && consistentNGpusGlobal) {
-      // consistentNPeersGlobal must be false
-      rasOutAppend("  Nodes  Processes         GPUs\n"
-                   "          per node  per process\n");
-      for (int i = 0; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        rasOutAppend("%7d  %9ld  %11d\n",
-                     vc->count, vc->value, firstNGpusGlobal);
-      }
-    } else { // !consistentNGpusNode || !consistentNGpusGlobal
-      rasOutAppend("  Nodes  Processes\n"
-                   "          per node\n");
-      for (int i = 0; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        rasOutAppend("%7d  %9ld\n",
-                     vc->count, vc->value);
-      }
-
-      // We calculate and print the GPUs/process separately.  This is required for !consistentNGpusNode and
-      // it also makes our life easier above for !consistentNGpusGlobal (which could require a larger valCounts).
-
-      // Sort peers by the GPU count, to simplify data extraction.  Not sure how fast COMPILER_POPCOUNT64 is so we
-      // may just as well cache it...
-      for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
-        auxRasPeers[peerIdx].value = COMPILER_POPCOUNT64(auxRasPeers[peerIdx].peer->cudaDevs);
-        TRACE(NCCL_RAS, "RAS: node %s pid %d: nGpus %d",
-              ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
-              auxRasPeers[peerIdx].peer->pid, auxRasPeers[peerIdx].value);
-      }
-      // GPU count is the primary key, host IP is the secondary, and process id is the tertiary.
+      // Re-sort it now using the number of processes on the node (value) as the primary key, host IP as the
+      // secondary, and process id as the tertiary.
       qsort(auxRasPeers, nRasPeers, sizeof(*auxRasPeers), rasAuxPeersValueCompare);
 
-      // Calculate the distribution of different numbers of GPUs per peer.
+      // Calculate the distribution of different numbers of peers per node.
       nValCounts = 0;
-      for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+      for (int peerIdx = 0; peerIdx < nRasPeers;) {
         if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx-1].value) {
           valCounts[nValCounts].value = auxRasPeers[peerIdx].value;
           valCounts[nValCounts].count = 1;
@@ -754,55 +704,106 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
         } else {
           valCounts[nValCounts-1].count++;
         }
+        // Advance peerIdx to the next node.
+        peerIdx += auxRasPeers[peerIdx].value;
       } // for (peerIdx)
-      // valCounts is currently sorted by value (number of GPUs per peer).  Sort it by the count (most frequent
-      // GPU counts first).
+      // valCounts is currently sorted by value (the number of peers per node).  Sort it by the count (most frequent
+      // number of peers first).
       qsort(valCounts, nValCounts, sizeof(*valCounts), rasValCountsCompareRev);
 
-      // Print it out, the most frequent GPU counts first.
-      rasOutAppend("\n"
-                   "         Processes         GPUs\n"
-                   "                    per process\n");
-      for (int i = 0; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        rasOutAppend("         %9d  %11ld\n",
-                     vc->count, vc->value);
-      }
-    } // !consistentNGpusNode || !consistentNGpusGlobal
-    rasOutAppend("\n"
-                 "  Nodes  Processes         GPUs\n"
-                 "(total)    (total)      (total)\n"
-                 "%7d"  "  %9d"    "  %11d\n",
-                 totalNodes, nRasPeers, totalGpus);
+      // Print it out, the most frequent peer counts first.
+      if (consistentNGpusNode && consistentNGpusGlobal) {
+        // consistentNPeersGlobal must be false
+        rasOutAppend("  Nodes  Processes         GPUs\n"
+                     "          per node  per process\n");
+        for (int i = 0; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts+i;
+          rasOutAppend("%7d  %9ld  %11d\n",
+              vc->count, vc->value, firstNGpusGlobal);
+        }
+      } else { // !consistentNGpusNode || !consistentNGpusGlobal
+        rasOutAppend("  Nodes  Processes\n"
+                     "          per node\n");
+        for (int i = 0; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts+i;
+          rasOutAppend("%7d  %9ld\n",
+              vc->count, vc->value);
+        }
 
-    if (consistentNGpusNode && consistentNGpusGlobal) {
-      // In this simpler case, also print the node outliers.
-      for (int i = 1; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        // We assume that the most frequent group is correct; for the remaining ones, we try to provide more info,
-        // provided that they meet our definition of an outlier.
-        if (rasCountIsOutlier(vc->count, client->verbose, totalNodes)) {
-          rasOutAppend("\nThe outlier node%s:\n", (vc->count > 1 ? "s" : ""));
-          // auxRasPeers is sorted by the node IP address (not port!) as the secondary key and the pid as
-          // the tertiary, which comes in handy when printing...
-          for (int peerIdx = vc->firstIdx; peerIdx < vc->count*vc->value + vc->firstIdx; peerIdx += vc->value) {
-            lineBuf[0] = '\0';
-            for (int j = 0; j < vc->value; j++) {
-              snprintf(lineBuf+strlen(lineBuf), sizeof(lineBuf)-strlen(lineBuf), "%s%d",
-                       (j > 0 ? "," : ""), auxRasPeers[j].peer->pid);
-            }
-            rasOutAppend("  Node %s running process%s %s\n",
-                         ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
-                         (vc->value > 1 ? "es" : ""), lineBuf);
-          } // for (peerIdx)
-        } // if (rasCountIsOutlier(vc->count))
-      } // for (i)
+        // We calculate and print the GPUs/process separately.  This is required for !consistentNGpusNode and
+        // it also makes our life easier above for !consistentNGpusGlobal (which could require a larger valCounts).
+
+        // Sort peers by the GPU count, to simplify data extraction.  Not sure how fast COMPILER_POPCOUNT64 is so we
+        // may just as well cache it...
+        for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+          auxRasPeers[peerIdx].value = COMPILER_POPCOUNT64(auxRasPeers[peerIdx].peer->cudaDevs);
+          TRACE(NCCL_RAS, "RAS: node %s pid %d: nGpus %d",
+              ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
+              auxRasPeers[peerIdx].peer->pid, auxRasPeers[peerIdx].value);
+        }
+        // GPU count is the primary key, host IP is the secondary, and process id is the tertiary.
+        qsort(auxRasPeers, nRasPeers, sizeof(*auxRasPeers), rasAuxPeersValueCompare);
+
+        // Calculate the distribution of different numbers of GPUs per peer.
+        nValCounts = 0;
+        for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+          if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx-1].value) {
+            valCounts[nValCounts].value = auxRasPeers[peerIdx].value;
+            valCounts[nValCounts].count = 1;
+            valCounts[nValCounts].firstIdx = peerIdx;
+            nValCounts++;
+          } else {
+            valCounts[nValCounts-1].count++;
+          }
+        } // for (peerIdx)
+        // valCounts is currently sorted by value (number of GPUs per peer).  Sort it by the count (most frequent
+        // GPU counts first).
+        qsort(valCounts, nValCounts, sizeof(*valCounts), rasValCountsCompareRev);
+
+        // Print it out, the most frequent GPU counts first.
+        rasOutAppend("\n"
+                     "         Processes         GPUs\n"
+                     "                    per process\n");
+        for (int i = 0; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts+i;
+          rasOutAppend("         %9d  %11ld\n",
+              vc->count, vc->value);
+        }
+      } // !consistentNGpusNode || !consistentNGpusGlobal
+      rasOutAppend("\n"
+                   "  Nodes  Processes         GPUs\n"
+                   "(total)    (total)      (total)\n"
+                   "%7d"  "  %9d"    "  %11d\n",
+          totalNodes, nRasPeers, totalGpus);
+
+      if (consistentNGpusNode && consistentNGpusGlobal) {
+        // In this simpler case, also print the node outliers.
+        for (int i = 1; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts+i;
+          // We assume that the most frequent group is correct; for the remaining ones, we try to provide more info,
+          // provided that they meet our definition of an outlier.
+          if (rasCountIsOutlier(vc->count, client->verbose, totalNodes)) {
+            rasOutAppend("\nThe outlier node%s:\n", (vc->count > 1 ? "s" : ""));
+            // auxRasPeers is sorted by the node IP address (not port!) as the secondary key and the pid as
+            // the tertiary, which comes in handy when printing...
+            for (int peerIdx = vc->firstIdx; peerIdx < vc->count*vc->value + vc->firstIdx; peerIdx += vc->value) {
+              lineBuf[0] = '\0';
+              for (int j = 0; j < vc->value; j++) {
+                snprintf(lineBuf+strlen(lineBuf), sizeof(lineBuf)-strlen(lineBuf), "%s%d",
+                  (j > 0 ? "," : ""), auxRasPeers[j].peer->pid);
+              }
+              rasOutAppend("  Node %s running process%s %s\n",
+                  ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
+                  (vc->value > 1 ? "es" : ""), lineBuf);
+            } // for (peerIdx)
+          } // if (rasCountIsOutlier(vc->count))
+        } // for (i)
       } // !consistentNPeersGlobal
     } // !consistentNGpusNode || !consistentNGpusGlobal || !consistentNPeersGlobal
   } // TEXT format only
 
 #if 0 // Commented out for now to focus the summary status report on the information most relevant to the users.
-      // To be revisited with future extensions to RAS.
+  // To be revisited with future extensions to RAS.
   rasOutAppend("\nGathering data about the RAS network (timeout %lds)...", client->timeout / CLOCK_UNITS_PER_SEC);
   msgLen = rasOutLength();
   NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
@@ -848,7 +849,7 @@ fail:
 }
 
 #if 0 // Commented out for now to focus the summary status report on the information most relevant to the users.
-      // To be revisited with future extensions to RAS.
+// To be revisited with future extensions to RAS.
 // Processes the response from the RAS_COLL_CONNS collective operation and sends the data to the client (for now
 // primarily the list of missing processes).  Initiates the RAS_COLL_COMMS collective operation.
 static ncclResult_t rasClientRunConns(struct rasClient* client) {
@@ -870,14 +871,14 @@ static ncclResult_t rasClientRunConns(struct rasClient* client) {
   rasOutAppend(" obtained a result in %.3fs\n", (clockNano()-coll->startTime)/1e9);
   if (coll->nLegTimeouts > 0) {
     rasOutAppend(" Warning: encountered %d communication timeout%s while gathering data\n", coll->nLegTimeouts,
-                 (coll->nLegTimeouts > 1 ? "s" : ""));
+        (coll->nLegTimeouts > 1 ? "s" : ""));
   }
 
   expected = nRasPeers - nRasDeadPeers;
   if (coll->nPeers != expected) {
     int missing = expected - coll->nPeers;
     rasOutAppend(" Warning: missing data from %d process%s (received from %d, expected %d)\n",
-                 missing, (missing > 1 ? "es" : ""), coll->nPeers, expected);
+      missing, (missing > 1 ? "es" : ""), coll->nPeers, expected);
     if (missing <= RAS_CLIENT_DETAIL_THRESHOLD) {
       // Extract a list of missing peers.  We don't want to print it right away because it would be sorted
       // by address (including port, which isn't meaningful to end users).
@@ -909,24 +910,24 @@ static ncclResult_t rasClientRunConns(struct rasClient* client) {
       rasOutAppend("  The missing process%s:\n", (missing > 1 ? "es" : ""));
       for (int peerIdx = 0; peerIdx < nPeersBuf; peerIdx++) {
         rasOutAppend("  Process %d on node %s managing GPU%s %s\n", peersBuf[peerIdx].pid,
-                     ncclSocketToHost(&peersBuf[peerIdx].addr, rasLine, sizeof(rasLine)),
-                     (COMPILER_POPCOUNT64(peersBuf[peerIdx].cudaDevs) > 1 ? "s" : ""),
-                     rasGpuDevsToString(peersBuf[peerIdx].cudaDevs, peersBuf[peerIdx].nvmlDevs, lineBuf,
-                                        sizeof(lineBuf)));
+            ncclSocketToHost(&peersBuf[peerIdx].addr, rasLine, sizeof(rasLine)),
+            (COMPILER_POPCOUNT64(peersBuf[peerIdx].cudaDevs) > 1 ? "s" : ""),
+            rasGpuDevsToString(peersBuf[peerIdx].cudaDevs, peersBuf[peerIdx].nvmlDevs, lineBuf,
+                sizeof(lineBuf)));
       }
       if (nPeersBuf != missing)
         rasOutAppend("  [could not find information on %d process%s]\n",
-                     missing-nPeersBuf, (missing-nPeersBuf > 1 ? "es" : ""));
+            missing-nPeersBuf, (missing-nPeersBuf > 1 ? "es" : ""));
     } // if (expected - coll->nPeers <= RAS_CLIENT_DETAIL_THRESHOLD)
   } // if (coll->nPeers != expected)
 
   if (connsData->nConns > 0) {
     rasOutAppend(" Collected data about %d unidirectional connection%s\n",
-                 connsData->nConns, (connsData->nConns > 1 ? "s" : ""));
+        connsData->nConns, (connsData->nConns > 1 ? "s" : ""));
     rasOutAppend(" Travel times (valid only if system clocks are synchronized between nodes):\n"
                  "  Minimum %.3fs, maximum %.3fs, average %.3fs\n",
-                 connsData->travelTimeMin/1e9, connsData->travelTimeMax/1e9,
-                 connsData->travelTimeSum/(1e9*connsData->travelTimeCount));
+      connsData->travelTimeMin/1e9, connsData->travelTimeMax/1e9,
+      connsData->travelTimeSum/(1e9*connsData->travelTimeCount));
   } else {
     rasOutAppend(" No connection data collected!\n");
   }
@@ -934,7 +935,7 @@ static ncclResult_t rasClientRunConns(struct rasClient* client) {
     rasOutAppend(" Warning: negative travel times were observed across %d connection%s,\n"
                  " indicating that the system clocks are *not* synchronized.\n"
                  " Ordering of events based on local timestamps should be considered unreliable\n",
-                 connsData->nNegativeMins, (connsData->nNegativeMins > 1 ? "s" : ""));
+        connsData->nNegativeMins, (connsData->nNegativeMins > 1 ? "s" : ""));
     if (connsData->nNegativeMins <= RAS_CLIENT_DETAIL_THRESHOLD) {
       rasOutAppend("  The affected connection%s:\n", (connsData->nNegativeMins > 1 ? "s" : ""));
       for (int i = 0; i < connsData->nNegativeMins; i++) {
@@ -943,16 +944,16 @@ static ncclResult_t rasClientRunConns(struct rasClient* client) {
         int destPeerIdx = rasPeerFind(&negativeMin->dest);
         if (sourcePeerIdx != -1 && destPeerIdx != -1)
           rasOutAppend("  From node %s process %d to node %s process %d: observed travel time of %.3fs\n",
-                       ncclSocketToHost(&negativeMin->source, rasLine, sizeof(rasLine)), rasPeers[sourcePeerIdx].pid,
-                       ncclSocketToHost(&negativeMin->dest, lineBuf, sizeof(lineBuf)), rasPeers[destPeerIdx].pid,
-                       negativeMin->travelTimeMin/1e9);
+              ncclSocketToHost(&negativeMin->source, rasLine, sizeof(rasLine)), rasPeers[sourcePeerIdx].pid,
+              ncclSocketToHost(&negativeMin->dest, lineBuf, sizeof(lineBuf)), rasPeers[destPeerIdx].pid,
+              negativeMin->travelTimeMin/1e9);
       }
     }
   }
   rasCollFree(coll);
 
   rasOutAppend("\nGathering data about the NCCL communicators (timeout %lds)...",
-               client->timeout / CLOCK_UNITS_PER_SEC);
+    client->timeout / CLOCK_UNITS_PER_SEC);
   msgLen = rasOutLength();
   NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
   rasOutExtract(msg);
@@ -1011,7 +1012,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
   TRACE(NCCL_RAS, "RAS: rasClientRunComms: starting");
   TRACE(NCCL_RAS, "RAS: coll nLegTimeouts %d, nPeers %d, nData %d; commsData nComms %d",
-        coll->nLegTimeouts, coll->nPeers, coll->nData, commsData->nComms);
+      coll->nLegTimeouts, coll->nPeers, coll->nData, commsData->nComms);
 
   if (coll == nullptr || coll->nFwdSent != coll->nFwdRecv) {
     INFO(NCCL_RAS, "RAS invalid collective operation status; client status %d -- internal error?", client->status);
@@ -1038,7 +1039,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       maxCommSize = comm->commNRanks;
     auxComms[commIdx].comm = comm;
     comm = (struct rasCollComms::comm*)(((char*)(comm+1)) + comm->nRanks * sizeof(*comm->ranks) +
-                                        comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
+      comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
   }
   NCCLCHECKGOTO(ncclCalloc(&auxCommRanks, maxCommSize), ret, fail);
   TRACE(NCCL_RAS, "RAS: maxCommSize %d", maxCommSize);
@@ -1073,8 +1074,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
     int nRanks = 0;
     comm = auxComm->comm;
     TRACE(NCCL_RAS, "RAS: coll comms[%d]: commId (0x%lx, 0x%lx, 0x%lx), commNRanks %d, nRanks %d, nMissingRanks %d",
-          commIdx, comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash,
-          comm->commNRanks, comm->nRanks, comm->nMissingRanks);
+      commIdx, comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash,
+      comm->commNRanks, comm->nRanks, comm->nMissingRanks);
 
     if (comm->nMissingRanks > 0) {
       // There are two possibilities here.  Either we are missing the data on some ranks because the processes are
@@ -1094,7 +1095,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
           struct rasCollCommsMissingRank* missingRank = missingRanks + rankIdx;
           void* found;
           if ((found = bsearch(&missingRank->addr, coll->peers, coll->nPeers, sizeof(*coll->peers),
-                               ncclSocketsCompare)) != nullptr) {
+            ncclSocketsCompare)) != nullptr) {
             // We did receive the data from that process, but not about this communicator.
             auxComm->errors |= RAS_ACE_MISMATCH;
             auxComm->status |= RAS_ACS_NOCOMM;
@@ -1104,8 +1105,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
             auxComm->nIncompleteRanks++;
           }
           TRACE(NCCL_RAS, "RAS: comm missingRank[%d] commRank %d, addr %td (-> %d), cudaDev %d, nvmlDev %d",
-                rankIdx, missingRank->commRank, (found ? ((union ncclSocketAddress*)found) - coll->peers: -1),
-                rasPeerFind(&missingRank->addr), missingRank->cudaDev, missingRank->nvmlDev);
+            rankIdx, missingRank->commRank, (found ? ((union ncclSocketAddress*)found) - coll->peers: -1),
+            rasPeerFind(&missingRank->addr), missingRank->cudaDev, missingRank->nvmlDev);
         } // for (rankIdx)
       } // nPeersMissing > 0 || nRasDeadPeers > 0
     } // if (comm->nMissingRanks > 0)
@@ -1117,13 +1118,13 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       auxCommRanks[rankIdx].rank = rank;
       auxCommRanks[rankIdx].value = peerIdxConv[rank->peerIdx];
       TRACE(NCCL_RAS, "RAS: comm rank[%d] commRank %d, peerIdx %d (-> %d), cudaDev %d, nvmlDev %d",
-            rankIdx, rank->commRank, rank->peerIdx, peerIdxConv[rank->peerIdx], rank->cudaDev, rank->nvmlDev);
+        rankIdx, rank->commRank, rank->peerIdx, peerIdxConv[rank->peerIdx], rank->cudaDev, rank->nvmlDev);
       TRACE(NCCL_RAS, "RAS: comm rank[%d] collOpCounts (%ld, %ld, %ld, %ld, %ld)",
-            rankIdx, rank->collOpCounts[0], rank->collOpCounts[1], rank->collOpCounts[2], rank->collOpCounts[3],
-            rank->collOpCounts[4]);
+        rankIdx, rank->collOpCounts[0], rank->collOpCounts[1], rank->collOpCounts[2], rank->collOpCounts[3],
+        rank->collOpCounts[4]);
       TRACE(NCCL_RAS, "RAS: comm rank[%d] status initState %d, asyncError %d, finalizeCalled %d, destroyFlag %d, "
-            "abortFlag %d", rankIdx, rank->status.initState, rank->status.asyncError, rank->status.finalizeCalled,
-            rank->status.destroyFlag, rank->status.abortFlag); /**/
+                      "abortFlag %d", rankIdx, rank->status.initState, rank->status.asyncError, rank->status.finalizeCalled,
+          rank->status.destroyFlag, rank->status.abortFlag); /**/
     }
     // This also sorts by the commRank, which we don't care about here, but it won't hurt.
     qsort(auxCommRanks, comm->nRanks, sizeof(*auxCommRanks), rasAuxCommRanksValueCompare);
@@ -1167,8 +1168,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
         // ncclCommFinalize first.  The code structure here ensures that we attribute destroyFlag properly
         // as a finalize state indicator (and ignore it in case of ncclCommAbort).
         auxComm->status |= RAS_ACS_FINALIZE;
-      }
-      else if (auxRank->rank->status.initState == ncclSuccess)
+      } else if (auxRank->rank->status.initState == ncclSuccess)
         auxComm->status |= RAS_ACS_RUNNING;
       else // auxRank->rank->initState != ncclSuccess
         auxComm->status |= RAS_ACS_INIT;
@@ -1188,9 +1188,9 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       auxComm->errors |= RAS_ACE_MISMATCH;
     }
     TRACE(NCCL_RAS, "RAS: auxComm nPeers %d, nNodes %d, nIncompleteRanks %d",
-          auxComm->nPeers, auxComm->nNodes, auxComm->nIncompleteRanks);
+        auxComm->nPeers, auxComm->nNodes, auxComm->nIncompleteRanks);
     TRACE(NCCL_RAS, "RAS: auxComm ranksPerNodeMin %d, ranksPerNodeMax %d, status 0x%x, errors 0x%x",
-          auxComm->ranksPerNodeMin, auxComm->ranksPerNodeMax, auxComm->status, auxComm->errors);
+        auxComm->ranksPerNodeMin, auxComm->ranksPerNodeMax, auxComm->status, auxComm->errors);
   } // for (commIdx)
   // Sort it by size/nNodes/status/errors/missing ranks.
   if (auxComms)
@@ -1207,7 +1207,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
         COMPILER_CLZ(auxComms[commIdx].status) != COMPILER_CLZ(auxComms[commIdx-1].status) ||
         auxComms[commIdx].errors != auxComms[commIdx-1].errors) {
       valCounts[nValCounts].value = 0; // We have many distinguishing values but only one field to store them.
-                                       // It doesn't really matter, given that we can extract them via firstIdx.
+      // It doesn't really matter, given that we can extract them via firstIdx.
       valCounts[nValCounts].count = 1;
       valCounts[nValCounts].firstIdx = commIdx;
       nValCounts++;
@@ -1229,7 +1229,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   NCCLCHECKGOTO(ncclCalloc(&peerNvmlDevs, coll->nPeers), ret, fail);
 
   // Print it out, the largest communicators first.
-  for (int vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
+  for (vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
     struct rasValCount* vc = valCounts+vcIdx;
     struct rasAuxComm* auxComm = auxComms+vc->firstIdx;
     int ranksPerNodeMin, ranksPerNodeMax;
@@ -1259,10 +1259,10 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
     else
       snprintf(rasLine, sizeof(rasLine), "%d-%d", ranksPerNodeMin, ranksPerNodeMax);
     rasOutAppend("%5d  %8d  %8d  %8s  %8d  %8d  %8s  %6s\n",
-                 vcIdx, vc->count, auxComm->nNodes, rasLine, auxComm->comm->commNRanks, ranksTotal,
-                 // COMPILER_CLZ returns the number of leading 0-bits.  This makes it possible to translate the
-                 // status (which is a bitmask) into an array index.
-                 statusStr[(sizeof(unsigned int)*8-1)-COMPILER_CLZ(auxComm->status)], errorStr[auxComm->errors]);
+        vcIdx, vc->count, auxComm->nNodes, rasLine, auxComm->comm->commNRanks, ranksTotal,
+        // COMPILER_CLZ returns the number of leading 0-bits.  This makes it possible to translate the
+        // status (which is a bitmask) into an array index.
+        statusStr[(sizeof(unsigned int)*8-1)-COMPILER_CLZ(auxComm->status)], errorStr[auxComm->errors]);
   }
   msgLen = rasOutLength();
   NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
@@ -1305,17 +1305,17 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
               auxPeersBuf[nPeersBuf++].peer = rasPeers+rasPeerIdx;
             } else {
               INFO(NCCL_RAS, "RAS overflow of auxPeersBuf: nPeersBuf %d, rasPeerIdx %d (%s), collPeerIdx %d -- "
-                   "internal error?",
-                   nPeersBuf, rasPeerIdx, ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), collPeerIdx);
+                             "internal error?",
+                nPeersBuf, rasPeerIdx, ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), collPeerIdx);
             }
           }
           TRACE(NCCL_RAS, "RAS rasPeerIdx %d (%s) is missing from coll->peers; dead %d",
-                rasPeerIdx, ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), dead);
+            rasPeerIdx, ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), dead);
           rasPeerIdx++;
         } else { // cmp > 0
           // Process not found in rasPeers -- shouldn't happen, unless during a race?
           INFO(NCCL_RAS, "RAS failed to find coll->peer[%d] (%s) in rasPeers -- internal error?",
-               collPeerIdx, ncclSocketToString(coll->peers+collPeerIdx, rasLine));
+            collPeerIdx, ncclSocketToString(coll->peers+collPeerIdx, rasLine));
           collPeerIdx++;
         } // cmp > 0
       } // for (rasPeerIdx, collPeerIdx)
@@ -1326,14 +1326,14 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       for (int peerIdx = 0; peerIdx < nPeersBuf; peerIdx++) {
         struct rasAuxPeerInfo* auxPeer = auxPeersBuf+peerIdx;
         rasOutAppend("  Process %d on node %s managing GPU%s %s\n", auxPeer->peer->pid,
-                     ncclSocketToHost(&auxPeer->peer->addr, rasLine, sizeof(rasLine)),
-                     (COMPILER_POPCOUNT64(auxPeer->peer->cudaDevs) > 1 ? "s" : ""),
-                     rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf,
-                                        sizeof(lineBuf)));
+            ncclSocketToHost(&auxPeer->peer->addr, rasLine, sizeof(rasLine)),
+            (COMPILER_POPCOUNT64(auxPeer->peer->cudaDevs) > 1 ? "s" : ""),
+            rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf,
+                sizeof(lineBuf)));
       }
       if (nPeersBuf != nPeersMissing)
         rasOutAppend("  [could not find information on %d process%s]\n",
-                     nPeersMissing-nPeersBuf, (nPeersMissing-nPeersBuf > 1 ? "es" : ""));
+            nPeersMissing-nPeersBuf, (nPeersMissing-nPeersBuf > 1 ? "es" : ""));
       free(auxPeersBuf);
     } // if (rasCountIsOutlier(nPeersMissing))
     rasOutAppend("\n");
@@ -1342,7 +1342,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   if (nRasDeadPeers > 0) {
     rasOutAppend("DEAD\n"
                  "  %d job process%s considered dead (unreachable via the RAS network)\n", nRasDeadPeers,
-                 (nRasDeadPeers > 1 ? "es are" : " is"));
+        (nRasDeadPeers > 1 ? "es are" : " is"));
     if (rasCountIsOutlier(nRasDeadPeers, client->verbose)) {
       // rasDeadPeers contains only addresses, whereas we want a complete rasPeerInfo, and sorted differently.
       struct rasAuxPeerInfo* auxPeersBuf = nullptr;
@@ -1359,14 +1359,14 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       for (int peerIdx = 0; peerIdx < nPeersBuf; peerIdx++) {
         struct rasAuxPeerInfo* auxPeer = auxPeersBuf+peerIdx;
         rasOutAppend("  Process %d on node %s managing GPU%s %s\n", auxPeer->peer->pid,
-                     ncclSocketToHost(&auxPeer->peer->addr, rasLine, sizeof(rasLine)),
-                     (COMPILER_POPCOUNT64(auxPeer->peer->cudaDevs) > 1 ? "s" : ""),
-                     rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf,
-                                        sizeof(lineBuf)));
+            ncclSocketToHost(&auxPeer->peer->addr, rasLine, sizeof(rasLine)),
+            (COMPILER_POPCOUNT64(auxPeer->peer->cudaDevs) > 1 ? "s" : ""),
+            rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf,
+                sizeof(lineBuf)));
       }
       if (nPeersBuf != nRasDeadPeers)
         rasOutAppend("  [could not find information on %d process%s]\n",
-                     nRasDeadPeers-nPeersBuf, (nRasDeadPeers-nPeersBuf > 1 ? "es" : ""));
+            nRasDeadPeers-nPeersBuf, (nRasDeadPeers-nPeersBuf > 1 ? "es" : ""));
       free(auxPeersBuf);
     } // if (rasCountIsOutlier(nRasDeadPeers)
     rasOutAppend("\n");
@@ -1382,22 +1382,22 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
       if (auxComm->errors & RAS_ACE_INCOMPLETE) {
         rasOutAppend("#%d-%d (%016lx) INCOMPLETE\n"
-                     "  Missing communicator data from %d rank%s\n", vcIdx, commIdx - vc->firstIdx,
-                     comm->commId.commHash, auxComm->nIncompleteRanks, (auxComm->nIncompleteRanks > 1 ? "s" : ""));
+          "  Missing communicator data from %d rank%s\n", vcIdx, commIdx - vc->firstIdx,
+          comm->commId.commHash, auxComm->nIncompleteRanks, (auxComm->nIncompleteRanks > 1 ? "s" : ""));
         if (rasCountIsOutlier(auxComm->nIncompleteRanks, client->verbose)) {
           struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks+comm->nRanks);
           for (int rankIdx = 0; rankIdx < comm->nMissingRanks; rankIdx++) {
             struct rasCollCommsMissingRank* missingRank = missingRanks + rankIdx;
             // Filter out ranks that provided a response but not for this communicator.
             if (bsearch(&missingRank->addr, coll->peers, coll->nPeers, sizeof(*coll->peers), ncclSocketsCompare) ==
-                nullptr) {
+              nullptr) {
               int peerIdx = rasPeerFind(&missingRank->addr);
               if (peerIdx != -1) {
                 rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                             missingRank->commRank,
-                             rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev, lineBuf, sizeof(lineBuf)),
-                             rasPeers[peerIdx].pid,
-                             ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
+                    missingRank->commRank,
+                    rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev, lineBuf, sizeof(lineBuf)),
+                    rasPeers[peerIdx].pid,
+                    ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
               } else {
                 rasOutAppend("  Rank %d -- [process information not found]\n", missingRank->commRank);
               }
@@ -1418,7 +1418,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
         nErrors = comm->nRanks - (ncclErrors[ncclSuccess] + ncclErrors[ncclInProgress]);
         if (nErrors > 0) {
           rasOutAppend("  Initialization error%s on %d rank%s\n",
-                       (nErrors > 1 ? "s" : ""), nErrors, (nErrors > 1 ? "s" : ""));
+              (nErrors > 1 ? "s" : ""), nErrors, (nErrors > 1 ? "s" : ""));
           rasClientBreakDownErrors(client, comm, peerIdxConv, ncclErrors);
         }
 
@@ -1428,7 +1428,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
         nErrors = comm->nRanks - (ncclErrors[ncclSuccess] + ncclErrors[ncclInProgress]);
         if (nErrors > 0) {
           rasOutAppend("  Asynchronous error%s on %d rank%s\n",
-                       (nErrors > 1 ? "s" : ""), nErrors, (nErrors > 1 ? "s" : ""));
+              (nErrors > 1 ? "s" : ""), nErrors, (nErrors > 1 ? "s" : ""));
           rasClientBreakDownErrors(client, comm, peerIdxConv, ncclErrors, /*isAsync*/true);
         }
         rasOutAppend("\n");
@@ -1447,11 +1447,11 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   if (coll->nLegTimeouts > 0) {
     rasOutAppend("TIMEOUT\n"
                  "  Encountered %d communication timeout%s while gathering communicator data\n\n",
-                 coll->nLegTimeouts, (coll->nLegTimeouts > 1 ? "s" : ""));
+        coll->nLegTimeouts, (coll->nLegTimeouts > 1 ? "s" : ""));
   }
 
   // Continue printing the largest communicators first, as in the summary table.
-  for (int vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
+  for (vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
     struct rasValCount* vc = valCounts+vcIdx;
     for (int commIdx = vc->firstIdx; commIdx < vc->count + vc->firstIdx; commIdx++) {
       struct rasAuxComm* auxComm = auxComms+commIdx;
@@ -1495,7 +1495,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
               // status (which is a bitmask) into an array index.  The argument is an unsigned int (there is no
               // 64-bit version seemingly, but we don't actually need one here).
               collOpCounts[nCollOpCounts].value =
-                (sizeof(unsigned int)*8-1) - COMPILER_CLZ((unsigned int)auxCommRanks[rankIdx].value);
+                  (sizeof(unsigned int)*8-1) - COMPILER_CLZ((unsigned int)auxCommRanks[rankIdx].value);
               collOpCounts[nCollOpCounts].count = 1;
               collOpCounts[nCollOpCounts].firstIdx = rankIdx;
               nCollOpCounts++;
@@ -1525,55 +1525,55 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
                   if (peerIdx != -1) {
                     if (vcc->count > 1)
                       rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                                   auxCommRanks[rankIdx].rank->commRank,
-                                   rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
-                                   rasPeers[peerIdx].pid,
-                                   ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                          auxCommRanks[rankIdx].rank->commRank,
+                          rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
+                          rasPeers[peerIdx].pid,
+                          ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
                     else
                       rasOutAppend("  Rank %d has status %s -- GPU %s managed by process %d on node %s\n",
-                                   auxCommRanks[rankIdx].rank->commRank, statusStr[vcc->value],
-                                   rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
-                                   rasPeers[peerIdx].pid,
-                                   ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                          auxCommRanks[rankIdx].rank->commRank, statusStr[vcc->value],
+                          rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
+                          rasPeers[peerIdx].pid,
+                          ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
                   } else { // peerIdx == -1
                     if (vcc->count > 1)
                       rasOutAppend("  Rank %d -- [process information not found]\n",
-                                   auxCommRanks[rankIdx].rank->commRank);
+                          auxCommRanks[rankIdx].rank->commRank);
                     else
                       rasOutAppend("  Rank %d has status %s -- [process information not found]\n",
-                                   auxCommRanks[rankIdx].rank->commRank, statusStr[vcc->value]);
+                          auxCommRanks[rankIdx].rank->commRank, statusStr[vcc->value]);
                   } // peerIdx == -1
                 } // for (rankIdx)
               } else {
                 // NOCOMM ranks are in a different array.
                 struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks +
-                                                                                                 comm->nRanks);
+                  comm->nRanks);
                 for (int rankIdx = 0; rankIdx < comm->nMissingRanks; rankIdx++) {
                   struct rasCollCommsMissingRank* missingRank = missingRanks + rankIdx;
                   // Filter out ranks that did not respond at all.
                   if (bsearch(&missingRank->addr, coll->peers, coll->nPeers, sizeof(*coll->peers),
-                              ncclSocketsCompare)) {
+                    ncclSocketsCompare)) {
                     int peerIdx = rasPeerFind(&missingRank->addr);
                     if (peerIdx != -1) {
                       if (vcc->count > 1) {
                         rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                                     missingRank->commRank, rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev,
-                                                                           lineBuf, sizeof(lineBuf)),
-                                     rasPeers[peerIdx].pid,
-                                     ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
+                            missingRank->commRank, rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev,
+                                lineBuf, sizeof(lineBuf)),
+                            rasPeers[peerIdx].pid,
+                            ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
                       } else {
                         rasOutAppend("  Rank %d has status %s -- GPU %s managed by process %d on node %s\n",
-                                     missingRank->commRank, statusStr[vcc->value],
-                                     rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev,
-                                                    lineBuf, sizeof(lineBuf)), rasPeers[peerIdx].pid,
-                                     ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
+                            missingRank->commRank, statusStr[vcc->value],
+                            rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev,
+                                lineBuf, sizeof(lineBuf)), rasPeers[peerIdx].pid,
+                            ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
                       }
                     } else { // peerIdx == -1
                       if (vcc->count > 1) {
                         rasOutAppend("  Rank %d -- [process information not found]\n", missingRank->commRank);
                       } else {
                         rasOutAppend("  Rank %d has status %s -- [process information not found]\n",
-                                     missingRank->commRank, statusStr[vcc->value]);
+                            missingRank->commRank, statusStr[vcc->value]);
                       }
                     } // peerIdx == -1
                   } // if rank responded
@@ -1634,36 +1634,36 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
                   if (peerIdx != -1) {
                     if (vcc->count > 1) {
                       rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                                   auxCommRanks[rankIdx].rank->commRank,
-                                   rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
-                                   rasPeers[peerIdx].pid,
-                                   ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                          auxCommRanks[rankIdx].rank->commRank,
+                          rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
+                          rasPeers[peerIdx].pid,
+                          ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
                     } else {
                       if (vcc->value > 0) {
                         rasOutAppend("  Rank %d has launched up to operation %ld -- GPU %s managed by process %d "
                                      "on node %s\n", auxCommRanks[rankIdx].rank->commRank, vcc->value,
-                                     rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
-                                     rasPeers[peerIdx].pid,
-                                     ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                            rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
+                            rasPeers[peerIdx].pid,
+                            ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
                       } else {
                         rasOutAppend("  Rank %d has not launched any operations -- GPU %s managed by process %d "
                                      "on node %s\n", auxCommRanks[rankIdx].rank->commRank,
-                                     rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
-                                     rasPeers[peerIdx].pid,
-                                     ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                            rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
+                            rasPeers[peerIdx].pid,
+                            ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
                       }
                     }
                   } else { // peerIdx == -1
                     if (vcc->count > 1) {
                       rasOutAppend("  Rank %d -- [process information not found]\n",
-                                   auxCommRanks[rankIdx].rank->commRank);
+                          auxCommRanks[rankIdx].rank->commRank);
                     } else {
                       if (vcc->value > 0)
                         rasOutAppend("  Rank %d has launched up to operation %ld -- [process information not found]\n",
-                                     auxCommRanks[rankIdx].rank->commRank, vcc->value);
+                            auxCommRanks[rankIdx].rank->commRank, vcc->value);
                       else
                         rasOutAppend("  Rank %d has not launched any operations -- [process information not found]\n",
-                                     auxCommRanks[rankIdx].rank->commRank);
+                            auxCommRanks[rankIdx].rank->commRank);
                     }
                   } // peerIdx == -1
                 } // for (rankIdx)
@@ -1698,7 +1698,7 @@ fail:
 
 // Generates detailed info about encountered errors, be it initialization ones or asynchronous ones.
 static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollComms::comm* comm,
-                                     const int* peerIdxConv, int ncclErrors[ncclNumResults], bool isAsync) {
+    const int* peerIdxConv, int ncclErrors[ncclNumResults], bool isAsync) {
   // Because the number of possible error kinds is finite and small, we don't bother in this case with allocating
   // temporary data structures, counting the errors, sorting arrays, etc.  Instead, in each iteration we pick the most
   // numerous error kind, we iterate through the ranks in search for this error, and immediately add it to the output.
@@ -1722,22 +1722,22 @@ static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollCom
           if (peerIdx != -1) {
             if (maxCount > 1)
               rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                           comm->ranks[rankIdx].commRank,
-                           rasCommRankGpuToString(comm->ranks+rankIdx, lineBuf, sizeof(lineBuf)),
-                           rasPeers[peerIdx].pid,
-                           ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                  comm->ranks[rankIdx].commRank,
+                  rasCommRankGpuToString(comm->ranks+rankIdx, lineBuf, sizeof(lineBuf)),
+                  rasPeers[peerIdx].pid,
+                  ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
             else
               rasOutAppend("  Rank %d reported %s -- GPU %s managed by process %d on node %s\n",
-                           comm->ranks[rankIdx].commRank, ncclErrorToString(maxCountIdx),
-                           rasCommRankGpuToString(comm->ranks+rankIdx, lineBuf, sizeof(lineBuf)),
-                           rasPeers[peerIdx].pid,
-                           ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                  comm->ranks[rankIdx].commRank, ncclErrorToString(maxCountIdx),
+                  rasCommRankGpuToString(comm->ranks+rankIdx, lineBuf, sizeof(lineBuf)),
+                  rasPeers[peerIdx].pid,
+                  ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
           } else { // peerIdx == -1
             if (maxCount > 1)
               rasOutAppend("  Rank %d -- [process information not found]\n", comm->ranks[rankIdx].commRank);
             else
               rasOutAppend("  Rank %d reported %s -- [process information not found]\n",
-                           comm->ranks[rankIdx].commRank, ncclErrorToString(maxCountIdx));
+                  comm->ranks[rankIdx].commRank, ncclErrorToString(maxCountIdx));
           } // peerIdx == -1
         } // if rank's error matches
       } // for (rankIdx)
@@ -1852,8 +1852,7 @@ static int ncclSocketsHostCompare(const void* p1, const void* p2) {
   int cmp;
   if (family == AF_INET) {
     cmp = memcmp(&a1->sin.sin_addr, &a2->sin.sin_addr, sizeof(a1->sin.sin_addr));
-  }
-  else if (family == AF_INET6) {
+  } else if (family == AF_INET6) {
     cmp = memcmp(&a1->sin6.sin6_addr, &a2->sin6.sin6_addr, sizeof(a1->sin6.sin6_addr));
   } else {
     // The only remaining valid case are empty addresses.
@@ -1936,7 +1935,7 @@ static int rasAuxCommRanksValueCompare(const void* p1, const void* p2) {
 
 // Writes the JSON document header with metadata and opens the communicators array.
 static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDriver,
-                            const char* timestamp, int commsCount) {
+    const char* timestamp, int commsCount) {
   rasOutAppend("{\n");
   rasOutAppend("  \"nccl_version\": \"%s\",\n", ncclVersion);
   rasOutAppend("  \"cuda_runtime_version\": %d,\n", cudaRuntime);
@@ -1948,7 +1947,7 @@ static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDr
 
 // Starts a new communicator entry in the JSON output.
 static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash, unsigned long pidHash,
-                                  int commSize, int ranksCount, int missingCount, bool firstComm) {
+    int commSize, int ranksCount, int missingCount, bool firstComm) {
   if (!firstComm) rasOutAppend(",\n");
   rasOutAppend("    {\n");
   rasOutAppend("      \"hash\": \"0x%lx\",\n", commHash);
@@ -1961,8 +1960,8 @@ static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash
 
 // Writes detailed rank information including status and collective operation counts.
 static void jsonWriteRankData(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                              int initState, int asyncError, bool finalizeCalled, bool destroyFlag,
-                              bool abortFlag, const unsigned long* collCounts, bool firstRank) {
+    int initState, int asyncError, bool finalizeCalled, bool destroyFlag,
+    bool abortFlag, const unsigned long* collCounts, bool firstRank) {
   if (!firstRank) rasOutAppend(",\n");
   rasOutAppend("        {\n");
   rasOutAppend("          \"rank\": %d,\n", rank);
@@ -2001,7 +2000,7 @@ static void jsonStartMissingRanks() {
 
 // Writes basic information for a missing rank.
 static void jsonWriteMissingRank(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                                 bool unresponsive, bool dead, bool firstMissing) {
+    bool unresponsive, bool dead, bool firstMissing) {
   if (!firstMissing) rasOutAppend(",\n");
   rasOutAppend("        {\n");
   rasOutAppend("          \"rank\": %d,\n", rank);
@@ -2095,8 +2094,8 @@ static const char* ncclErrorToString(ncclResult_t err) {
 const char* ncclSocketToHost(const union ncclSocketAddress* addr, char* buf, size_t size) {
   if (addr->sa.sa_family > 0)
     return inet_ntop(addr->sa.sa_family,
-                     (addr->sa.sa_family == AF_INET ? (void*)&addr->sin.sin_addr : (void*)&addr->sin6.sin6_addr),
-                     buf, size);
+            (addr->sa.sa_family == AF_INET ? (void*)&addr->sin.sin_addr : (void*)&addr->sin6.sin6_addr),
+            buf, size);
   else {
     if (size > 0)
       buf[0] = '\0';
@@ -2105,8 +2104,8 @@ const char* ncclSocketToHost(const union ncclSocketAddress* addr, char* buf, siz
 }
 
 // Dump communicator data to JSON format - build JSON in output buffer.
-static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* commsData,
-                               struct rasCollective* coll, const int* peerIdxConv) {
+static void rasDumpCommsToJSON(struct rasClient* /*client*/, struct rasCollComms* commsData,
+    struct rasCollective* coll, const int* peerIdxConv) {
   char hostBuf[256], timeBuf[64];
 
   time_t timestampSec = time(NULL);
@@ -2116,14 +2115,14 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
 
   // Write JSON header with metadata.
   jsonWriteHeader(STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX,
-                  cudaRuntimeVersion, cudaDriverVersion, timeBuf, commsData->nComms);
+    cudaRuntimeVersion, cudaDriverVersion, timeBuf, commsData->nComms);
 
   struct rasCollComms::comm* comm = commsData->comms;
 
   // Iterate through communicators.
   for (int commIdx = 0; commIdx < commsData->nComms; commIdx++) {
     jsonStartCommunicator(comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash,
-                          comm->commNRanks, comm->nRanks, comm->nMissingRanks, (commIdx == 0));
+        comm->commNRanks, comm->nRanks, comm->nMissingRanks, (commIdx == 0));
 
     // Add each rank.
     for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
@@ -2139,9 +2138,9 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
       }
 
       jsonWriteRankData(rank->commRank, host, pid, rank->cudaDev, rank->nvmlDev,
-                        rank->status.initState, rank->status.asyncError,
-                        rank->status.finalizeCalled, rank->status.destroyFlag, rank->status.abortFlag,
-                        rank->collOpCounts, (rankIdx == 0));
+          rank->status.initState, rank->status.asyncError,
+          rank->status.finalizeCalled, rank->status.destroyFlag, rank->status.abortFlag,
+          rank->collOpCounts, (rankIdx == 0));
     }
 
     // Start missing ranks section.
@@ -2157,7 +2156,7 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
       const char* host = "unknown";
       int pid = -1;
       bool unresponsive = (bsearch(&missingRank->addr, coll->peers, coll->nPeers, sizeof(*coll->peers),
-                                   ncclSocketsCompare) == nullptr);
+        ncclSocketsCompare) == nullptr);
       bool dead = rasPeerIsDead(&missingRank->addr);
       if (rasPeerIdx >= 0) {
         host = ncclSocketToHost(&rasPeers[rasPeerIdx].addr, hostBuf, sizeof(hostBuf));
@@ -2165,14 +2164,14 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
       }
 
       jsonWriteMissingRank(missingRank->commRank, host, pid, missingRank->cudaDev, missingRank->nvmlDev,
-                           unresponsive, dead, (missingIdx == 0));
+          unresponsive, dead, (missingIdx == 0));
     }
 
     jsonEndCommunicator();
 
     // Move to the next communicator.
     comm = (struct rasCollComms::comm*)(((char*)(comm+1)) + comm->nRanks * sizeof(*comm->ranks) +
-                                        comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
+      comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
   }
 
   // Write JSON footer with RAS metadata.
@@ -2187,7 +2186,7 @@ static bool rasCountIsOutlier(int count, bool verbose, int totalCount) {
     return (totalCount != -1 ? count < totalCount * RAS_CLIENT_VERBOSE_OUTLIER_FRACTION : true);
   } else {
     return count <= RAS_CLIENT_DETAIL_THRESHOLD &&
-           (totalCount == -1 || count <= totalCount * RAS_CLIENT_OUTLIER_FRACTION);
+        (totalCount == -1 || count <= totalCount * RAS_CLIENT_OUTLIER_FRACTION);
   }
 }
 
@@ -2242,43 +2241,43 @@ void rasClientsNotifyEvent(rasEventGroup group, const struct rasEventNotificatio
           }
           snprintf(nvmlDevs + offset, sizeof(nvmlDevs) - offset, "]");
           snprintf(formattedNotification, sizeof(formattedNotification),
-                   "{\n"
-                   "  \"timestamp\": \"%s\",\n"
-                   "  \"group\": \"%s\",\n"
-                   "  \"event\": \"%s\",\n"
-                   "  \"peer\": {\n"
-                   "    \"host\": \"%s\",\n"
-                   "    \"pid\": %d,\n"
-                   "    \"cuda_devs\": %s,\n"
-                   "    \"nvml_devs\": %s\n"
-                   "  },\n"
-                   "  \"details\": \"%s\"\n"
-                   "}\n",
-                   timeStr, groupStr, event->eventType, hostBuf, peer->pid, cudaDevs, nvmlDevs, event->details);
+            "{\n"
+            "  \"timestamp\": \"%s\",\n"
+            "  \"group\": \"%s\",\n"
+            "  \"event\": \"%s\",\n"
+            "  \"peer\": {\n"
+            "    \"host\": \"%s\",\n"
+            "    \"pid\": %d,\n"
+            "    \"cuda_devs\": %s,\n"
+            "    \"nvml_devs\": %s\n"
+            "  },\n"
+            "  \"details\": \"%s\"\n"
+            "}\n",
+            timeStr, groupStr, event->eventType, hostBuf, peer->pid, cudaDevs, nvmlDevs, event->details);
         } else if (event->peerAddr) {
           // Peer not found, just use address.
           char addrStr[SOCKET_NAME_MAXLEN+1];
           ncclSocketToString(event->peerAddr, addrStr, sizeof(addrStr));
           snprintf(formattedNotification, sizeof(formattedNotification),
-                   "{\n"
-                   "  \"timestamp\": \"%s\",\n"
-                   "  \"group\": \"%s\",\n"
-                   "  \"event\": \"%s\",\n"
-                   "  \"peer\": {\n"
-                   "    \"addr\": \"%s\"\n"
-                   "  },\n"
-                   "  \"details\": \"%s\"\n"
-                   "}\n",
-                   timeStr, groupStr, event->eventType, addrStr, event->details);
+            "{\n"
+            "  \"timestamp\": \"%s\",\n"
+            "  \"group\": \"%s\",\n"
+            "  \"event\": \"%s\",\n"
+            "  \"peer\": {\n"
+            "    \"addr\": \"%s\"\n"
+            "  },\n"
+            "  \"details\": \"%s\"\n"
+            "}\n",
+            timeStr, groupStr, event->eventType, addrStr, event->details);
         } else {
           snprintf(formattedNotification, sizeof(formattedNotification),
-                   "{\n"
-                   "  \"timestamp\": \"%s\",\n"
-                   "  \"group\": \"%s\",\n"
-                   "  \"event\": \"%s\",\n"
-                   "  \"details\": \"%s\"\n"
-                   "}\n",
-                   timeStr, groupStr, event->eventType, event->details);
+            "{\n"
+            "  \"timestamp\": \"%s\",\n"
+            "  \"group\": \"%s\",\n"
+            "  \"event\": \"%s\",\n"
+            "  \"details\": \"%s\"\n"
+            "}\n",
+            timeStr, groupStr, event->eventType, event->details);
         }
       } else { // client->outputFormat == RAS_OUTPUT_TEXT
         char peerStr[512] = "";
@@ -2289,10 +2288,10 @@ void rasClientsNotifyEvent(rasEventGroup group, const struct rasEventNotificatio
         }
         if (strlen(peerStr) > 0) {
           snprintf(formattedNotification, sizeof(formattedNotification),
-                   "[%s] %s: %s %s\n", timeStr, event->eventType, peerStr, event->details);
+            "[%s] %s: %s %s\n", timeStr, event->eventType, peerStr, event->details);
         } else {
           snprintf(formattedNotification, sizeof(formattedNotification),
-                   "[%s] %s: %s\n", timeStr, event->eventType, event->details);
+            "[%s] %s: %s\n", timeStr, event->eventType, event->details);
         }
       }
 

--- a/src/ras/collectives.cc
+++ b/src/ras/collectives.cc
@@ -39,13 +39,13 @@ struct rasCollective* rasCollectivesTail;
 
 static ncclResult_t getNewCollEntry(struct rasCollective** pColl);
 static ncclResult_t rasLinkSendCollReq(struct rasLink* link, struct rasCollective* coll,
-                                       const struct rasCollRequest* req, size_t reqLen, struct rasConnection* fromConn);
+    const struct rasCollRequest* req, size_t reqLen, struct rasConnection* fromConn);
 static ncclResult_t rasConnSendCollReq(struct rasConnection* conn, const struct rasCollRequest* req, size_t reqLen);
 static ncclResult_t rasCollReadyResp(struct rasCollective* coll);
 static ncclResult_t rasConnSendCollResp(struct rasConnection* conn,
-                                        const union ncclSocketAddress* rootAddr, uint64_t rootId,
-                                        const union ncclSocketAddress* peers, int nPeers,
-                                        const char* data, int nData, int nLegTimeouts);
+    const union ncclSocketAddress* rootAddr, uint64_t rootId,
+    const union ncclSocketAddress* peers, int nPeers,
+    const char* data, int nData, int nLegTimeouts);
 
 static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqLen, char** pData, int* pNData);
 static ncclResult_t rasCollConnsMerge(struct rasCollective* coll, struct rasMsg* msg);
@@ -107,7 +107,7 @@ void rasCollReqInit(struct rasCollRequest* req) {
 // pColl provides on return a pointer to the allocated rasCollective structure to track this collective (unless
 // it's a broadcast, which require no such tracking).
 ncclResult_t rasNetSendCollReq(const struct rasCollRequest* req, bool* pAllDone,
-                               struct rasCollective** pColl, struct rasConnection* fromConn) {
+    struct rasCollective** pColl, struct rasConnection* fromConn) {
   struct rasCollective* coll = nullptr;
   struct rasCollRequest* reqMod = (struct rasCollRequest*)req;
   size_t reqLen = 0;
@@ -135,7 +135,7 @@ ncclResult_t rasNetSendCollReq(const struct rasCollRequest* req, bool* pAllDone,
     // Add the info to the collective message history.
     nRasCollHistory = std::min(nRasCollHistory+1, COLL_HISTORY_SIZE);
     memcpy(&rasCollHistory[rasCollHistNextIdx].rootAddr, &req->rootAddr,
-           sizeof(rasCollHistory[rasCollHistNextIdx].rootAddr));
+        sizeof(rasCollHistory[rasCollHistNextIdx].rootAddr));
     rasCollHistory[rasCollHistNextIdx].rootId = req->rootId;
     rasCollHistNextIdx = (rasCollHistNextIdx + 1) % COLL_HISTORY_SIZE;
 
@@ -165,8 +165,8 @@ exit:
 // Sends the collective message through all connections associated with this link (with the exception of the one
 // the message came from, if any).
 static ncclResult_t rasLinkSendCollReq(struct rasLink* link, struct rasCollective* coll,
-                                       const struct rasCollRequest* req, size_t reqLen,
-                                       struct rasConnection* fromConn) {
+    const struct rasCollRequest* req, size_t reqLen,
+    struct rasConnection* fromConn) {
   for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConn = linkConn->next) {
     if (linkConn->conn && linkConn->conn != fromConn && !linkConn->conn->linkFlag) {
       // We send collective messages through fully established and operational connections only.
@@ -205,8 +205,8 @@ ncclResult_t rasMsgHandleCollReq(struct rasMsg* msg, struct rasSocket* sock) {
   char line[SOCKET_NAME_MAXLEN+1];
 
   INFO(NCCL_RAS, "RAS handling collReq from %s (root %s:%ld, timeout %ld, type %d)",
-       ncclSocketToString(&sock->sock.addr, rasLine), ncclSocketToString(&msg->collReq.rootAddr, line),
-       msg->collReq.rootId, msg->collReq.timeout/CLOCK_UNITS_PER_SEC, msg->collReq.type);
+    ncclSocketToString(&sock->sock.addr, rasLine), ncclSocketToString(&msg->collReq.rootAddr, line),
+    msg->collReq.rootId, msg->collReq.timeout/CLOCK_UNITS_PER_SEC, msg->collReq.type);
   if (sock->conn == nullptr) {
     INFO(NCCL_RAS, "RAS socket lacks a connection: status %d -- internal error?", sock->status);
     return ncclInternalError;
@@ -217,13 +217,13 @@ ncclResult_t rasMsgHandleCollReq(struct rasMsg* msg, struct rasSocket* sock) {
     // In principle we can use i to index the array but we convert it so that we check the most recent entries first.
     int collHistIdx = (rasCollHistNextIdx + COLL_HISTORY_SIZE - 1 - i) % COLL_HISTORY_SIZE;
     if (memcmp(&msg->collReq.rootAddr, &rasCollHistory[collHistIdx].rootAddr, sizeof(msg->collReq.rootAddr)) == 0 &&
-        msg->collReq.rootId == rasCollHistory[collHistIdx].rootId) {
+      msg->collReq.rootId == rasCollHistory[collHistIdx].rootId) {
       INFO(NCCL_RAS, "RAS found a duplicate finished collective");
       if (msg->collReq.type >= RAS_COLL_CONNS) {
         // Send an empty response so that the sender can account for it.  The non-empty response has already been
         // sent through the connection that we received the request through first.
         NCCLCHECK(rasConnSendCollResp(sock->conn, &msg->collReq.rootAddr, msg->collReq.rootId,
-                                      /*peers*/nullptr, /*nPeers*/0, /*data*/nullptr, /*nData*/0, /*nLegTimeouts*/0));
+          /*peers*/nullptr, /*nPeers*/0, /*data*/nullptr, /*nData*/0, /*nLegTimeouts*/0));
       }
       goto exit;
     }
@@ -233,18 +233,18 @@ ncclResult_t rasMsgHandleCollReq(struct rasMsg* msg, struct rasSocket* sock) {
     // Check if we're currently handling this collective request.
     for (coll = rasCollectivesHead; coll; coll = coll->next) {
       if (memcmp(&msg->collReq.rootAddr, &coll->rootAddr, sizeof(msg->collReq.rootAddr)) == 0 &&
-          msg->collReq.rootId == coll->rootId) {
+        msg->collReq.rootId == coll->rootId) {
         if (msg->collReq.type == coll->type) {
           INFO(NCCL_RAS, "RAS found a duplicate ongoing collective");
           // Send an empty response so that the sender can account for it.  The non-empty response will be
           // sent through the connection that we received the request through first.
           NCCLCHECK(rasConnSendCollResp(sock->conn, &msg->collReq.rootAddr, msg->collReq.rootId,
-                                        /*peers*/nullptr, /*nPeers*/0, /*data*/nullptr, /*nData*/0, /*nLegTimeouts*/0));
+            /*peers*/nullptr, /*nPeers*/0, /*data*/nullptr, /*nData*/0, /*nLegTimeouts*/0));
           goto exit;
         } else {
           // Should never happen.
           INFO(NCCL_RAS, "RAS collective type mismatch: request %d, ongoing %d -- internal error?",
-               msg->collReq.type, coll->type);
+              msg->collReq.type, coll->type);
         }
       } // if match
     } // for (coll)
@@ -275,12 +275,12 @@ static ncclResult_t rasCollReadyResp(struct rasCollective* coll) {
   if (coll->fromConn) {
     // For remotely-initiated collectives, send the response back.
     NCCLCHECK(rasConnSendCollResp(coll->fromConn, &coll->rootAddr, coll->rootId,
-                                  coll->peers, coll->nPeers, coll->data, coll->nData, coll->nLegTimeouts));
+      coll->peers, coll->nPeers, coll->data, coll->nData, coll->nLegTimeouts));
 
     // Add the identifying info to the collective message history.
     nRasCollHistory = std::min(nRasCollHistory+1, COLL_HISTORY_SIZE);
     memcpy(&rasCollHistory[rasCollHistNextIdx].rootAddr, &coll->rootAddr,
-           sizeof(rasCollHistory[rasCollHistNextIdx].rootAddr));
+        sizeof(rasCollHistory[rasCollHistNextIdx].rootAddr));
     rasCollHistory[rasCollHistNextIdx].rootId = coll->rootId;
     rasCollHistNextIdx = (rasCollHistNextIdx + 1) % COLL_HISTORY_SIZE;
 
@@ -295,9 +295,9 @@ static ncclResult_t rasCollReadyResp(struct rasCollective* coll) {
 // Sends a collective response via the connection we originally received the request from.  The message should be
 // a cumulative response from this process and all the processes that we forwarded the request to.
 static ncclResult_t rasConnSendCollResp(struct rasConnection* conn,
-                                        const union ncclSocketAddress* rootAddr, uint64_t rootId,
-                                        const union ncclSocketAddress* peers, int nPeers,
-                                        const char* data, int nData, int nLegTimeouts) {
+    const union ncclSocketAddress* rootAddr, uint64_t rootId,
+    const union ncclSocketAddress* peers, int nPeers,
+    const char* data, int nData, int nLegTimeouts) {
   struct rasMsg* msg = nullptr;
   int msgLen = rasMsgLength(RAS_MSG_COLLRESP) + nPeers*sizeof(*peers);
   int dataOffset = 0;
@@ -333,12 +333,12 @@ ncclResult_t rasMsgHandleCollResp(struct rasMsg* msg, struct rasSocket* sock) {
   char line[SOCKET_NAME_MAXLEN+1];
 
   INFO(NCCL_RAS, "RAS handling collResp from %s (root %s:%ld, nPeers %d, nData %d, nLegTimeouts %d)",
-       ncclSocketToString(&sock->sock.addr, rasLine), ncclSocketToString(&msg->collResp.rootAddr, line),
-       msg->collResp.rootId, msg->collResp.nPeers, msg->collResp.nData, msg->collResp.nLegTimeouts);
+    ncclSocketToString(&sock->sock.addr, rasLine), ncclSocketToString(&msg->collResp.rootAddr, line),
+    msg->collResp.rootId, msg->collResp.nPeers, msg->collResp.nData, msg->collResp.nLegTimeouts);
 
   for (coll = rasCollectivesHead; coll; coll = coll->next) {
     if (memcmp(&msg->collResp.rootAddr, &coll->rootAddr, sizeof(msg->collResp.rootAddr)) == 0 &&
-        msg->collResp.rootId == coll->rootId)
+      msg->collResp.rootId == coll->rootId)
       break;
   }
   if (coll == nullptr) {
@@ -389,8 +389,8 @@ void rasCollsPurgeConn(struct rasConnection* conn) {
     char line[SOCKET_NAME_MAXLEN+1];
     if (coll->fromConn == conn) {
       INFO(NCCL_RAS, "RAS purging collective %s:%ld because it comes from %s",
-           ncclSocketToString(&coll->rootAddr, line), coll->rootId,
-           ncclSocketToString(&conn->addr, rasLine));
+          ncclSocketToString(&coll->rootAddr, line), coll->rootId,
+          ncclSocketToString(&conn->addr, rasLine));
       rasCollFree(coll);
     } else {
       for (int i = 0; i < coll->nFwdSent; i++) {
@@ -399,9 +399,9 @@ void rasCollsPurgeConn(struct rasConnection* conn) {
           coll->nFwdRecv++;
           coll->nLegTimeouts++;
           INFO(NCCL_RAS, "RAS not waiting for response from %s to collective %s:%ld "
-               "(nFwdSent %d, nFwdRecv %d, nLegTimeouts %d)",
-               ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line), coll->rootId,
-               coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
+                         "(nFwdSent %d, nFwdRecv %d, nLegTimeouts %d)",
+              ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line), coll->rootId,
+              coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
           if (coll->nFwdSent == coll->nFwdRecv)
             (void)rasCollReadyResp(coll);
           break;
@@ -451,8 +451,8 @@ void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         // We've exceeded the leg timeout.  For all outstanding responses, check their connections.
         if (!coll->timeoutWarned) {
           INFO(NCCL_RAS, "RAS collective %s:%ld timeout warning (%lds) -- %d responses missing",
-               ncclSocketToString(&coll->rootAddr, rasLine), coll->rootId,
-               (now - coll->startTime) / CLOCK_UNITS_PER_SEC, coll->nFwdSent - coll->nFwdRecv);
+            ncclSocketToString(&coll->rootAddr, rasLine), coll->rootId,
+            (now - coll->startTime) / CLOCK_UNITS_PER_SEC, coll->nFwdSent - coll->nFwdRecv);
           coll->timeoutWarned = true;
         }
         for (int i = 0; i < coll->nFwdSent; i++) {
@@ -468,9 +468,9 @@ void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
             }
             // In all other cases we declare a timeout so that we can (hopefully) recover.
             INFO(NCCL_RAS, "RAS not waiting for response from %s to collective %s:%ld "
-                 "(nFwdSent %d, nFwdRecv %d, nLegTimeouts %d)",
-                 ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line),
-                 coll->rootId, coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
+                           "(nFwdSent %d, nFwdRecv %d, nLegTimeouts %d)",
+                ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line),
+                coll->rootId, coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
             coll->fwdConns[i] = nullptr;
             coll->nFwdRecv++;
             coll->nLegTimeouts++;
@@ -486,8 +486,8 @@ void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
             // We've exceeded even the longer timeout, which is unexpected.  Try to return whatever we have (though
             // the originator of the collective, if it's not us, may have timed out already anyway).
             INFO(NCCL_RAS, "RAS collective %s:%ld timeout error (%lds) -- giving up on %d missing responses",
-                 ncclSocketToString(&coll->rootAddr, rasLine), coll->rootId,
-                 (now - coll->startTime) / CLOCK_UNITS_PER_SEC, coll->nFwdSent - coll->nFwdRecv);
+              ncclSocketToString(&coll->rootAddr, rasLine), coll->rootId,
+              (now - coll->startTime) / CLOCK_UNITS_PER_SEC, coll->nFwdSent - coll->nFwdRecv);
             coll->nLegTimeouts += coll->nFwdSent - coll->nFwdRecv;
             coll->nFwdRecv = coll->nFwdSent;
             (void)rasCollReadyResp(coll);
@@ -513,8 +513,10 @@ void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
 // For this particular collective, we keep some reduced statistical data (min/max/avg travel time) as well
 // as connection-specific info in case we observed a negative min travel time (which, ideally, shouldn't happen,
 // but the system clocks may not be perfectly in sync).
-static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqLen, char** pData, int* pNData) {
-  struct rasCollConns connsData = {.travelTimeMin = INT64_MAX, .travelTimeMax = INT64_MIN};
+static ncclResult_t rasCollConnsInit(struct rasCollRequest** /*pReq*/, size_t* pReqLen, char** pData, int* pNData) {
+  struct rasCollConns connsData = {};
+  connsData.travelTimeMin = INT64_MAX;
+  connsData.travelTimeMax = INT64_MIN;
   struct rasCollConns* pConnsData;
 
   *pReqLen = rasCollDataLength(RAS_COLL_CONNS);
@@ -547,7 +549,7 @@ static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqL
         if (negMinsIdx >= connsData.nNegativeMins) {
           // Should never happen;
           INFO(NCCL_RAS, "RAS overflow of negativeMins: connsData.nNegativeMins %d, negMinsIdx %d -- internal error?",
-               connsData.nNegativeMins, negMinsIdx);
+              connsData.nNegativeMins, negMinsIdx);
           break;
         }
         memcpy(&negativeMin->source, &rasNetListeningSocket.addr, sizeof(negativeMin->source));
@@ -583,11 +585,11 @@ static ncclResult_t rasCollConnsMerge(struct rasCollective* coll, struct rasMsg*
   // Append the info about negative minimums.
   if (msgData->nNegativeMins > 0) {
     int nData = sizeof(*collData) +
-      (collData->nNegativeMins+msgData->nNegativeMins) * sizeof(*collData->negativeMins);
+        (collData->nNegativeMins+msgData->nNegativeMins) * sizeof(*collData->negativeMins);
     NCCLCHECK(ncclRealloc(&coll->data, coll->nData, nData));
     collData = (struct rasCollConns*)coll->data;
     memcpy(coll->data+coll->nData, msgData->negativeMins,
-           msgData->nNegativeMins * sizeof(*collData->negativeMins));
+        msgData->nNegativeMins * sizeof(*collData->negativeMins));
     coll->nData = nData;
     collData->nNegativeMins += msgData->nNegativeMins;
   }
@@ -621,7 +623,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
   int firstNewSkipMissingIdx = -1;
 
   *pReqLen = rasCollDataLength(RAS_COLL_COMMS) +
-    (*pReq)->comms.nSkipMissingRanksComms * sizeof(*(*pReq)->comms.skipMissingRanksComms);
+      (*pReq)->comms.nSkipMissingRanksComms * sizeof(*(*pReq)->comms.skipMissingRanksComms);
   *pData = nullptr;
 
   // Start by counting the communicators so that we know how much space to allocate.
@@ -673,7 +675,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
   // This is extra complicated because of the "hidden" array of struct rasCollCommsMissingRank following the
   // ranks array for each communicator.
   *pNData = sizeof(*commsData) + nComms * sizeof(*commsData->comms) + nRanks * sizeof(*commsData->comms[0].ranks) +
-    nMissingRanks * sizeof(struct rasCollCommsMissingRank);
+      nMissingRanks * sizeof(struct rasCollCommsMissingRank);
   NCCLCHECKGOTO(ncclCalloc(pData, *pNData), ret, fail);
   commsData = (struct rasCollComms*)*pData;
   commsData->nComms = nComms;
@@ -689,7 +691,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
     if ((char*)(comm+1) - (char*)commsData > *pNData) {
       // Should never happen.
       INFO(NCCL_RAS, "RAS overflow of commsData: collCommIdx %d, nComms %d, pNData %d, needs %td -- internal error?",
-           collCommIdx, nComms, *pNData, (char*)(comm+1) - (char*)commsData);
+          collCommIdx, nComms, *pNData, (char*)(comm+1) - (char*)commsData);
       break;
     }
 
@@ -701,15 +703,15 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
 
     // Fill in the comm->ranks array.
     for (; commIdx < nNcclComms && ncclComms[commIdx] && ncclComms[commIdx]->commHash == comm->commId.commHash;
-         commIdx++) {
+        commIdx++) {
       ncclComm = ncclComms[commIdx];
       struct rasCollComms::comm::rank* rank = comm->ranks+comm->nRanks;
 
       if ((char*)(rank+1) - (char*)commsData > *pNData) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS overflow of commsData: collCommIdx %d, nComms %d, rank %d, commIdx %d, pNData %d, "
-             "needs %td -- internal error?",
-             collCommIdx, nComms, comm->nRanks, commIdx, *pNData, (char*)(rank+1) - (char*)commsData);
+                       "needs %td -- internal error?",
+            collCommIdx, nComms, comm->nRanks, commIdx, *pNData, (char*)(rank+1) - (char*)commsData);
         break;
       }
 
@@ -731,7 +733,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
     } // for (commIdx)
 
     if (COMPILER_ATOMIC_LOAD(&ncclComm->peerInfoValid, std::memory_order_acquire) && firstNewSkipMissingIdx != -1 &&
-        memcmp(req->comms.skipMissingRanksComms+firstNewSkipMissingIdx, &comm->commId, sizeof(comm->commId)) == 0) {
+      memcmp(req->comms.skipMissingRanksComms+firstNewSkipMissingIdx, &comm->commId, sizeof(comm->commId)) == 0) {
       // Fill in the missingRanks array that follows the comm->ranks.
       struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks+comm->nRanks);
 
@@ -754,9 +756,9 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
         if ((char*)(missingRank+1) - (char*)commsData > *pNData) {
           // Should never happen.
           INFO(NCCL_RAS, "RAS overflow of commsData: collCommIdx %d, nComms %d, nRanks %d, missingRankIdx %d, "
-               "nMissingRanks %d, pNData %d, needs %td -- internal error?",
-               collCommIdx, nComms, comm->nRanks, missingRankIdx, comm->nMissingRanks, *pNData,
-               (char*)(missingRank+1) - (char*)commsData);
+                         "nMissingRanks %d, pNData %d, needs %td -- internal error?",
+              collCommIdx, nComms, comm->nRanks, missingRankIdx, comm->nMissingRanks, *pNData,
+              (char*)(missingRank+1) - (char*)commsData);
           break;
         }
 
@@ -780,15 +782,15 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
     } // if need to fill in the missingRanks
 
     comm = (struct rasCollComms::comm*)((char*)(comm+1) + comm->nRanks * sizeof(*comm->ranks) +
-                                        comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
+      comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
   } // for (collCommIdx)
 
   if (req) {
     // Finish updating the request.
     *pReqLen = rasCollDataLength(RAS_COLL_COMMS) +
-      req->comms.nSkipMissingRanksComms * sizeof(*req->comms.skipMissingRanksComms);
+        req->comms.nSkipMissingRanksComms * sizeof(*req->comms.skipMissingRanksComms);
     qsort(req->comms.skipMissingRanksComms, req->comms.nSkipMissingRanksComms,
-          sizeof(*req->comms.skipMissingRanksComms), rasCommIdCompare);
+        sizeof(*req->comms.skipMissingRanksComms), rasCommIdCompare);
   }
 ret:
   free(peersReSorted);
@@ -831,8 +833,8 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
       if ((char*)(newComm+1) - (char*)newData > nNewData) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
-             "needs %td -- internal error?",
-             newData->nComms, collIdx, msgIdx, nNewData, (char*)(newComm+1) - (char*)newData);
+                       "needs %td -- internal error?",
+            newData->nComms, collIdx, msgIdx, nNewData, (char*)(newComm+1) - (char*)newData);
         break;
       }
       if (collIdx < collData->nComms &&
@@ -840,9 +842,9 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
           collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)collData > coll->nData) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS overflow of collData: collIdx %d, nComms %d, nData %d, needs %td -- internal error?",
-             collIdx, collData->nComms, coll->nData,
-             (char*)(collComm+1) + collComm->nRanks * sizeof(*collComm->ranks) +
-             collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)collData);
+            collIdx, collData->nComms, coll->nData,
+            (char*)(collComm+1) + collComm->nRanks * sizeof(*collComm->ranks) +
+            collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)collData);
         break;
       }
       if (msgIdx < msgData->nComms &&
@@ -850,9 +852,9 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
           msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)msgData > msg->collResp.nData) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS overflow of msgData: msgIdx %d, nComms %d, nData %d, needs %td -- internal error?",
-             msgIdx, msgData->nComms, msg->collResp.nData,
-             (char*)(msgComm+1) + msgComm->nRanks * sizeof(*msgComm->ranks) +
-             msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)msgData);
+            msgIdx, msgData->nComms, msg->collResp.nData,
+            (char*)(msgComm+1) + msgComm->nRanks * sizeof(*msgComm->ranks) +
+            msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)msgData);
         break;
       }
 
@@ -863,8 +865,8 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
 
       if (cmp == 0 && collComm->commNRanks != msgComm->commNRanks) {
         INFO(NCCL_RAS, "RAS encountered inconsistent communicator data: size %d != %d -- "
-             "possible hash collision (0x%lx, 0x%lx, 0x%lx)", collComm->commNRanks, msgComm->commNRanks,
-             collComm->commId.commHash, collComm->commId.hostHash, collComm->commId.pidHash);
+                       "possible hash collision (0x%lx, 0x%lx, 0x%lx)", collComm->commNRanks, msgComm->commNRanks,
+            collComm->commId.commHash, collComm->commId.hostHash, collComm->commId.pidHash);
         cmp = (collComm->commNRanks < msgComm->commNRanks ? -1 : 1);
         // We try to preserve them both separately...
       }
@@ -875,9 +877,9 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
         newComm->commNRanks = collComm->commNRanks;
         if (collComm->nRanks + msgComm->nRanks > collComm->commNRanks) {
           INFO(NCCL_RAS,
-               "RAS encountered more ranks (%d) than the communicator size (%d) -- possible hash collision "
-               "(0x%lx, 0x%lx, 0x%lx)", collComm->nRanks + msgComm->nRanks, newComm->commNRanks,
-               collComm->commId.commHash, collComm->commId.hostHash, collComm->commId.pidHash);
+              "RAS encountered more ranks (%d) than the communicator size (%d) -- possible hash collision "
+              "(0x%lx, 0x%lx, 0x%lx)", collComm->nRanks + msgComm->nRanks, newComm->commNRanks,
+              collComm->commId.commHash, collComm->commId.hostHash, collComm->commId.pidHash);
           newComm->nRanks = newComm->commNRanks;
           // We'll skip the extras in the loop below.
         } else {
@@ -885,14 +887,14 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
         }
         // Merge the ranks.
         for (int newRankIdx = 0, collRankIdx = 0, msgRankIdx = 0;
-             collRankIdx < collComm->nRanks || msgRankIdx < msgComm->nRanks;
-             newRankIdx++) {
+            collRankIdx < collComm->nRanks || msgRankIdx < msgComm->nRanks;
+            newRankIdx++) {
           int cmpRank;
           if (newRankIdx == newComm->commNRanks)
             break; // Short of failing, the best we can do is skip...
           if (collRankIdx < collComm->nRanks && msgRankIdx < msgComm->nRanks) {
             cmpRank = (collComm->ranks[collRankIdx].commRank < msgComm->ranks[msgRankIdx].commRank ? -1 :
-                       (collComm->ranks[collRankIdx].commRank > msgComm->ranks[msgRankIdx].commRank ? 1 : 0));
+                    (collComm->ranks[collRankIdx].commRank > msgComm->ranks[msgRankIdx].commRank ? 1 : 0));
           } else {
             cmpRank = (collRankIdx < collComm->nRanks ? -1 : 1);
           }
@@ -900,19 +902,19 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
           // There shouldn't be any overlaps in ranks between different sources.
           if (cmpRank == 0) {
             INFO(NCCL_RAS, "RAS encountered duplicate data for rank %d -- possible hash collision "
-                 "(0x%lx, 0x%lx, 0x%lx)", collComm->ranks[collRankIdx].commRank,
-                 newComm->commId.commHash, newComm->commId.hostHash, newComm->commId.pidHash);
+                           "(0x%lx, 0x%lx, 0x%lx)", collComm->ranks[collRankIdx].commRank,
+                newComm->commId.commHash, newComm->commId.hostHash, newComm->commId.pidHash);
             msgRankIdx++; // Short of failing, the best we can do is skip...
           }
           if ((char*)(newComm->ranks+newRankIdx+1) - (char*)newData <= nNewData) {
             memcpy(newComm->ranks+newRankIdx, (cmpRank <= 0 ? collComm->ranks+collRankIdx++ :
-                                               msgComm->ranks+msgRankIdx++), sizeof(*newComm->ranks));
+              msgComm->ranks+msgRankIdx++), sizeof(*newComm->ranks));
           } else {
             // Should never happen.
             INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, newRankIdx %d, collRankIdx %d, "
-                 "msgRankIdx %d, newNRanks %d, collNranks %d, msgNranks %d, nNewData %d, needs %td -- internal error?",
-                 newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, msgRankIdx, newComm->nRanks,
-                 collComm->nRanks, msgComm->nRanks, nNewData, (char*)(newComm->ranks+newRankIdx+1) - (char*)newData);
+                           "msgRankIdx %d, newNRanks %d, collNranks %d, msgNranks %d, nNewData %d, needs %td -- internal error?",
+                newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, msgRankIdx, newComm->nRanks,
+                collComm->nRanks, msgComm->nRanks, nNewData, (char*)(newComm->ranks+newRankIdx+1) - (char*)newData);
             break;
           }
           if (cmpRank > 0) {
@@ -923,10 +925,10 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
               // Remove the corresponding entry from missingRanks.
               struct rasCollCommsMissingRank* missingRank;
               missingRank = (struct rasCollCommsMissingRank*)bsearch(&newComm->ranks[newRankIdx].commRank,
-                                                                     collComm->ranks+collComm->nRanks,
-                                                                     collComm->nMissingRanks,
-                                                                     sizeof(struct rasCollCommsMissingRank),
-                                                                     rasCollCommsMissingRankSearch);
+                collComm->ranks+collComm->nRanks,
+                collComm->nMissingRanks,
+                sizeof(struct rasCollCommsMissingRank),
+                rasCollCommsMissingRankSearch);
               if (missingRank) {
                 // Mark the entry as no longer needed.
                 memset(&missingRank->addr, '\0', sizeof(missingRank->addr));
@@ -952,9 +954,9 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
               } else {
                 // Should never happen.
                 INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, newRankIdx %d, "
-                     "collRankIdx %d, collNMissingRanks %d, nNewData %d, needs %td -- internal error?",
-                     newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, collComm->nMissingRanks,
-                     nNewData, (char*)(newMissingRanks + newRankIdx+1) - (char*)newData);
+                               "collRankIdx %d, collNMissingRanks %d, nNewData %d, needs %td -- internal error?",
+                    newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, collComm->nMissingRanks,
+                    nNewData, (char*)(newMissingRanks + newRankIdx+1) - (char*)newData);
                 break;
               }
             }
@@ -963,29 +965,29 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
           if (newComm->nRanks + newComm->nMissingRanks != newComm->commNRanks) {
             // Should never happen.
             INFO(NCCL_RAS, "RAS collective comms merge mismatch for newIdx %d: nRanks %d, nMissingRanks %d, "
-                 "commNRanks %d -- internal error?",
-                 newData->nComms, newComm->nRanks, newComm->nMissingRanks, newComm->commNRanks);
+                           "commNRanks %d -- internal error?",
+                newData->nComms, newComm->nRanks, newComm->nMissingRanks, newComm->commNRanks);
           }
         }
         newComm = (struct rasCollComms::comm*)(((char*)(newComm+1)) + newComm->nRanks * sizeof(*newComm->ranks) +
-                                               newComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
+          newComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
         collComm = (struct rasCollComms::comm*)(((char*)(collComm+1)) + collComm->nRanks * sizeof(*collComm->ranks) +
-                                                collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
+          collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
         collIdx++;
         msgComm = (struct rasCollComms::comm*)(((char*)(msgComm+1)) + msgComm->nRanks * sizeof(*msgComm->ranks) +
-                                               msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
+          msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
         msgIdx++;
       } else if (cmp < 0) {
         // Copy from collComm.
         int commSize = sizeof(*collComm) + collComm->nRanks * sizeof(*collComm->ranks) +
-          collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
+            collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
         if ((char*)newComm + commSize - (char*)newData <= nNewData) {
           memcpy(newComm, collComm, commSize);
         } else {
           // Should never happen.
           INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
-               "needs %td -- internal error?",
-               newData->nComms, collIdx, msgIdx, nNewData, (char*)newComm + commSize - (char*)newData);
+                         "needs %td -- internal error?",
+              newData->nComms, collIdx, msgIdx, nNewData, (char*)newComm + commSize - (char*)newData);
           break;
         }
         newComm = (struct rasCollComms::comm*)(((char*)(newComm)) + commSize);
@@ -994,14 +996,14 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
       } else { // cmp > 0
         // Copy from msgComm.
         int commSize = sizeof(*msgComm) + msgComm->nRanks * sizeof(*msgComm->ranks) +
-          msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
+            msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
         if ((char*)newComm + commSize - (char*)newData <= nNewData) {
           memcpy(newComm, msgComm, commSize);
         } else {
           // Should never happen.
           INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
-               "needs %td -- internal error?",
-               newData->nComms, collIdx, msgIdx, nNewData, (char*)newComm + commSize - (char*)newData);
+                         "needs %td -- internal error?",
+              newData->nComms, collIdx, msgIdx, nNewData, (char*)newComm + commSize - (char*)newData);
           break;
         }
         for (int i = 0; i < newComm->nRanks; i++) {
@@ -1030,7 +1032,7 @@ static bool rasCollCommsSkipMissing(const struct rasCollRequest* req, struct ncc
   id.hostHash = comm->peerInfo->hostHash;
   id.pidHash = comm->peerInfo->pidHash;
   return (bsearch(&id, req->comms.skipMissingRanksComms, req->comms.nSkipMissingRanksComms,
-                  sizeof(*req->comms.skipMissingRanksComms), rasCommIdCompare) != nullptr);
+    sizeof(*req->comms.skipMissingRanksComms), rasCommIdCompare) != nullptr);
 }
 
 // Sorting callback for the ncclComms array.

--- a/src/ras/peers.cc
+++ b/src/ras/peers.cc
@@ -36,17 +36,17 @@ static int rasDeadPeersSize;
 uint64_t rasDeadPeersHash;
 
 static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks,
-                                           struct rasPeerInfo** rankPeers, int *nRankPeers, int* newNRasPeers);
+    struct rasPeerInfo** rankPeers, int *nRankPeers, int* newNRasPeers);
 static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeers, int newNRasPeers = -1);
 
 static ncclResult_t rasNetUpdatePeers(const struct rasPeerInfo* newPeers, int nNewPeers, bool updateDeadPeers,
-                                      struct rasRankInit* ranks = nullptr, int nranks = 0,
-                                      struct rasConnection* fromConn = nullptr);
+    struct rasRankInit* ranks = nullptr, int nranks = 0,
+    struct rasConnection* fromConn = nullptr);
 static ncclResult_t rasLinkPropagateUpdate(struct rasLink* link, const struct rasPeerInfo* newPeers, int nNewPeers,
-                                           bool updateDeadPeers, struct rasRankInit* ranks, int nranks,
-                                           struct rasConnection* fromConn);
+    bool updateDeadPeers, struct rasRankInit* ranks, int nranks,
+    struct rasConnection* fromConn);
 static ncclResult_t rasConnPropagateUpdate(struct rasConnection* conn, const struct rasPeerInfo* newPeers,
-                                           int nNewPeers, bool updateDeadPeers, struct rasRankInit* ranks, int nranks);
+    int nNewPeers, bool updateDeadPeers, struct rasRankInit* ranks, int nranks);
 ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock);
 
 static ncclResult_t rasLinkReinitConns(struct rasLink* link);
@@ -85,7 +85,7 @@ ncclResult_t rasLocalHandleAddRanks(struct rasRankInit* ranks, int nranks) {
   NCCLCHECKGOTO(rasPeersUpdate(rankPeers, &nRankPeers, newNRasPeers), ret, fail);
 
   INFO(NCCL_RAS, "RAS finished local processing of addRanks request (new nRasPeers %d, nRankPeers %d)",
-       nRasPeers, nRankPeers);
+    nRasPeers, nRankPeers);
   // Print peers only if something changed and we're the "root".
   if (nRankPeers > 0 && memcmp(&ranks[0].addr, &rasNetListeningSocket.addr, sizeof(ranks[0].addr)) == 0)
     rasPeersDump();
@@ -106,7 +106,7 @@ fail:
 // elements by the address/cudaDev, and merges elements with duplicate addresses (in case of multiple CUDA devices per
 // process).  In the process we also calculate how large the merged rasPeers array will need to be.
 static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks,
-                                           struct rasPeerInfo** rankPeers, int *nRankPeers, int* newNRasPeers) {
+    struct rasPeerInfo** rankPeers, int *nRankPeers, int* newNRasPeers) {
   ncclResult_t ret = ncclSuccess;
   int peerIdx, rankPeerIdx;
 
@@ -177,7 +177,7 @@ static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks
     } else { // cmp == 0.  Duplicates between the rank array and the peers array will be merged.
       if (rank->pid != rasPeer->pid) {
         INFO(NCCL_RAS, "RAS pid mismatch for the same address %s: rank->pid %d, rasPeer->pid %d -- internal error?",
-             ncclSocketToString(&rank->addr, rasLine), rank->pid, rasPeer->pid);
+            ncclSocketToString(&rank->addr, rasLine), rank->pid, rasPeer->pid);
         // This really should never happen.  Best to skip the new one?
         rankPeerIdx--;
       }
@@ -261,14 +261,14 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
               rasNewPeerNotify(rankPeer);
             } else {
               INFO(NCCL_RAS, "RAS new peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
-                   "nRasPeers %d -- internal error?",
-                   ncclSocketToString(&rankPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
+                             "nRasPeers %d -- internal error?",
+                  ncclSocketToString(&rankPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
               break;
             }
           } else {
             // Should never happen -- newNRasPeers should include room for it.
             INFO(NCCL_RAS, "RAS new peer %s but there's no room for it: newNRasPeers %d, nRasPeers %d -- "
-                 "internal error?", ncclSocketToString(&rankPeer->addr, rasLine), newNRasPeers, nRasPeers);
+                           "internal error?", ncclSocketToString(&rankPeer->addr, rasLine), newNRasPeers, nRasPeers);
           }
           rankPeerIdx++;
         } else { // cmp >= 0
@@ -278,16 +278,16 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
               memcpy(newRasPeer, rasPeer, sizeof(*newRasPeer));
             } else {
               INFO(NCCL_RAS, "RAS old peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
-                   "nRasPeers %d -- internal error?",
-                   ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
+                             "nRasPeers %d -- internal error?",
+                  ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
               break;
             }
           } else { // in-place
             if (newPeerIdx != peerIdx) {
               // Should never happen -- both indexes should advance at the same pace.
               INFO(NCCL_RAS, "RAS old peer %s in-place mismatch: newPeerIdx %d, peerIdx %d, newNRasPeers %d, "
-                   "nRasPeers %d -- internal error?",
-                   ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, peerIdx, newNRasPeers, nRasPeers);
+                             "nRasPeers %d -- internal error?",
+                  ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, peerIdx, newNRasPeers, nRasPeers);
             }
           }
 
@@ -316,8 +316,8 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
           rasNewPeerNotify(rankPeer);
         } else {
           INFO(NCCL_RAS, "RAS new peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
-               "nRasPeers %d -- internal error?",
-               ncclSocketToString(&rankPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
+                         "nRasPeers %d -- internal error?",
+              ncclSocketToString(&rankPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
           break;
         }
         // If this is the first time this function is run, myPeerIdx will need to be set.  It's more work in that
@@ -333,17 +333,16 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
           memcpy(newRasPeer, rasPeer, sizeof(*newRasPeer));
         } else {
           INFO(NCCL_RAS, "RAS old peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
-               "nRasPeers %d -- internal error?",
-               ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
+                         "nRasPeers %d -- internal error?",
+              ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
           break;
         }
-      }
-      else { // in-place at the end.
+      } else { // in-place at the end.
         if (newPeerIdx != peerIdx) {
           // Should never happen -- both indexes should advance at the same pace.
           INFO(NCCL_RAS, "RAS old peer %s in-place mismatch: newPeerIdx %d, peerIdx %d, newNRasPeers %d, "
-               "nRasPeers %d -- internal error?",
-               ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, peerIdx, newNRasPeers, nRasPeers);
+                         "nRasPeers %d -- internal error?",
+              ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, peerIdx, newNRasPeers, nRasPeers);
         }
       }
       if (myPeerIdx == peerIdx)
@@ -354,7 +353,7 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
   if (newPeerIdx != newNRasPeers) {
     // Should never happen, unless an internal error got triggered above?
     INFO(NCCL_RAS, "RAS post-merge discrepancy: newPeerIdx %d, newNRasPeers %d, nRasPeers %d, nRankPeers %d -- "
-         "internal error?", newPeerIdx, newNRasPeers, nRasPeers, *nRankPeers);
+                   "internal error?", newPeerIdx, newNRasPeers, nRasPeers, *nRankPeers);
   }
 
   if (newRasPeers != rasPeers) {
@@ -366,14 +365,14 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
       // Should never happen, but if it does, then we are in deep trouble...  Try the regular binary search.
       newMyPeerIdx = rasPeerFind(&rasNetListeningSocket.addr);
       INFO(NCCL_RAS, "RAS post-merge discrepancy: myPeerIdx %d, newMyPeerIdx -1, found value %d -- internal error?",
-           myPeerIdx, newMyPeerIdx);
+          myPeerIdx, newMyPeerIdx);
     }
     myPeerIdx = newMyPeerIdx;
   } else {
     if (newMyPeerIdx != myPeerIdx) {
       // Should never happen, but if it does, then we are in deep trouble...  Update via the regular binary search.
       INFO(NCCL_RAS, "RAS post-merge discrepancy: myPeerIdx %d, newMyPeerIdx %d -- internal error?",
-           myPeerIdx, newMyPeerIdx);
+          myPeerIdx, newMyPeerIdx);
       myPeerIdx = rasPeerFind(&rasNetListeningSocket.addr);
       INFO(NCCL_RAS, "RAS post-merge discrepancy: found value %d", myPeerIdx);
     }
@@ -402,7 +401,7 @@ fail:
 // array or -1 if not found.
 int rasPeerFind(const union ncclSocketAddress* addr) {
   struct rasPeerInfo* peer = (struct rasPeerInfo*)bsearch(addr, rasPeers, nRasPeers, sizeof(*rasPeers),
-                                                          rasAddrPeerInfoCompare);
+    rasAddrPeerInfoCompare);
   return (peer ? peer-rasPeers : -1);
 }
 
@@ -420,7 +419,7 @@ int rasPeerFind(const union ncclSocketAddress* addr) {
 // Reconfigures the RAS network to accommodate the newly added peers, by modifying the links and establishing new
 // connections as needed.
 static ncclResult_t rasNetUpdatePeers(const struct rasPeerInfo* newPeers, int nNewPeers, bool updateDeadPeers,
-                                      struct rasRankInit* ranks, int nranks, struct rasConnection* fromConn) {
+    struct rasRankInit* ranks, int nranks, struct rasConnection* fromConn) {
   ncclResult_t ret = ncclSuccess;
 
   // Do we actually have anything to do?
@@ -445,8 +444,8 @@ fail:
 // Sends a peers update through all the connections associated with a particular link.  See rasNetUpdatePeers
 // for the explanation of the function arguments.
 static ncclResult_t rasLinkPropagateUpdate(struct rasLink* link, const struct rasPeerInfo* newPeers, int nNewPeers,
-                                           bool updateDeadPeers, struct rasRankInit* ranks, int nranks,
-                                           struct rasConnection* fromConn) {
+    bool updateDeadPeers, struct rasRankInit* ranks, int nranks,
+    struct rasConnection* fromConn) {
   for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConn = linkConn->next) {
     // Note that we don't send the update via the connection that we received this notification from in the first
     // place (while it wouldn't loop indefinitely, it would add a needless extra exchange).
@@ -462,14 +461,14 @@ static ncclResult_t rasLinkPropagateUpdate(struct rasLink* link, const struct ra
 // Sends a peers update down a particular connection.  See rasNetUpdatePeers for the explanation of the function
 // arguments.
 static ncclResult_t rasConnPropagateUpdate(struct rasConnection* conn, const struct rasPeerInfo* newPeers,
-                                           int nNewPeers, bool updateDeadPeers, struct rasRankInit* ranks, int nranks) {
+    int nNewPeers, bool updateDeadPeers, struct rasRankInit* ranks, int nranks) {
   if (conn->sock && conn->sock->status == RAS_SOCK_READY) {
     // If we have the rank info, check if the peer on the other side of this connection has participated in the new
     // communicator.
     int connRank = -1;
     if (ranks && !updateDeadPeers) {
       struct rasRankInit* rank = (struct rasRankInit*)bsearch(&conn->addr, ranks, nranks, sizeof(*ranks),
-                                                              rasAddrRankInitCompare);
+        rasAddrRankInitCompare);
       if (rank)
         connRank = rank-ranks;
     }
@@ -527,7 +526,7 @@ ncclResult_t rasConnSendPeersUpdate(struct rasConnection* conn, const struct ras
     conn->lastSentDeadPeersHash = rasDeadPeersHash;
 
   INFO(NCCL_RAS, "RAS sending a peersUpdate to %s (nPeers %d, nDeadPeers %d)",
-       ncclSocketToString(&conn->addr, rasLine), nPeers, nDeadPeers);
+    ncclSocketToString(&conn->addr, rasLine), nPeers, nDeadPeers);
 
   rasConnEnqueueMsg(conn, msg, msgLen);
 exit:
@@ -547,10 +546,10 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
   bool updatePeers, updateDeadPeers;
 
   INFO(NCCL_RAS, "RAS handling peersUpdate from %s (peersHash 0x%lx, deadPeersHash 0x%lx, nPeers %d, nDeadPeers %d)",
-       ncclSocketToString(&sock->sock.addr, rasLine), msg->peersUpdate.peersHash, msg->peersUpdate.deadPeersHash,
-       msg->peersUpdate.nPeers, msg->peersUpdate.nDeadPeers);
+    ncclSocketToString(&sock->sock.addr, rasLine), msg->peersUpdate.peersHash, msg->peersUpdate.deadPeersHash,
+    msg->peersUpdate.nPeers, msg->peersUpdate.nDeadPeers);
   INFO(NCCL_RAS, "RAS my old rasPeersHash 0x%lx, rasDeadPeersHash 0x%lx, nRasPeers %d, nRasDeadPeers %d",
-       rasPeersHash, rasDeadPeersHash, nRasPeers, nRasDeadPeers);
+      rasPeersHash, rasDeadPeersHash, nRasPeers, nRasDeadPeers);
   if (sock->conn == nullptr) {
     INFO(NCCL_RAS, "RAS socket lacks a connection: status %d -- internal error?", sock->status);
     return ncclInternalError;
@@ -591,13 +590,13 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
       msg->peersUpdate.nPeers = 0;
     if (nDeadPeers > 0)
       NCCLCHECKGOTO(rasDeadPeersUpdate((union ncclSocketAddress*)(((char*)msg)+deadPeersOffset),
-                                       &msg->peersUpdate.nDeadPeers), ret, fail);
+        &msg->peersUpdate.nDeadPeers), ret, fail);
     else
       msg->peersUpdate.nDeadPeers = 0;
 
     INFO(NCCL_RAS, "RAS finished local processing of peersUpdate "
-         "(new nRasPeers %d, nRasDeadPeers %d, nPeers %d, nDeadPeers %d)",
-         nRasPeers, nRasDeadPeers, msg->peersUpdate.nPeers, msg->peersUpdate.nDeadPeers);
+                   "(new nRasPeers %d, nRasDeadPeers %d, nPeers %d, nDeadPeers %d)",
+        nRasPeers, nRasDeadPeers, msg->peersUpdate.nPeers, msg->peersUpdate.nDeadPeers);
 
     if (msg->peersUpdate.nPeers > 0)
       rasPeersDump();
@@ -607,7 +606,7 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
     // If post-merge the hashes are still different, send our (dead) peers back.
     updatePeers = (sock->conn->lastSentPeersHash != rasPeersHash && sock->conn->lastRecvPeersHash != rasPeersHash);
     updateDeadPeers = (sock->conn->lastSentDeadPeersHash != rasDeadPeersHash &&
-                       sock->conn->lastRecvDeadPeersHash != rasDeadPeersHash);
+            sock->conn->lastRecvDeadPeersHash != rasDeadPeersHash);
     if (updatePeers || updateDeadPeers) {
       newMsg->peersUpdate.peersHash = rasPeersHash;
       newMsg->peersUpdate.deadPeersHash = rasDeadPeersHash;
@@ -629,7 +628,7 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
         if (nRasDeadPeers == 0) {
           // Should never happen.
           INFO(NCCL_RAS, "RAS peersUpdate discrepancy: updateDeadPeers is true but nRasDeadPeers is 0 -- "
-               "internal error?");
+                         "internal error?");
         }
         sock->conn->lastSentDeadPeersHash = rasDeadPeersHash;
 
@@ -645,7 +644,7 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
       }
 
       INFO(NCCL_RAS, "RAS sending back a peersUpdate (nPeers %d, nDeadPeers %d)",
-           newMsg->peersUpdate.nPeers, newMsg->peersUpdate.nDeadPeers);
+        newMsg->peersUpdate.nPeers, newMsg->peersUpdate.nDeadPeers);
 
       rasConnEnqueueMsg(sock->conn, newMsg, newMsgLen);
       newMsg = nullptr;
@@ -653,7 +652,7 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
 
     // Propagate the changes through our RAS network links.
     NCCLCHECKGOTO(rasNetUpdatePeers(msg->peersUpdate.peers, msg->peersUpdate.nPeers, updateDeadPeers, nullptr, 0,
-                                    sock->conn), ret, fail);
+      sock->conn), ret, fail);
   }
 
 exit:
@@ -682,10 +681,10 @@ static ncclResult_t rasLinkReinitConns(struct rasLink* link) {
 
   if (link->conns) {
     // Free the old contents but keep the first entry for convenience (though wipe it).
-    for (struct rasLinkConn* linkConn = link->conns->next; linkConn;) {
-      struct rasLinkConn* linkConnNext = linkConn->next;
-      free(linkConn);
-      linkConn = linkConnNext;
+    for (struct rasLinkConn* lc = link->conns->next; lc;) {
+      struct rasLinkConn* lcNext = lc->next;
+      free(lc);
+      lc = lcNext;
     }
     memset(link->conns, '\0', sizeof(*link->conns));
     link->lastUpdatePeersTime = 0;
@@ -704,24 +703,23 @@ static ncclResult_t rasLinkReinitConns(struct rasLink* link) {
       // We try to initiate primary connections from the side with a lower address (and thus an earlier peer index)
       // to avoid races and the creation of duplicate connections.
       INFO(NCCL_RAS, "RAS link %d: %s primary connection with %s",
-           link->direction, (myPeerIdx < linkConn->peerIdx ? "opening new" : "calculated deferred"),
-           ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
+          link->direction, (myPeerIdx < linkConn->peerIdx ? "opening new" : "calculated deferred"),
+          ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
       if (myPeerIdx < linkConn->peerIdx) {
         NCCLCHECK(rasConnCreate(&rasPeers[linkConn->peerIdx].addr, &linkConn->conn));
-      }
-      else { // If we didn't initiate the connection, start the timeout.
+      } else { // If we didn't initiate the connection, start the timeout.
         link->lastUpdatePeersTime = clockNano();
       }
     } // if (linkConn->peerIdx != -1)
   } else { // linkConn->conn
     INFO(NCCL_RAS, "RAS link %d: calculated existing primary connection with %s",
-         link->direction, ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
+        link->direction, ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
   } // linkConn->conn
 
   if (linkConn->conn && linkConn->conn->experiencingDelays) {
     INFO(NCCL_RAS, "RAS connection experiencingDelays %d, startRetryTime %.2fs, socket status %d",
-         linkConn->conn->experiencingDelays, (clockNano()-linkConn->conn->startRetryTime)/1e9,
-         (linkConn->conn->sock ? linkConn->conn->sock->status : - 1));
+        linkConn->conn->experiencingDelays, (clockNano()-linkConn->conn->startRetryTime)/1e9,
+        (linkConn->conn->sock ? linkConn->conn->sock->status : - 1));
     NCCLCHECK(rasLinkAddFallback(link, linkConn->conn));
   }
 
@@ -775,8 +773,7 @@ int rasLinkCalculatePeer(const struct rasLink* link, int peerIdx, bool isFallbac
 
     if (rasPeerIsDead(&rasPeers[newPeerIdx].addr)) {
       newPeerIdx = (newPeerIdx + nRasPeers + link->direction) % nRasPeers;
-    }
-    else
+    } else
       break;
   } while (newPeerIdx != myPeerIdx);
 
@@ -801,7 +798,7 @@ ncclResult_t rasPeerDeclareDead(const union ncclSocketAddress* addr) {
     rasDeadPeersHash = getHash((const char*)rasDeadPeers, nRasDeadPeers*sizeof(*rasDeadPeers));
 
     INFO(NCCL_RAS, "RAS declaring peer %s as DEAD; rasDeadPeersHash 0x%lx",
-         ncclSocketToString(addr, rasLine), rasDeadPeersHash);
+        ncclSocketToString(addr, rasLine), rasDeadPeersHash);
 
     struct rasEventNotification event = {
       .eventType = "PEER_DEAD",
@@ -822,9 +819,9 @@ const char* rasPeerInfoToString(const struct rasPeerInfo* peer, char* buf, size_
   ncclSocketToHost(&peer->addr, hostBuf, sizeof(hostBuf));
 
   snprintf(buf, size, "Process %d on node %s managing GPU%s %s",
-           peer->pid, hostBuf,
-           (COMPILER_POPCOUNT64(peer->cudaDevs) > 1 ? "s" : ""),
-           rasGpuDevsToString(peer->cudaDevs, peer->nvmlDevs, gpuBuf, sizeof(gpuBuf)));
+      peer->pid, hostBuf,
+      (COMPILER_POPCOUNT64(peer->cudaDevs) > 1 ? "s" : ""),
+      rasGpuDevsToString(peer->cudaDevs, peer->nvmlDevs, gpuBuf, sizeof(gpuBuf)));
   return buf;
 }
 
@@ -954,13 +951,13 @@ static int rasRanksCompare(const void* e1, const void* e2) {
     if (r1->pid != r2->pid) {
       // Should never happen.
       INFO(NCCL_RAS, "RAS ranks discrepancy for same address %s: r1->pid %d, r2->pid %d -- internal error?",
-           ncclSocketToString(&r1->addr, rasLine), r1->pid, r2->pid);
+          ncclSocketToString(&r1->addr, rasLine), r1->pid, r2->pid);
     }
     cmp = (r1->cudaDev < r2->cudaDev ? -1 : (r1->cudaDev > r2->cudaDev ? 1 : 0));
     if (cmp == 0) {
       // There should be no complete duplicates within the rank array.
       INFO(NCCL_RAS, "RAS ranks discrepancy for %s: identical entries with index difference %td -- internal error?",
-           ncclSocketToString(&r1->addr, rasLine), r2-r1);
+          ncclSocketToString(&r1->addr, rasLine), r2-r1);
     }
   }
   return cmp;
@@ -986,8 +983,7 @@ int ncclSocketsCompare(const void* p1, const void* p2) {
     if ((cmp = memcmp(&a1->sin.sin_addr, &a2->sin.sin_addr, sizeof(a1->sin.sin_addr))) == 0) {
       cmp = memcmp(&a1->sin.sin_port, &a2->sin.sin_port, sizeof(a1->sin.sin_port));
     }
-  }
-  else if (family == AF_INET6) {
+  } else if (family == AF_INET6) {
     if ((cmp = memcmp(&a1->sin6.sin6_addr, &a2->sin6.sin6_addr, sizeof(a1->sin6.sin6_addr))) == 0) {
       cmp = memcmp(&a1->sin6.sin6_port, &a2->sin6.sin6_port, sizeof(a1->sin6.sin6_port));
     }
@@ -1021,7 +1017,7 @@ static void rasPeersDump() {
   for (int p = 0; p < nRasPeers; p++) {
     const struct rasPeerInfo* peer = rasPeers+p;
     INFO(NCCL_RAS, "RAS peer %d: %s%s", p, rasPeerDump(peer, rasLine, sizeof(rasLine)),
-         (p == myPeerIdx ? " [this process]" : ""));
+      (p == myPeerIdx ? " [this process]" : ""));
   }
   if (nRasPeers > 0)
     INFO(NCCL_RAS, "RAS peersHash 0x%lx", rasPeersHash);
@@ -1032,8 +1028,8 @@ static void rasDeadPeersDump() {
   for (int p = 0; p < nRasDeadPeers; p++) {
     int deadPeerIdx = rasPeerFind(rasDeadPeers+p);
     INFO(NCCL_RAS, "RAS dead peer %d: %s", p,
-         (deadPeerIdx >= 0 ? rasPeerDump(rasPeers+deadPeerIdx, rasLine, sizeof(rasLine)) :
-          ncclSocketToString(rasDeadPeers+p, rasLine)));
+        (deadPeerIdx >= 0 ? rasPeerDump(rasPeers+deadPeerIdx, rasLine, sizeof(rasLine)) :
+      ncclSocketToString(rasDeadPeers+p, rasLine)));
   }
   if (nRasDeadPeers > 0)
     INFO(NCCL_RAS, "RAS deadPeersHash 0x%lx", rasDeadPeersHash);
@@ -1043,8 +1039,8 @@ static void rasDeadPeersDump() {
 static char* rasPeerDump(const struct rasPeerInfo* peer, char* result, size_t nres) {
   char line[SOCKET_NAME_MAXLEN+1], line2[1024];
   snprintf(result, nres, "socket %s, pid %d, GPU%s %s", ncclSocketToString(&peer->addr, line), peer->pid,
-           (COMPILER_POPCOUNT64(peer->cudaDevs) > 1 ? "s" : ""),
-           rasGpuDevsToString(peer->cudaDevs, peer->nvmlDevs, line2, sizeof(line2)));
+    (COMPILER_POPCOUNT64(peer->cudaDevs) > 1 ? "s" : ""),
+    rasGpuDevsToString(peer->cudaDevs, peer->nvmlDevs, line2, sizeof(line2)));
   return result;
 }
 

--- a/src/ras/rasnet.cc
+++ b/src/ras/rasnet.cc
@@ -9,7 +9,7 @@
 #include "os.h"
 
 // Links forming the backbone of the RAS network (currently a ring).
-struct rasLink rasNextLink = {1}, rasPrevLink = {-1};
+struct rasLink rasNextLink = {1, nullptr, 0}, rasPrevLink = {-1, nullptr, 0};
 
 // Connections on the RAS network.
 struct rasConnection* rasConnsHead;
@@ -38,12 +38,12 @@ static void rasConnSendKeepAlive(struct rasConnection* conn, bool nack = false);
 static void rasConnResume(struct rasConnection* conn);
 static void rasLinkSanitizeFallbacks(struct rasLink* link);
 static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* conn, int peerIdx, bool pretend = false,
-                                   int* pLinkIdx = nullptr, struct rasLinkConn** pLinkConn = nullptr,
-                                   bool insert = true);
+    int* pLinkIdx = nullptr, struct rasLinkConn** pLinkConn = nullptr,
+    bool insert = true);
 static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConnection* conn, int peerIdx);
 static void rasLinkConnDrop(struct rasLink* link, const struct rasConnection* conn, bool external = false);
 static struct rasLinkConn* rasLinkConnFind(const struct rasLink* link, const struct rasConnection* conn,
-                                           int* pLinkIdx = nullptr);
+    int* pLinkIdx = nullptr);
 
 
 ///////////////////////////////////////////////
@@ -128,7 +128,7 @@ static void rasConnOpen(struct rasConnection* conn) {
 
   NCCLCHECKGOTO(getNewSockEntry(&sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketInit(&sock->sock, &conn->addr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork, nullptr,
-                               /*asyncFlag*/1, /*customRetry*/1), ret, fail);
+    /*asyncFlag*/1, /*customRetry*/1), ret, fail);
   closeSocketOnFail = true;
   NCCLCHECKGOTO(ncclSocketConnect(&sock->sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketReady(&sock->sock, &ready), ret, fail);
@@ -206,7 +206,7 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           int ready;
           if (ncclSocketReady(&conn->sock->sock, &ready) != ncclSuccess) {
             INFO(NCCL_RAS, "Unexpected error from ncclSocketReady; terminating the socket connection with %s",
-                 ncclSocketToString(&conn->addr, rasLine));
+                ncclSocketToString(&conn->addr, rasLine));
             rasSocketTerminate(conn->sock, /*finalize*/true);
             // We will retry below in the same loop.
             sockTerminated = true;
@@ -227,11 +227,11 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
       // consider their sockets lost and terminate them.
       if (!sockTerminated && !ncclIntruQueueEmpty(&conn->sendQ) && conn->sock->status == RAS_SOCK_READY) {
         if (now - std::max(conn->sock->lastSendTime,
-                           ncclIntruQueueHead(&conn->sendQ)->enqueueTime) > RAS_STUCK_TIMEOUT) {
+          ncclIntruQueueHead(&conn->sendQ)->enqueueTime) > RAS_STUCK_TIMEOUT) {
           char details[256];
           long timeoutSecs = (now - std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime)) / CLOCK_UNITS_PER_SEC;
           snprintf(details, sizeof(details),
-                   "send operation stuck for %lds, terminating connection", timeoutSecs);
+            "send operation stuck for %lds, terminating connection", timeoutSecs);
           struct rasEventNotification event = {
             .eventType = "PEER_SEND_STUCK",
             .details = details,
@@ -241,13 +241,13 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
           INFO(NCCL_RAS, "RAS send stuck timeout error (%lds) on socket connection with %s",
-               timeoutSecs, ncclSocketToString(&conn->addr, rasLine));
+            timeoutSecs, ncclSocketToString(&conn->addr, rasLine));
           rasSocketTerminate(conn->sock, /*finalize*/false, RAS_STUCK_TIMEOUT);
           // We will retry below in the same loop.
         } else {
           *nextWakeup = std::min(*nextWakeup,
-                                 std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime)+
-                                 RAS_STUCK_TIMEOUT);
+                  std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime)+
+                  RAS_STUCK_TIMEOUT);
         }
       } // if (!ncclIntruQueueEmpty(&conn->sendQ) && conn->sock->status == RAS_SOCK_READY)
     } // if (conn->sock)
@@ -262,8 +262,8 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         struct rasCollRequest bCast;
         char details[256];
         snprintf(details, sizeof(details),
-                 "peer failed to respond for %lds, declaring dead",
-                 (now-conn->startRetryTime)/CLOCK_UNITS_PER_SEC);
+          "peer failed to respond for %lds, declaring dead",
+          (now-conn->startRetryTime)/CLOCK_UNITS_PER_SEC);
         struct rasEventNotification event = {
           .eventType = "PEER_TIMEOUT_DEAD",
           .details = details,
@@ -273,7 +273,7 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
         INFO(NCCL_RAS, "RAS connect retry timeout (%lds) on socket connection with %s",
-             (now-conn->startRetryTime)/CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
+          (now-conn->startRetryTime)/CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
 
         // Broadcast the info about a dead peer to everybody.  This will handle it locally as well, including
         // declaring the peer dead and terminating the connection.
@@ -297,8 +297,8 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           if (!conn->experiencingDelays) {
             char details[256];
             snprintf(details, sizeof(details),
-                     "peer not responding for %lds (connect timeout)",
-                     (now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC);
+              "peer not responding for %lds (connect timeout)",
+              (now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC);
             struct rasEventNotification event = {
               .eventType = "PEER_UNRESPONSIVE",
               .details = details,
@@ -307,7 +307,7 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
             };
             rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
             INFO(NCCL_RAS, "RAS connect timeout warning (%lds) on socket connection with %s",
-                 (now-conn->startRetryTime) / CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
+              (now-conn->startRetryTime) / CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
 
             // See if the connection was meant to be a part of a RAS link and if so, try to initiate fallback
             // connection(s).  At this point, it's mostly just a precaution; we will continue trying to establish
@@ -330,8 +330,8 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
             if (conn->lastRetryTime == 0) {
               char details[256];
               snprintf(details, sizeof(details),
-                       "connection attempt timed out after %lds, attempting reconnect",
-                       (now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC);
+                "connection attempt timed out after %lds, attempting reconnect",
+                (now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC);
               struct rasEventNotification event = {
                 .eventType = "PEER_RETRY",
                 .details = details,
@@ -341,8 +341,8 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
               rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
             }
             INFO(NCCL_RAS, "RAS trying to reconnect with %s (experiencingDelays %d, startRetryTime %.2fs)",
-                 ncclSocketToString(&conn->addr, rasLine), conn->experiencingDelays,
-                 (conn->startRetryTime ? (now-conn->startRetryTime)/1e9 : 0.0));
+              ncclSocketToString(&conn->addr, rasLine), conn->experiencingDelays,
+              (conn->startRetryTime ? (now-conn->startRetryTime)/1e9 : 0.0));
             rasConnOpen(conn);
           }
           if (conn->sock == nullptr)
@@ -406,7 +406,7 @@ ncclResult_t rasNetAcceptNewSocket() {
   NCCLCHECKGOTO(getNewSockEntry(&sock), ret, fail);
 
   NCCLCHECKGOTO(ncclSocketInit(&sock->sock, nullptr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork, nullptr,
-                               /*asyncFlag*/1), ret, fail);
+    /*asyncFlag*/1), ret, fail);
   socketInitialized = true;
   NCCLCHECKGOTO(ncclSocketAccept(&sock->sock, &rasNetListeningSocket), ret, fail);
   NCCLCHECKGOTO(ncclSocketReady(&sock->sock, &ready), ret, fail);
@@ -417,7 +417,7 @@ ncclResult_t rasNetAcceptNewSocket() {
   NCCLCHECKGOTO(rasGetNewPollEntry(&sock->pfd), ret, fail);
   rasPfds[sock->pfd].fd = sock->sock.socketDescriptor;
   rasPfds[sock->pfd].events = POLLIN; // Initially we'll just wait for a handshake from the other side.  This also
-                                      // helps the code tell the sides apart.
+  // helps the code tell the sides apart.
   sock->status = RAS_SOCK_CONNECTING;
 
   INFO(NCCL_RAS, "RAS new incoming socket connection from %s", ncclSocketToString(&sock->sock.addr, rasLine));
@@ -479,8 +479,8 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         char details[256];
         if (sock->conn == nullptr) {
           snprintf(details, sizeof(details),
-                   "handshake completion timed out after %lds (incoming connection)",
-                   (now-sock->createTime)/CLOCK_UNITS_PER_SEC);
+            "handshake completion timed out after %lds (incoming connection)",
+            (now-sock->createTime)/CLOCK_UNITS_PER_SEC);
           struct rasEventNotification event = {
             .eventType = "PEER_INIT_TIMEOUT",
             .details = details,
@@ -490,11 +490,11 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
           INFO(NCCL_RAS, "RAS init timeout error (%lds) on incoming socket connection from %s",
-               (now-sock->createTime)/CLOCK_UNITS_PER_SEC, ncclSocketToString(&sock->sock.addr, rasLine));
+            (now-sock->createTime)/CLOCK_UNITS_PER_SEC, ncclSocketToString(&sock->sock.addr, rasLine));
         } else {
           snprintf(details, sizeof(details),
-                   "handshake completion timed out after %lds (outgoing connection)",
-                   (now-sock->createTime)/CLOCK_UNITS_PER_SEC);
+            "handshake completion timed out after %lds (outgoing connection)",
+            (now-sock->createTime)/CLOCK_UNITS_PER_SEC);
           struct rasEventNotification event = {
             .eventType = "PEER_INIT_TIMEOUT",
             .details = details,
@@ -504,10 +504,10 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
           INFO(NCCL_RAS, "RAS init timeout error (%lds) on socket connection with %s "
-               "(experiencingDelays %d, startRetryTime %.2fs, socket status %d)",
-               (now-sock->createTime)/CLOCK_UNITS_PER_SEC, ncclSocketToString(&sock->sock.addr, rasLine),
-               sock->conn->experiencingDelays,
-               (sock->conn->startRetryTime ? (now-sock->conn->startRetryTime)/1e9 : 0.0), sock->status);
+                         "(experiencingDelays %d, startRetryTime %.2fs, socket status %d)",
+            (now-sock->createTime)/CLOCK_UNITS_PER_SEC, ncclSocketToString(&sock->sock.addr, rasLine),
+            sock->conn->experiencingDelays,
+            (sock->conn->startRetryTime ? (now-sock->conn->startRetryTime)/1e9 : 0.0), sock->status);
         }
         rasSocketTerminate(sock, /*finalize*/true);
         // We may retry later.
@@ -518,8 +518,8 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
       // For sockets that are being terminated, force finalization of the ones that haven't made progress in too long.
       if (now - std::max(sock->lastSendTime, sock->lastRecvTime) > RAS_STUCK_TIMEOUT) {
         INFO(NCCL_RAS, "RAS termination stuck timeout error (%lds) on socket connection with %s",
-             (now-std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC,
-             ncclSocketToString(&sock->sock.addr, rasLine));
+          (now-std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC,
+          ncclSocketToString(&sock->sock.addr, rasLine));
         rasSocketTerminate(sock, /*finalize*/true);
         // This socket is presumably already being re-established, if needed.
       } else {
@@ -531,8 +531,8 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
       // suspend, rasSocketTerminate will do additional checking.
       if (now - std::max(sock->lastSendTime, sock->lastRecvTime) > RAS_IDLE_TIMEOUT) {
         INFO(NCCL_RAS, "RAS idle timeout (%lds) on socket connection with %s",
-             (now - std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC,
-             ncclSocketToString(&sock->sock.addr, rasLine));
+          (now - std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC,
+          ncclSocketToString(&sock->sock.addr, rasLine));
         rasSocketTerminate(sock, /*finalize*/false, /*startRetryOffset*/0, /*retry*/false);
         // The RAS network timeout handler will terminate the conn it was associated with, if any.
       } else {
@@ -566,8 +566,8 @@ void rasSocketTerminate(struct rasSocket* sock, bool finalize, uint64_t startRet
       // Don't attempt to retry on sockets that have been unused for so long that the remote peer probably
       // deliberately closed them.  Make an exception for sockets that are part of the RAS network links.
       if ((retry &&
-           clockNano() - std::max(sock->lastSendTime, sock->lastRecvTime) < RAS_IDLE_TIMEOUT - RAS_IDLE_GRACE_PERIOD) ||
-          rasLinkConnFind(&rasNextLink, sock->conn) || rasLinkConnFind(&rasPrevLink, sock->conn)) {
+        clockNano() - std::max(sock->lastSendTime, sock->lastRecvTime) < RAS_IDLE_TIMEOUT - RAS_IDLE_GRACE_PERIOD) ||
+        rasLinkConnFind(&rasNextLink, sock->conn) || rasLinkConnFind(&rasPrevLink, sock->conn)) {
         // For connections that were fine until now, the connection-level timeout starts at termination, and possibly
         // even earlier, depending on what event trigerred the termination -- if it was another timeout expiring, then
         // we need to include that timeout as well.
@@ -632,7 +632,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
     // Socket is not yet fully established. Continue the OS or NCCL-level handshake.
     if (ncclSocketReady(&sock->sock, &ready) != ncclSuccess) {
       INFO(NCCL_RAS, "RAS unexpected error from ncclSocketReady; terminating the socket connection with %s",
-           ncclSocketToString(&sock->sock.addr, rasLine));
+          ncclSocketToString(&sock->sock.addr, rasLine));
       rasSocketTerminate(sock);
       // We may retry further down.
     } else {
@@ -645,12 +645,12 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
           if (sock->conn == nullptr) {
             // Should never happen.
             INFO(NCCL_RAS, "RAS connect-side socket with %s lacks a connection -- internal error?",
-                 ncclSocketToString(&sock->sock.addr, rasLine));
+                ncclSocketToString(&sock->sock.addr, rasLine));
             rasSocketTerminate(sock);
           } else if (sock->conn->sock == sock) {
             if (rasConnPrepare(sock->conn) != ncclSuccess) {
               INFO(NCCL_RAS, "RAS unexpected error from rasConnPrepare; terminating the socket connection with %s",
-                   ncclSocketToString(&sock->sock.addr, rasLine));
+                  ncclSocketToString(&sock->sock.addr, rasLine));
               rasSocketTerminate(sock);
               // We may retry further down.
             }
@@ -658,7 +658,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
             // The connection this socket is associated with no longer considers it to be the current one.
             // This could possibly happen due to a race condition.  Simply terminate it.
             INFO(NCCL_RAS, "RAS connected with %s via a socket that's no longer current!",
-                 ncclSocketToString(&sock->sock.addr, rasLine));
+                ncclSocketToString(&sock->sock.addr, rasLine));
             rasSocketTerminate(sock);
           }
         } // if (connectSide)
@@ -676,16 +676,16 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
       if (sock->conn == nullptr) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS non-terminating socket with %s lacks a connection: status %d -- internal error?",
-             ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
+            ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
         rasSocketTerminate(sock);
       } else if (sock->conn->sock != sock) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS non-terminating socket with %s is not current: status %d -- internal error?",
-             ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
+            ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
         rasSocketTerminate(sock);
       } else if (rasConnSendMsg(sock->conn, &closed, &allSent) != ncclSuccess) {
         INFO(NCCL_RAS, "RAS unexpected error from rasConnSendMsg; terminating the socket connection with %s",
-             ncclSocketToString(&sock->sock.addr, rasLine));
+            ncclSocketToString(&sock->sock.addr, rasLine));
         rasSocketTerminate(sock);
         // We may retry further down.
       } else if (closed) {
@@ -698,7 +698,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
         rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
         INFO(NCCL_RAS, "RAS socket connection with %s closed by peer on send; terminating it",
-             ncclSocketToString(&sock->sock.addr, rasLine));
+            ncclSocketToString(&sock->sock.addr, rasLine));
         rasSocketTerminate(sock);
         // We may retry further down.
       } else {
@@ -714,7 +714,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
         msg = nullptr;
         if (rasMsgRecv(sock, &msg, &closed) != ncclSuccess) {
           INFO(NCCL_RAS, "RAS unexpected error from rasMsgRecv; terminating the socket connection with %s",
-               ncclSocketToString(&sock->sock.addr, rasLine));
+              ncclSocketToString(&sock->sock.addr, rasLine));
           rasSocketTerminate(sock, /*finalize*/true);
           // We may retry further down.
         } else if (closed) {
@@ -729,7 +729,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
             socketType = "current";
           char details[256];
           snprintf(details, sizeof(details),
-                   "peer closed %s connection during receive operation", socketType);
+            "peer closed %s connection during receive operation", socketType);
           struct rasEventNotification event = {
             .eventType = "PEER_DISCONNECTED",
             .details = details,
@@ -739,7 +739,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
           INFO(NCCL_RAS, "RAS %s socket connection with %s closed by peer on receive; terminating it",
-               socketType, ncclSocketToString(&sock->sock.addr, rasLine));
+              socketType, ncclSocketToString(&sock->sock.addr, rasLine));
           rasSocketTerminate(sock, /*finalize*/true);
           // We may retry further down.
         } else { // !closed
@@ -802,8 +802,8 @@ static ncclResult_t rasLinkHandleNetTimeouts(struct rasLink* link, int64_t now, 
       // than the peer.  If that peer fails to initiate within RAS_CONNECT_WARN, we need to take action.
       if (now - link->lastUpdatePeersTime > RAS_CONNECT_WARN) {
         INFO(NCCL_RAS, "RAS peer connect timeout warning (%lds) on socket connection from %s",
-             (now-link->lastUpdatePeersTime) / CLOCK_UNITS_PER_SEC,
-             ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
+          (now-link->lastUpdatePeersTime) / CLOCK_UNITS_PER_SEC,
+          ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
         NCCLCHECK(rasConnCreate(&rasPeers[linkConn->peerIdx].addr, &linkConn->conn));
         if (linkConn->conn) {
           linkConn->conn->linkFlag = true;
@@ -836,8 +836,8 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
         if (!conn->experiencingDelays) {
           char details[256];
           snprintf(details, sizeof(details),
-                   "peer not responding for %lds (keepalive warning)",
-                   (now - conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC);
+            "peer not responding for %lds (keepalive warning)",
+            (now - conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC);
           struct rasEventNotification event = {
             .eventType = "PEER_UNRESPONSIVE",
             .details = details,
@@ -846,7 +846,7 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
           };
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
           INFO(NCCL_RAS, "RAS keep-alive timeout warning (%lds) on socket connection with %s",
-               (now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
+            (now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
 
           // At this point, it's mostly just a precaution; we will continue with the primary connection until
           // RAS_PEER_DEAD_TIMEOUT expires.
@@ -865,8 +865,8 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
       if (now - conn->sock->lastRecvTime > RAS_KEEPALIVE_TIMEOUT_ERROR) {
         char details[256];
         snprintf(details, sizeof(details),
-                 "keepalive timeout after %lds, terminating connection",
-                 (now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC);
+          "keepalive timeout after %lds, terminating connection",
+          (now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC);
         struct rasEventNotification event = {
           .eventType = "PEER_KEEPALIVE_TIMEOUT",
           .details = details,
@@ -876,7 +876,7 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
         rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
         INFO(NCCL_RAS, "RAS keep-alive timeout error (%lds) on socket connection with %s",
-             (now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
+          (now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC, ncclSocketToString(&conn->addr, rasLine));
         rasSocketTerminate(conn->sock, /*finalize*/true, RAS_KEEPALIVE_TIMEOUT_ERROR);
         *nextWakeup = now; // Retry will be in the next iteration of the main loop so ensure we don't wait.
       } else {
@@ -919,12 +919,12 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
   if (sock->conn == nullptr) {
     // Should never happen.
     INFO(NCCL_RAS, "RAS received a keep-alive message on socket with %s that lacks a connection: status %d -- "
-         "internal error?", ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
+                   "internal error?", ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
     return ncclInternalError;
   }
   clockRealtime(&currentTime);
   travelTime = (currentTime.tv_sec-msg->keepAlive.realTime.tv_sec)*1000*1000*1000 +
-    (currentTime.tv_nsec-msg->keepAlive.realTime.tv_nsec);
+      (currentTime.tv_nsec-msg->keepAlive.realTime.tv_nsec);
 
   if (msg->keepAlive.peersHash != sock->conn->lastRecvPeersHash) {
     sock->conn->lastRecvPeersHash = msg->keepAlive.peersHash;
@@ -973,7 +973,7 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
     // Just in case there's some unforeseen problem with the peers propagation though, exchange with the
     // remote to get everybody in sync.
     INFO(NCCL_RAS, "RAS keepAlive hash mismatch from %s (peersHash 0x%lx, deadPeersHash 0x%lx)",
-         ncclSocketToString(&sock->sock.addr, rasLine), msg->keepAlive.peersHash, msg->keepAlive.deadPeersHash);
+      ncclSocketToString(&sock->sock.addr, rasLine), msg->keepAlive.peersHash, msg->keepAlive.deadPeersHash);
     INFO(NCCL_RAS, "RAS my peersHash 0x%lx, deadPeersHash 0x%lx", rasPeersHash, rasDeadPeersHash);
     NCCLCHECK(rasConnSendPeersUpdate(sock->conn, rasPeers, nRasPeers));
   }
@@ -1040,7 +1040,7 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
   if (foundLinkConn->peerIdx == -1) {
     // Should never happen.
     INFO(NCCL_RAS, "RAS link %d: found connection with %s that has uninitialized peerIdx -- internal error?",
-         link->direction, ncclSocketToString(&conn->addr, rasLine));
+        link->direction, ncclSocketToString(&conn->addr, rasLine));
     ret = ncclInternalError;
     goto exit;
   }
@@ -1061,7 +1061,7 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
       if (linkIdx == -1) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS link %d: could not add a fallback connection with %s -- internal error?",
-             link->direction, ncclSocketToString(&conn->addr, rasLine));
+            link->direction, ncclSocketToString(&conn->addr, rasLine));
         ret = ncclInternalError;
         goto exit;
       }
@@ -1076,8 +1076,8 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
       firstExtLinkIdx++; // Adjust if we inserted a new entry ahead of this one.
 
     INFO(NCCL_RAS, "RAS link %d: %s fallback connection %d with %s",
-         link->direction, (newConn == nullptr ? "opening new" : "calculated existing"),
-         linkIdx, ncclSocketToString(&rasPeers[newPeerIdx].addr, rasLine));
+        link->direction, (newConn == nullptr ? "opening new" : "calculated existing"),
+        linkIdx, ncclSocketToString(&rasPeers[newPeerIdx].addr, rasLine));
     // Note that we don't follow here our convention of "lower address is the one establishing connections" --
     // that convention is for optimizing regular operations, but we don't want to take chances during fault
     // recovery. It may temporarily result in duplicate connections, but we have a mechanism to deal with those.
@@ -1090,8 +1090,8 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
     if (!newConn->experiencingDelays)
       break;
     INFO(NCCL_RAS, "RAS connection experiencingDelays %d, startRetryTime %.2fs, socket status %d",
-         newConn->experiencingDelays, (newConn->startRetryTime ? (clockNano()-newConn->startRetryTime)/1e9 : 0.0),
-         (newConn->sock ? newConn->sock->status : -1));
+        newConn->experiencingDelays, (newConn->startRetryTime ? (clockNano()-newConn->startRetryTime)/1e9 : 0.0),
+        (newConn->sock ? newConn->sock->status : -1));
 
     newPeerIdx = rasLinkCalculatePeer(link, newPeerIdx, /*isFallback*/true);
   }
@@ -1110,9 +1110,9 @@ exit:
 static void rasConnResume(struct rasConnection* conn) {
   if (conn->sock && conn->sock->status == RAS_SOCK_READY) {
     INFO(NCCL_RAS, "RAS %s connection with %s (sendQ %sempty, experiencingDelays %d, startRetryTime %.2fs)",
-         (conn->experiencingDelays && conn->startRetryTime == 0 ? "recovered" : "established"),
-         ncclSocketToString(&conn->addr, rasLine), (ncclIntruQueueEmpty(&conn->sendQ) ? "" : "not "),
-         conn->experiencingDelays, (conn->startRetryTime ? (clockNano()-conn->startRetryTime)/1e9 : 0.0));
+      (conn->experiencingDelays && conn->startRetryTime == 0 ? "recovered" : "established"),
+      ncclSocketToString(&conn->addr, rasLine), (ncclIntruQueueEmpty(&conn->sendQ) ? "" : "not "),
+      conn->experiencingDelays, (conn->startRetryTime ? (clockNano()-conn->startRetryTime)/1e9 : 0.0));
 
     if (conn->experiencingDelays) {
       struct rasEventNotification event = {
@@ -1155,8 +1155,8 @@ static void rasLinkSanitizeFallbacks(struct rasLink* link) {
       for (struct rasLinkConn* linkConn = link->conns->next; linkConn; i++) {
         struct rasLinkConn* linkConnNext = linkConn->next;
         INFO(NCCL_RAS, "RAS link %d: dropping %sfallback connection %d with %s",
-             link->direction, (linkConn->external ? "external " : ""), i,
-             ncclSocketToString(&linkConn->conn->addr, rasLine));
+            link->direction, (linkConn->external ? "external " : ""), i,
+            ncclSocketToString(&linkConn->conn->addr, rasLine));
         free(linkConn);
         linkConn = linkConnNext;
       }
@@ -1178,7 +1178,7 @@ static void rasLinkSanitizeFallbacks(struct rasLink* link) {
 // may need to be sync'ed to the other one as well.  They used to be a single function that could do it all but the
 // logic was extremely difficult to follow then.
 static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* conn, int peerIdx, bool pretend,
-                                   int* pLinkIdx, struct rasLinkConn** pLinkConn, bool insert) {
+    int* pLinkIdx, struct rasLinkConn** pLinkConn, bool insert) {
   ncclResult_t ret = ncclSuccess;
   struct rasLinkConn* oldLinkConn = nullptr;
   struct rasLinkConn* linkConnPrev = nullptr;
@@ -1187,7 +1187,7 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
   if (peerIdx == -1) {
     // Should never happen.
     INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd invoked with invalid peerIdx (pretend %d, insert %d) -- internal error?",
-         link->direction, pretend, insert);
+      link->direction, pretend, insert);
     ret = ncclInternalError;
     goto exit;
   }
@@ -1201,9 +1201,9 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
         if (oldLinkConn->peerIdx != peerIdx) {
           // Should never happen.
           INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd peerIdx %d mismatch with connection with %s "
-               "(pretend %d, insert %d, oldLinkConn->peerIdx %d) -- internal error?",
-               link->direction, peerIdx, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), pretend, insert,
-               oldLinkConn->peerIdx);
+                         "(pretend %d, insert %d, oldLinkConn->peerIdx %d) -- internal error?",
+              link->direction, peerIdx, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), pretend, insert,
+              oldLinkConn->peerIdx);
           ret = ncclInternalError;
           goto exit;
         }
@@ -1229,9 +1229,9 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
         // Should never happen.
         char line[SOCKET_NAME_MAXLEN+1];
         INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd connection mismatch: linkConn %s, conn %s "
-             "(peerIdx %d, pretend %d, insert %d) -- internal error?",
-             link->direction, ncclSocketToString(&linkConn->conn->addr, line), ncclSocketToString(&conn->addr, rasLine),
-             peerIdx, pretend, insert);
+                       "(peerIdx %d, pretend %d, insert %d) -- internal error?",
+            link->direction, ncclSocketToString(&linkConn->conn->addr, line), ncclSocketToString(&conn->addr, rasLine),
+            peerIdx, pretend, insert);
         ret = ncclInternalError;
         goto exit;
       }
@@ -1262,11 +1262,11 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
     // Detect a roll-over and handle it specially.
     if (link->direction * (linkConnPrev->peerIdx - linkConn->peerIdx) > 0) {
       if (link->direction * (peerIdx - linkConnPrev->peerIdx) > 0 ||
-          link->direction * (peerIdx - linkConn->peerIdx) < 0)
+        link->direction * (peerIdx - linkConn->peerIdx) < 0)
         break;
     } else { // Regular, monotonic case with the peerIdx value between two existing elements.
       if (link->direction * (peerIdx - linkConnPrev->peerIdx) > 0 &&
-          link->direction * (peerIdx - linkConn->peerIdx) < 0)
+        link->direction * (peerIdx - linkConn->peerIdx) < 0)
         break;
     }
   } // for (linkConn)
@@ -1283,8 +1283,8 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
       if (i >= oldLinkIdx) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd new link index %d later in the list than the old one "
-             "(insert %d, oldLinkConn %s, oldLinkIdx %d) -- internal error?",
-             link->direction, i, insert, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkIdx);
+                       "(insert %d, oldLinkConn %s, oldLinkIdx %d) -- internal error?",
+            link->direction, i, insert, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkIdx);
         ret = ncclInternalError;
         goto exit;
       }
@@ -1311,7 +1311,7 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
       if (link->conns != nullptr) {
         // Should never happen -- we don't add an element that would replace an existing primary.
         INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd attempting to replace an existing primary connection with %s "
-             "-- internal error?", link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
+                       "-- internal error?", link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
         ret = ncclInternalError;
         goto exit;
       }
@@ -1344,7 +1344,7 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
   if (conn == nullptr) {
     // Should never happen.
     INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternal invoked with nullptr conn (peerIdx %d) -- internal error?",
-         link->direction, peerIdx);
+      link->direction, peerIdx);
     ret = ncclInternalError;
     goto exit;
   }
@@ -1353,15 +1353,15 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
     if (oldLinkConn->peerIdx != -1 && oldLinkConn->peerIdx != peerIdx) {
       // Should never happen.
       INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternald peerIdx %d mismatch with connection with %s "
-           "(oldLinkConn->peerIdx %d) -- internal error?",
-           link->direction, peerIdx, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkConn->peerIdx);
+                     "(oldLinkConn->peerIdx %d) -- internal error?",
+          link->direction, peerIdx, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkConn->peerIdx);
       ret = ncclInternalError;
       goto exit;
     }
 
     if (oldLinkConn->peerIdx == peerIdx)
       goto exit; // Nothing more to do if both conn and peerIdx are up to date.  Note that we neither check nor
-                 // update the value of external here.
+    // update the value of external here.
 
     // Otherwise (oldLinkConn->peerIdx == -1 && peerIdx != -1) oldLinkConn, due to its -1 peerIdx, is in
     // a wrong place in the array -- we need to find the right spot.  oldLinkConn->peerIdx == -1 can only happen for
@@ -1381,9 +1381,9 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
         // Should never happen.
         char line[SOCKET_NAME_MAXLEN+1];
         INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternal connection mismatch: linkConn %s, conn %s "
-             "(peerIdx %d) -- internal error?",
-             link->direction, ncclSocketToString(&linkConn->conn->addr, line), ncclSocketToString(&conn->addr, rasLine),
-             peerIdx);
+                       "(peerIdx %d) -- internal error?",
+            link->direction, ncclSocketToString(&linkConn->conn->addr, line), ncclSocketToString(&conn->addr, rasLine),
+            peerIdx);
         ret = ncclInternalError;
         goto exit;
       }
@@ -1408,11 +1408,11 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
     // Detect a roll-over and handle it specially.
     if (link->direction * (linkConnPrev->peerIdx - linkConn->peerIdx) > 0) {
       if (link->direction * (peerIdx - linkConnPrev->peerIdx) > 0 ||
-          link->direction * (peerIdx - linkConn->peerIdx) < 0)
+        link->direction * (peerIdx - linkConn->peerIdx) < 0)
         break;
     } else { // Regular, monotonic case with the peerIdx value between two existing elements.
       if (link->direction * (peerIdx - linkConnPrev->peerIdx) > 0 &&
-          link->direction * (peerIdx - linkConn->peerIdx) < 0)
+        link->direction * (peerIdx - linkConn->peerIdx) < 0)
         break;
     }
   } // for (linkConn)
@@ -1424,13 +1424,13 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
       if (i >= oldLinkIdx) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternal new link index %d later in the list than the old one "
-             "(oldLinkConn %s, oldLinkIdx %d) -- internal error?",
-             link->direction, i, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkIdx);
+                       "(oldLinkConn %s, oldLinkIdx %d) -- internal error?",
+            link->direction, i, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkIdx);
         ret = ncclInternalError;
         goto exit;
       }
       INFO(NCCL_RAS, "RAS link %d: moving %sfallback connection with %s from %d to %d", link->direction,
-           (oldLinkConn->external ? "external " : ""), ncclSocketToString(&conn->addr, rasLine), oldLinkIdx, i);
+          (oldLinkConn->external ? "external " : ""), ncclSocketToString(&conn->addr, rasLine), oldLinkIdx, i);
       // Remove oldLinkConn from its old spot.
       for (struct rasLinkConn* linkConn = linkConnPrev; linkConn->next; linkConn = linkConn->next) {
         if (linkConn->next == oldLinkConn) {
@@ -1449,13 +1449,13 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
     NCCLCHECK(ncclCalloc(&linkConn, 1));
     if (linkConnPrev) {
       INFO(NCCL_RAS, "RAS link %d: adding external fallback connection %d with %s", link->direction, i,
-           ncclSocketToString(&conn->addr, rasLine));
+          ncclSocketToString(&conn->addr, rasLine));
       linkConn->next = linkConnPrev->next;
       linkConnPrev->next = linkConn;
       linkConn->external = true;
     } else {
       INFO(NCCL_RAS, "RAS link %d: adding external fallback with %s as a new primary connection", link->direction,
-           ncclSocketToString(&conn->addr, rasLine));
+          ncclSocketToString(&conn->addr, rasLine));
       linkConn->next = link->conns;
       link->conns = linkConn;
       linkConn->external = false; // Primary connections are never external.
@@ -1477,13 +1477,13 @@ ncclResult_t rasLinkConnUpdate(struct rasLink* link, struct rasConnection* conn,
   if (conn == nullptr || peerIdx == -1) {
     // Should never happen.
     INFO(NCCL_RAS, "RAS link %d: rasLinkConnUpdate invoked with conn %s, peerIdx %d -- internal error?",
-         link->direction, conn ? ncclSocketToString(&conn->addr, rasLine) : "(null)", peerIdx);
+        link->direction, conn ? ncclSocketToString(&conn->addr, rasLine) : "(null)", peerIdx);
     ret = ncclInternalError;
     goto exit;
   }
 
   NCCLCHECK(rasLinkConnAdd(link, conn, peerIdx, /*pretend*/false, /*pLinkIdx*/nullptr, /*pLinkConn*/nullptr,
-                           /*insert*/false));
+    /*insert*/false));
 exit:
   return ret;
 }
@@ -1498,13 +1498,13 @@ static void rasLinkConnDrop(struct rasLink* link, const struct rasConnection* co
     if (linkConn->conn == conn && (!external || linkConn->external)) {
       if (linkConnPrev) {
         INFO(NCCL_RAS, "RAS link %d: dropping %sfallback connection %d with %s",
-             link->direction, (linkConn->external ? "external " : ""), i,
-             ncclSocketToString(&conn->addr, rasLine));
+            link->direction, (linkConn->external ? "external " : ""), i,
+            ncclSocketToString(&conn->addr, rasLine));
         linkConnPrev->next = linkConn->next;
         free(linkConn);
       } else { // linkConnPrev == nullptr
         INFO(NCCL_RAS, "RAS link %d: dropping primary connection with %s",
-             link->direction, ncclSocketToString(&conn->addr, rasLine));
+            link->direction, ncclSocketToString(&conn->addr, rasLine));
         if (linkConn->next) {
           link->conns = linkConn->next;
           // Ensure that the conn becoming the primary is not marked as external (we don't want to lose it if
@@ -1512,7 +1512,7 @@ static void rasLinkConnDrop(struct rasLink* link, const struct rasConnection* co
           link->conns->external = false;
           if (link->conns->conn)
             INFO(NCCL_RAS, "RAS link %d: former fallback connection 1 with %s is the new primary",
-                 link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
+                link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
           rasLinkSanitizeFallbacks(link);
           free(linkConn);
         } else { // linkConn->next == nullptr
@@ -1530,7 +1530,7 @@ static void rasLinkConnDrop(struct rasLink* link, const struct rasConnection* co
 // Optionally returns the position of the connection in the conns list.
 // Returns nullptr if connection not found.
 static struct rasLinkConn* rasLinkConnFind(const struct rasLink* link, const struct rasConnection* conn,
-                                           int* pLinkIdx) {
+    int* pLinkIdx) {
   int i = 0;
   for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConn = linkConn->next, i++) {
     if (linkConn->conn == conn) {

--- a/src/rma/rma.cc
+++ b/src/rma/rma.cc
@@ -21,7 +21,7 @@ static bool isLsaAccessible(struct ncclComm* comm, int rank) {
   return false;
 }
 
-ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // If we have both proxy and CE tasks, execute them in parallel
@@ -42,11 +42,9 @@ ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* pla
     // Synchronize streams
     CUDACHECKGOTO(cudaEventRecord(ceEvent, ceStream), ret, fail);
     CUDACHECKGOTO(cudaStreamWaitEvent(stream, ceEvent, 0), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksProxy > 0) {
+  } else if (plan->rmaArgs->nRmaTasksProxy > 0) {
     NCCLCHECKGOTO(ncclRmaWaitSignalProxy(comm, plan, stream), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksCe > 0) {
+  } else if (plan->rmaArgs->nRmaTasksCe > 0) {
     NCCLCHECKGOTO(ncclRmaWaitSignalCe(comm, plan, stream), ret, fail);
   }
 
@@ -57,7 +55,7 @@ fail:
 }
 
 
-ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // If we have both proxy and CE tasks, execute them in parallel
@@ -78,11 +76,9 @@ ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cuda
     // Synchronize streams
     CUDACHECKGOTO(cudaEventRecord(ceEvent, ceStream), ret, fail);
     CUDACHECKGOTO(cudaStreamWaitEvent(stream, ceEvent, 0), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksProxy > 0) {
+  } else if (plan->rmaArgs->nRmaTasksProxy > 0) {
     NCCLCHECKGOTO(ncclRmaPutProxy(comm, plan, stream), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksCe > 0) {
+  } else if (plan->rmaArgs->nRmaTasksCe > 0) {
     NCCLCHECKGOTO(ncclRmaPutCe(comm, plan, stream), ret, fail);
   }
 
@@ -260,11 +256,11 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
         break;
       }
 
-      bool lsaAccessible = isLsaAccessible(comm, task->peer);
+      bool taskLsaAccessible = isLsaAccessible(comm, task->peer);
 
       // If the task can be batched, remove from context queue and add to plan
       ncclIntruQueueDequeue(ctxQueue);
-      if (lsaAccessible) {
+      if (taskLsaAccessible) {
         ncclIntruQueueEnqueue(&plan->rmaTaskQueueCe, task);
         plan->rmaArgs->nRmaTasksCe++;
       } else {
@@ -277,7 +273,7 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
   }
 
   INFO(NCCL_COLL, "scheduleRmaTasksToPlan: rank=%d ctx=%d func=%d nRmaTasks=%d nRmaTasksProxy=%d nRmaTasksCe=%d",
-    comm->rank, ctx, plan->rmaArgs->func, plan->rmaArgs->nRmaTasks, plan->rmaArgs->nRmaTasksProxy, plan->rmaArgs->nRmaTasksCe);
+      comm->rank, ctx, plan->rmaArgs->func, plan->rmaArgs->nRmaTasks, plan->rmaArgs->nRmaTasksProxy, plan->rmaArgs->nRmaTasksCe);
 
   return ret;
 }

--- a/src/rma/rma_proxy.cc
+++ b/src/rma/rma_proxy.cc
@@ -59,7 +59,7 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
           uint32_t pi = __atomic_load_n(&ctx->pis[peer], __ATOMIC_ACQUIRE);
           uint32_t ci = __atomic_load_n(&ctx->cis[peer], __ATOMIC_ACQUIRE);
           printf("      Peer %d: readySeq: %lu, doneSeq: %lu, opSeq: %lu, PI: %u, CI: %u\n",
-                 peer, readySeq, doneSeq, opSeq, pi, ci);
+              peer, readySeq, doneSeq, opSeq, pi, ci);
 
           // Count and print pending Descs from circular buffer
           int pendingCount = pi - ci;
@@ -69,7 +69,7 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
             struct ncclRmaProxyDesc* desc = ctx->pendingQueues[peer * ctx->queueSize + idx];
             if (desc != NULL) {
               printf("          Desc: seq=%lu targetRank=%d size=%zu\n",
-                    desc->seq, desc->targetRank, desc->size);
+                  desc->seq, desc->targetRank, desc->size);
             }
           }
 
@@ -85,7 +85,7 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
           desc = ncclIntruQueueHead(&ctx->rmaProxyInProgressQueues[peer]);
           while (desc != NULL) {
             printf("          Desc: seq=%lu targetRank=%d size=%zu\n",
-                  desc->seq, desc->targetRank, desc->size);
+                desc->seq, desc->targetRank, desc->size);
             desc = desc->next;
           }
         }
@@ -97,12 +97,12 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
   return ncclSuccess;
 }
 
-void ncclDumpRmaProxyState(int signal) {
+void ncclDumpRmaProxyState(int /*signal*/) {
   dumpRmaProxyState(ncclLastRmaProxyState);
 }
 
 static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
-                                bool forceNonDataDirect = false) {
+    bool forceNonDataDirect = false) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 
 #if CUDA_VERSION >= 11070
@@ -113,13 +113,13 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 #if CUDA_VERSION >= 12080
   if (ncclParamIbDataDirect() && !forceNonDataDirect) {
     CUresult status = pfn_cuMemGetHandleForAddressRange(
-      (void *)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
+            (void *)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+            CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
     if (status == CUDA_SUCCESS) return ncclSuccess;
   }
 #endif
   CUresult status = pfn_cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
-                                                      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+    CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
   if (status == CUDA_SUCCESS) return ncclSuccess;
 #endif
 
@@ -129,8 +129,8 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 // Check if the GIN plugin supports DMA-BUF, if so we can try to get the DMA-BUF handle from CUDA,
 // if that fails we fallback to non-DMA-BUF
 static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, ncclNetProperties_t props, void *addr,
-                                         size_t size, int type, int mr_flags, void **mhandle,
-                                         void **ginHandle) {
+    size_t size, int type, int mr_flags, void **mhandle,
+    void **ginHandle) {
   if (type == NCCL_PTR_HOST) {
     NCCLCHECK(ginComm->regMrSym(ginCollComm, addr, size, type, mr_flags, mhandle, ginHandle));
   } else if (type == NCCL_PTR_CUDA) {
@@ -141,7 +141,7 @@ static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, 
       dmabufResult = getDmaBufFd(addr, size, &dmabufFd);
       if (dmabufResult == ncclSuccess) {
         registrationResult = ginComm->regMrSymDmaBuf(ginCollComm, addr, size, type, 0, dmabufFd,
-                                                     mr_flags, mhandle, ginHandle);
+                mr_flags, mhandle, ginHandle);
         close(dmabufFd);
       }
       if (registrationResult != ncclSuccess) {
@@ -149,7 +149,7 @@ static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, 
         dmabufResult = getDmaBufFd(addr, size, &dmabufFd, true);
         if (dmabufResult == ncclSuccess) {
           NCCLCHECK(ginComm->regMrSymDmaBuf(ginCollComm, addr, size, type, 0, dmabufFd,
-                                            mr_flags, mhandle, ginHandle));
+            mr_flags, mhandle, ginHandle));
           close(dmabufFd);
         }
       }
@@ -167,7 +167,7 @@ static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, 
 static uint64_t isPowerOfTwo(uint64_t n) { return (n > 0) && ((n & (n - 1)) == 0); }
 
 ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, ncclNetProperties_t props,
-                                       void **outRmaProxyCtx, ncclNetDeviceHandle_t **outDevHandle) {
+    void **outRmaProxyCtx, ncclNetDeviceHandle_t **outDevHandle) {
   // Get the GIN plugin interface
   ncclGin_t *ginComm = (ncclGin_t *)comm->rmaState.rmaProxyState.ncclGin;
 
@@ -183,11 +183,11 @@ ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, nc
   // Enforcing strong ordering on the signals mr is vital to ensure ordering between puts and signals.
   size_t signalsBufSize = (comm->nRanks + 1) * sizeof(uint64_t);
   NCCLCHECK(ncclCuMemAlloc((void **)&rmaProxyCtx->signalsDev, &rmaProxyCtx->signalsCumemhandle,
-                           CU_MEM_HANDLE_TYPE_NONE, signalsBufSize, comm->memManager));
+    CU_MEM_HANDLE_TYPE_NONE, signalsBufSize, comm->memManager));
   CUDACHECK(cudaMemset(rmaProxyCtx->signalsDev, 0, signalsBufSize));
   NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, rmaProxyCtx->props, rmaProxyCtx->signalsDev, signalsBufSize,
-                                 NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
-                                 &rmaProxyCtx->signalsMhandle, &rmaProxyCtx->signalsGinHandle));
+    NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
+    &rmaProxyCtx->signalsMhandle, &rmaProxyCtx->signalsGinHandle));
 
   // Allocate the host buffer to track the expected values of the signals
   NCCLCHECK(ncclCalloc(&rmaProxyCtx->signalsHost, signalsBufSize));
@@ -195,11 +195,11 @@ ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, nc
   // Allocate the sequence numbers for the per-rank network function descriptors
   // These are allocated as CPU-accessible memory (either GDR or host memory)
   NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->opSeqs, &rmaProxyCtx->opSeqsDev,
-                                  comm->nRanks, 0, &rmaProxyCtx->opSeqsGdrHandle, comm->memManager));
+    comm->nRanks, 0, &rmaProxyCtx->opSeqsGdrHandle, comm->memManager));
   NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->readySeqs, &rmaProxyCtx->readySeqsDev,
-                                  comm->nRanks, 0, &rmaProxyCtx->readySeqsGdrHandle, comm->memManager));
+    comm->nRanks, 0, &rmaProxyCtx->readySeqsGdrHandle, comm->memManager));
   NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->doneSeqs, &rmaProxyCtx->doneSeqsDev,
-                                  comm->nRanks, 0, &rmaProxyCtx->doneSeqsGdrHandle, comm->memManager));
+    comm->nRanks, 0, &rmaProxyCtx->doneSeqsGdrHandle, comm->memManager));
 
   // Sanitize and set up the lock-free circular buffer queue size
   uint64_t queueSize = ncclParamRmaProxyQueueSize();
@@ -209,18 +209,18 @@ ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, nc
   }
   if (queueSize > maxRequests) {
     INFO(NCCL_NET,
-         "NCCL_RMA_PROXY_QUEUE_SIZE is greater than the maximum outstanding requests (%d), using the default/maximum value instead",
-         maxRequests);
+        "NCCL_RMA_PROXY_QUEUE_SIZE is greater than the maximum outstanding requests (%d), using the default/maximum value instead",
+        maxRequests);
     queueSize = maxRequests;
   }
   if (queueSize < 1) {
     INFO(NCCL_NET,
-         "NCCL_RMA_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
+        "NCCL_RMA_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
     queueSize = maxRequests;
   }
   if (!isPowerOfTwo(queueSize)) {
     INFO(NCCL_NET,
-         "NCCL_RMA_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
+        "NCCL_RMA_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
     queueSize = maxRequests;
   }
   rmaProxyCtx->queueSize = queueSize;
@@ -265,7 +265,7 @@ static ncclResult_t ncclRmaProxyPollCompletion(ncclGin_t *ncclGin, struct ncclRm
     NCCLCHECK(ncclGin->test(ctx->ginCollComm, inProgressDesc->request, &done));
     if (done) {
       INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollCompletion: targetRank=%d descSeq=%lu COMPLETED, updating doneSeq",
-        ctx->comm->rank, inProgressDesc->targetRank, inProgressDesc->seq);
+          ctx->comm->rank, inProgressDesc->targetRank, inProgressDesc->seq);
 
       // Update the doneSeq for the target rank with RELEASE to ensure GPU sees it
       __atomic_store_n(&ctx->doneSeqs[inProgressDesc->targetRank], inProgressDesc->seq, __ATOMIC_RELEASE); // sync with the custreamWait aquire semantic
@@ -324,7 +324,7 @@ static ncclResult_t ncclRmaProxyPollDesc(ncclGin_t *ncclGin, struct ncclRmaProxy
       ncclIntruQueueEnqueue(&ctx->rmaProxyInProgressQueues[peer], pendingDesc);
 
       INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollDesc: targetRank=%d descSeq=%lu readySeq=%lu srcOff=%lu srcHandle=%p dstOff=%lu dstHandle=%p size=%lu - issuing network operation",
-        ctx->comm->rank, pendingDesc->targetRank, pendingDesc->seq, readySeq, pendingDesc->srcOff, pendingDesc->srcHandle, pendingDesc->dstOff, pendingDesc->dstHandle, pendingDesc->size);
+          ctx->comm->rank, pendingDesc->targetRank, pendingDesc->seq, readySeq, pendingDesc->srcOff, pendingDesc->srcHandle, pendingDesc->dstOff, pendingDesc->dstHandle, pendingDesc->size);
     } else {
       // ReadySeq not ready yet - stop processing this peer's pending queue to maintain FIFO order
       break;
@@ -348,7 +348,7 @@ ncclResult_t ncclRmaProxyProgress(ncclGin_t *ncclGin, void *rmaProxyCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
+ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx) {
   if (!rmaProxyCtx) return ncclSuccess;
   struct ncclRmaProxyCtx *ctx = (struct ncclRmaProxyCtx *)rmaProxyCtx;
 
@@ -413,20 +413,20 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
 
 ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t size,
     void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS],
-    ncclGinWindow_t rmaDevWins[NCCL_GIN_MAX_CONNECTIONS]){
-      struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
-      for (int n = 0; n < rmaProxyState->ginCommCount; n++) {
-          NCCLCHECK(ncclRmaProxyRegMrSym(rmaProxyState->ncclGin, rmaProxyState->ginComms[n], rmaProxyState->props[n], address, size,
-                                         NCCL_PTR_CUDA, 0, &rmaHostWins[n], &rmaDevWins[n]));
-        if (rmaHostWins[n] == NULL) {
-          WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
-          return ncclSystemError;
-        }
-      }
-      return ncclSuccess;
+    ncclGinWindow_t rmaDevWins[NCCL_GIN_MAX_CONNECTIONS]) {
+  struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
+  for (int n = 0; n < rmaProxyState->ginCommCount; n++) {
+    NCCLCHECK(ncclRmaProxyRegMrSym(rmaProxyState->ncclGin, rmaProxyState->ginComms[n], rmaProxyState->props[n], address, size,
+      NCCL_PTR_CUDA, 0, &rmaHostWins[n], &rmaDevWins[n]));
+    if (rmaHostWins[n] == NULL) {
+      WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
+      return ncclSystemError;
+    }
+  }
+  return ncclSuccess;
 }
 
-ncclResult_t ncclRmaProxyDeregister(struct ncclComm* comm, void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS]){
+ncclResult_t ncclRmaProxyDeregister(struct ncclComm* comm, void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS]) {
   struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
   for (int n = 0; n < rmaProxyState->ginCommCount; n++) {
     NCCLCHECK(rmaProxyState->ncclGin->deregMrSym(rmaProxyState->ginComms[n], rmaHostWins[n]));
@@ -530,15 +530,15 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   for (int n = 0; n < ginCommCount; n++) {
     void* listenComm;
     NCCLCHECKGOTO(
-      rmaProxyState->ncclGin->listen(rmaProxyState->ginInstance, localGinDevs[n],
-                                allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
-      ret, fail);
+        rmaProxyState->ncclGin->listen(rmaProxyState->ginInstance, localGinDevs[n],
+            allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
+        ret, fail);
     NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allHandles, NCCL_NET_HANDLE_MAXSIZE), ret,
-                  fail);
+      fail);
     NCCLCHECKGOTO(
-      rmaProxyState->ncclGin->connect(comm->netContext, handles, comm->nRanks, comm->rank, 1, 0,
-                                      listenComm, rmaProxyState->ginComms + n),
-      ret, fail);
+        rmaProxyState->ncclGin->connect(comm->netContext, handles, comm->nRanks, comm->rank, 1, 0,
+            listenComm, rmaProxyState->ginComms + n),
+        ret, fail);
     NCCLCHECKGOTO(rmaProxyState->ncclGin->getProperties(localGinDevs[n], &rmaProxyState->props[n]), ret, fail);
     NCCLCHECKGOTO(rmaProxyState->ncclGin->closeListen(listenComm), ret, fail);
   }
@@ -555,8 +555,8 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
     // Round-robin mapping to physical GIN communicator contexts
     int ginCommIdx = n % rmaProxyState->ginCommCount;
     NCCLCHECKGOTO(ncclRmaProxyCreateContext(comm, rmaProxyState->ginComms[ginCommIdx], rmaProxyState->props[ginCommIdx],
-                                              &rmaProxyState->rmaProxyCtxs[n], &rmaProxyState->rmaProxyDevHandles[n]),
-                  ret, fail);
+      &rmaProxyState->rmaProxyCtxs[n], &rmaProxyState->rmaProxyDevHandles[n]),
+      ret, fail);
   }
 
   // Check whether we need proxy progress and if so, start / wake up the progress thread.
@@ -628,7 +628,7 @@ ncclResult_t ncclRmaProxyFinalize(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclRmaPutProxy(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaPutProxy(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // Make sure the RMA proxy is connected
@@ -710,7 +710,7 @@ ncclResult_t ncclRmaPutProxy(struct ncclComm* comm, struct ncclKernelPlan* plan,
     batchParams[batchIdx+nRmaTasksProxy].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
 
     INFO(NCCL_COLL, "ncclRmaPutProxy enqueued Desc: rank=%d peer=%d ctx=%d size=%ld signalMode=%d readySeq=%lu doneSeq=%lu",
-      comm->rank, task->peer, ctx, task->count * ncclTypeSize(task->datatype), task->signalMode, (uint64_t)desc->seq, (uint64_t)desc->seq);
+        comm->rank, task->peer, ctx, task->count * ncclTypeSize(task->datatype), task->signalMode, (uint64_t)desc->seq, (uint64_t)desc->seq);
 
     // Write descriptor to queue
     uint32_t idx = pi & (rmaProxyCtx->queueSize - 1);
@@ -741,7 +741,7 @@ fail:
 
 
 
-ncclResult_t ncclRmaWaitSignalProxy(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaWaitSignalProxy(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // Make sure the RMA proxy is connected

--- a/src/scheduler/allgatherv_sched.cc
+++ b/src/scheduler/allgatherv_sched.cc
@@ -82,7 +82,7 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
 
     // Break each bcast into nParts evenly, each part assigned to a channel.
     int nParts = nChannels;
-    uint32_t channelWorkBytes[MAXCHANNELS] = {0};
+    uint32_t channelWorkBytes[MAXCHANNELS] = {};
     for (int part=0; part < nParts; part++) {
       // Sort tasks according to ring depth upstream from us.
       int nTasks = batchTasks;
@@ -155,7 +155,7 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
           ncclAddWorkBatchToPlan(comm, plan, channelId, ncclDevWorkTypeBcast, funcIndex, plan->workBytes, /*p2pEpoch=*/-1, /*p2pRound=*/-1, newBatch);
           newBatch = false;
           plan->workBytes += sizeof(ncclDevWorkBcast);
-      }
+        }
       }
 
       // calculate proxy for this channel

--- a/src/scheduler/symmetric_sched.cc
+++ b/src/scheduler/symmetric_sched.cc
@@ -14,7 +14,7 @@ extern int64_t ncclParamSingleProcMemRegEnable();
 
 NCCL_PARAM(SymNoWinEnable, "SYM_NOWIN_ENABLE", 0);
 
-ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskColl* task, struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue, struct ncclTaskColl** remainTasksHead) {
+ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskColl* task, struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* /*symTaskQueue*/, struct ncclTaskColl** remainTasksHead) {
   ncclResult_t ret = ncclSuccess;
   int fnOpTySymCount = 0;
   struct ncclTaskColl* tasksSymByFnOpTy[ncclNumFuncs * ncclNumDevRedOps * ncclNumTypes * ncclNumSymRegTypes];
@@ -62,7 +62,7 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
 
   // Determine symmetric tasks kernels
   for (int cursor = 0; cursor < fnOpTySymCount; cursor++) {
-    struct ncclTaskColl* task = tasksSymByFnOpTy[fnOpTySymIndices[cursor]];
+    task = tasksSymByFnOpTy[fnOpTySymIndices[cursor]];
     while (task != NULL) {
       ncclSymkKernelId kernelId = ncclSymkKernelId_Count;
       int nChannels = MAXCHANNELS;
@@ -87,8 +87,8 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
         task = task->next;
       }
       NCCLCHECK(ncclSymkPickKernel(comm, headTask->func, headTask->opDev.op, headTask->datatype,
-                                   countTotal, countMax, nWorks, headTask->winRegType,
-                                   &estTimeUs, &kernelId, &nChannels, &nWarps, &forced));
+        countTotal, countMax, nWorks, headTask->winRegType,
+        &estTimeUs, &kernelId, &nChannels, &nWarps, &forced));
       task = headTask;
       bool isLLKernel = (1 << kernelId) & ncclSymkLLKernelMask();
       bool isOneThreadMultiGpus = comm->intraRanks > 1 && !ncclParamSingleProcMemRegEnable();
@@ -219,7 +219,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
     NCCLCHECKGOTO(ncclSymkMakeDevWork(comm, task, &devWork), ret, fail);
 
     cellLeft = taskCell = DIVUP(task->count, cellCount);
-    for (;curChannel < nMaxChannels;) {
+    for (; curChannel < nMaxChannels;) {
       workRangePtr[curChannel].workHi = workIndex;
       if (curChannelWork == 0) {
         if (devWork.nChannels == 0) {
@@ -272,7 +272,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
     if (isSymLast == 1) break;
     if (curChannel == nMaxChannels) {
       WARN("ncclSymmetricTaskScheduler ran out of channel space (nMaxChannels=%d, workCount=%d, workIndex=%d)",
-           nMaxChannels, workCount, workIndex);
+        nMaxChannels, workCount, workIndex);
       goto fail;
     }
   }
@@ -286,7 +286,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
 
   if (comm->rank == 0) {
     INFO(NCCL_TUNING, "%s [Symmetric]: %ld Bytes -> Kernel %s nchannels %d nthreads %d nWorks %d", funcName,
-         logCount * ncclTypeSize(headTask->datatype), kernelName, curChannel, plan->threadPerBlock, workCount);
+        logCount * ncclTypeSize(headTask->datatype), kernelName, curChannel, plan->threadPerBlock, workCount);
   }
 
 exit:

--- a/src/sym_kernels.cc
+++ b/src/sym_kernels.cc
@@ -32,54 +32,54 @@ constexpr char const* kernelName[] = {
 };
 
 constexpr uint32_t kernelMask_STMC = 1<<ncclSymkKernelId_AllGather_LLMC |
-                                     1<<ncclSymkKernelId_AllGather_STMC |
-                                     1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                     1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                     1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                     1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
+    1<<ncclSymkKernelId_AllGather_STMC |
+    1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
+    1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
+    1<<ncclSymkKernelId_ReduceScatter_LDMC |
+    1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
 
 constexpr uint32_t kernelMask_LDMC = 1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                     1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                     1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
+    1<<ncclSymkKernelId_ReduceScatter_LDMC |
+    1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
 
 constexpr uint32_t kernelMask_LL = 1<<ncclSymkKernelId_AllReduce_AGxLL_R |
-                                   1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                   1<<ncclSymkKernelId_AllGather_LL |
-                                   1<<ncclSymkKernelId_AllGather_LLMC |
-                                   1<<ncclSymkKernelId_ReduceScatter_LL;
+    1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
+    1<<ncclSymkKernelId_AllGather_LL |
+    1<<ncclSymkKernelId_AllGather_LLMC |
+    1<<ncclSymkKernelId_ReduceScatter_LL;
 
 constexpr uint32_t kernelMask_AG = 1<<ncclSymkKernelId_AllGather_LL |
-                                   1<<ncclSymkKernelId_AllGather_LLMC |
-                                   1<<ncclSymkKernelId_AllGather_ST |
-                                   1<<ncclSymkKernelId_AllGather_STMC |
-                                   1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
+    1<<ncclSymkKernelId_AllGather_LLMC |
+    1<<ncclSymkKernelId_AllGather_ST |
+    1<<ncclSymkKernelId_AllGather_STMC |
+    1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
 
 constexpr uint32_t kernelMask_AR = 1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                   1<<ncclSymkKernelId_AllReduce_AGxLL_R |
-                                   1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                   1<<ncclSymkKernelId_AllReduce_RSxLD_AGxST;
+    1<<ncclSymkKernelId_AllReduce_AGxLL_R |
+    1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
+    1<<ncclSymkKernelId_AllReduce_RSxLD_AGxST;
 
 constexpr uint32_t kernelMask_RS = 1<<ncclSymkKernelId_ReduceScatter_LD |
-                                   1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                   1<<ncclSymkKernelId_ReduceScatter_LL |
-                                   1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
-                                   1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
+    1<<ncclSymkKernelId_ReduceScatter_LDMC |
+    1<<ncclSymkKernelId_ReduceScatter_LL |
+    1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
+    1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
 
 constexpr uint32_t kernelMask_LSA = 1<<ncclSymkKernelId_AllReduce_AGxLL_R |
-                                    1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                    1<<ncclSymkKernelId_AllReduce_RSxLD_AGxST |
-                                    1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                    1<<ncclSymkKernelId_AllGather_LL |
-                                    1<<ncclSymkKernelId_AllGather_LLMC |
-                                    1<<ncclSymkKernelId_AllGather_ST |
-                                    1<<ncclSymkKernelId_AllGather_STMC |
-                                    1<<ncclSymkKernelId_ReduceScatter_LL |
-                                    1<<ncclSymkKernelId_ReduceScatter_LD |
-                                    1<<ncclSymkKernelId_ReduceScatter_LDMC;
+    1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
+    1<<ncclSymkKernelId_AllReduce_RSxLD_AGxST |
+    1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
+    1<<ncclSymkKernelId_AllGather_LL |
+    1<<ncclSymkKernelId_AllGather_LLMC |
+    1<<ncclSymkKernelId_AllGather_ST |
+    1<<ncclSymkKernelId_AllGather_STMC |
+    1<<ncclSymkKernelId_ReduceScatter_LL |
+    1<<ncclSymkKernelId_ReduceScatter_LD |
+    1<<ncclSymkKernelId_ReduceScatter_LDMC;
 
 constexpr uint32_t kernelMask_Gin = 1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
-                                    1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC |
-                                    1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
+    1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC |
+    1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
 
 constexpr uint32_t kernelMask_DynamicSmem = kernelMask_Gin & kernelMask_RS;
 
@@ -92,10 +92,10 @@ int ncclSymkDynamicSmemKernelMask() {
 
 static uint32_t kernelMask_coll(ncclFunc_t coll) {
   switch (coll) {
-  case ncclFuncAllGather: return kernelMask_AG;
-  case ncclFuncAllReduce: return kernelMask_AR;
-  case ncclFuncReduceScatter: return kernelMask_RS;
-  default: return 0;
+    case ncclFuncAllGather: return kernelMask_AG;
+    case ncclFuncAllReduce: return kernelMask_AR;
+    case ncclFuncReduceScatter: return kernelMask_RS;
+    default: return 0;
   }
 }
 
@@ -185,20 +185,20 @@ static void getBusMul_ReduceScatter_RailA2A(
     struct ncclComm* comm, bool ldmc,
     // Bus multipliers per bottleneck
     double* out_smMul, double* out_lsaMul, double* out_ginMul
-  ) {
+) {
   int lsaRanks = ncclTeamLsa(comm).nRanks;
   int railRanks = ncclTeamRail(comm).nRanks;
   // LSA
   *out_lsaMul = std::max(
-    /*inbound*/(ldmc ? lsaRanks : lsaRanks-1)*railRanks,
-    /*outbound*/(lsaRanks-1)*railRanks
-  );
+          /*inbound*/(ldmc ? lsaRanks : lsaRanks-1)*railRanks,
+          /*outbound*/(lsaRanks-1)*railRanks
+      );
   // GIN
   *out_ginMul = railRanks-1; // inbound == outbound
   // SM. Inbound (reads) only because it dominates outbound (writes).
   *out_smMul =
-    /*stage 0*/(lsaRanks == 1 ? 0 : (ldmc ? 1 : lsaRanks)*(railRanks-1)) +
-    /*stage 1*/(ldmc ? 1 : lsaRanks) + (railRanks-1);
+      /*stage 0*/(lsaRanks == 1 ? 0 : (ldmc ? 1 : lsaRanks)*(railRanks-1)) +
+      /*stage 1*/(ldmc ? 1 : lsaRanks) + (railRanks-1);
 }
 
 static double getSmBw_ReduceScatter_RailA2A(struct ncclComm* comm, bool ldmc) {
@@ -212,7 +212,7 @@ static double getSmBw_ReduceScatter_RailA2A(struct ncclComm* comm, bool ldmc) {
   }
 }
 
-static double getSmLat_ReduceScatter_RailA2A(struct ncclComm* comm, bool ldmc) {
+static double getSmLat_ReduceScatter_RailA2A(struct ncclComm* /*comm*/, bool /*ldmc*/) {
   // Processing delay. Larger value means bigger network buffers.
   return 10.e-6;
 }
@@ -274,7 +274,7 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
   *timeUs = FLT_MAX;
   *nBlocks = 0;
   switch (k) {
-  case ncclSymkKernelId_AllGather_RailRing_LsaSTMC: {
+    case ncclSymkKernelId_AllGather_RailRing_LsaSTMC: {
       constexpr int railChunkSize = ncclSymkAllGather_RailRing_ChunkSize;
       int requiredBlocks = DIVUP(nBytes, railChunkSize);
       float intraBw = lsaBw;
@@ -285,8 +285,8 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
       *timeUs = steps * ginLat + std::max(intraTime, interTime);
       *nBlocks = std::max(nMinBlocks, std::min(nMaxBlocks, requiredBlocks));
     } break;
-  case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD:
-  case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC: {
+    case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD:
+    case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC: {
       bool ldmc = k == ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
       nMaxBlocks = std::min(nMaxBlocks, symk->maxGinInboxBlocks);
       nMaxBlocks = std::min(nMaxBlocks, calcSatBlocks_ReduceScatter_RailA2A(comm, ldmc));
@@ -307,7 +307,7 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
       time += ginLat;
       *timeUs = (/*usec/sec=*/1.e6)*time;
     } break;
-  default: break;
+    default: break;
   }
 }
 
@@ -321,53 +321,53 @@ static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
   double busMultiplier = 1;
 
   switch (k) {
-  default:
-    busBytes = size_t(1)<<50;
-    break;
+    default:
+      busBytes = size_t(1)<<50;
+      break;
 
-  case ncclSymkKernelId_AllReduce_AGxLL_R:
-    busBytes = nRanks*nBytes*LL_BusFactor;
-    break;
-  case ncclSymkKernelId_AllReduce_AGxLLMC_R:
-    busBytes = nRanks*nBytes*LL_BusFactor;
-    busMultiplier = 1.1; // To beat non-MC LL
-    break;
-  case ncclSymkKernelId_AllReduce_RSxLD_AGxST:
-    busBytes = 2*nBytes*(nRanks-1)/nRanks;
-    break;
-  case ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC:
-    busBytes = nBytes/nRanks + nBytes;
-    busMultiplier = nRanks;
-    nMaxBlocks = nMaxBlocksNvls;
-    break;
+    case ncclSymkKernelId_AllReduce_AGxLL_R:
+      busBytes = nRanks*nBytes*LL_BusFactor;
+      break;
+    case ncclSymkKernelId_AllReduce_AGxLLMC_R:
+      busBytes = nRanks*nBytes*LL_BusFactor;
+      busMultiplier = 1.1; // To beat non-MC LL
+      break;
+    case ncclSymkKernelId_AllReduce_RSxLD_AGxST:
+      busBytes = 2*nBytes*(nRanks-1)/nRanks;
+      break;
+    case ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC:
+      busBytes = nBytes/nRanks + nBytes;
+      busMultiplier = nRanks;
+      nMaxBlocks = nMaxBlocksNvls;
+      break;
 
-  case ncclSymkKernelId_AllGather_LL:
-    busBytes = nRanks*nBytes*LL_BusFactor;
-    break;
-  case ncclSymkKernelId_AllGather_LLMC:
-    busBytes = nRanks*nBytes*LL_BusFactor;
-    busMultiplier = 1.1; // To beat non-MC LL
-    break;
-  case ncclSymkKernelId_AllGather_ST:
-    busBytes = (nRanks-1)*nBytes;
-    break;
-  case ncclSymkKernelId_AllGather_STMC:
-    busBytes = (nRanks-1)*nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
-    busMultiplier = 0.55*nRanks;
-    nMaxBlocks = nMaxBlocksNvls;
-    break;
+    case ncclSymkKernelId_AllGather_LL:
+      busBytes = nRanks*nBytes*LL_BusFactor;
+      break;
+    case ncclSymkKernelId_AllGather_LLMC:
+      busBytes = nRanks*nBytes*LL_BusFactor;
+      busMultiplier = 1.1; // To beat non-MC LL
+      break;
+    case ncclSymkKernelId_AllGather_ST:
+      busBytes = (nRanks-1)*nBytes;
+      break;
+    case ncclSymkKernelId_AllGather_STMC:
+      busBytes = (nRanks-1)*nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
+      busMultiplier = 0.55*nRanks;
+      nMaxBlocks = nMaxBlocksNvls;
+      break;
 
-  case ncclSymkKernelId_ReduceScatter_LL:
-    busBytes = nRanks*nBytes*LL_BusFactor;
-    break;
-  case ncclSymkKernelId_ReduceScatter_LD:
-    busBytes = (nRanks-1)*nBytes;
-    break;
-  case ncclSymkKernelId_ReduceScatter_LDMC:
-    busBytes = (nRanks-1)*nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
-    busMultiplier = 0.55*nRanks;
-    nMaxBlocks = nMaxBlocksNvls;
-    break;
+    case ncclSymkKernelId_ReduceScatter_LL:
+      busBytes = nRanks*nBytes*LL_BusFactor;
+      break;
+    case ncclSymkKernelId_ReduceScatter_LD:
+      busBytes = (nRanks-1)*nBytes;
+      break;
+    case ncclSymkKernelId_ReduceScatter_LDMC:
+      busBytes = (nRanks-1)*nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
+      busMultiplier = 0.55*nRanks;
+      nMaxBlocks = nMaxBlocksNvls;
+      break;
   }
 
   nMaxBlocks = std::min<int>(nMaxBlocks, comm->config.maxCTAs);
@@ -417,8 +417,8 @@ ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) {
 
     struct ncclDevResourceRequirements lla2aReq;
     ncclLLA2ACreateRequirement(
-      ncclSymkMaxBlocks, ncclLLA2ACalcSlots(ncclTeamLsa(comm).nRanks*ncclSymkMaxThreads, ncclSymkLLMaxEltSize),
-      &symk->kcomm.lsaLLA2A, &lla2aReq
+        ncclSymkMaxBlocks, ncclLLA2ACalcSlots(ncclTeamLsa(comm).nRanks*ncclSymkMaxThreads, ncclSymkLLMaxEltSize),
+        &symk->kcomm.lsaLLA2A, &lla2aReq
     );
     lla2aReq.next = reqs.resourceRequirementsList;
     reqs.resourceRequirementsList = &lla2aReq;
@@ -438,15 +438,15 @@ ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) {
       symk->maxGinInboxBlocks = maxBlocks;
 
       ncclGinInboxA2ACreateRequirement(
-        ncclTeamRail(comm), maxBlocks, log2Up(bufSize),
-        &symk->kcomm.ginInboxRail, &ginInboxRailReq
+          ncclTeamRail(comm), maxBlocks, log2Up(bufSize),
+          &symk->kcomm.ginInboxRail, &ginInboxRailReq
       );
       ginInboxRailReq.next = reqs.resourceRequirementsList;
       reqs.resourceRequirementsList = &ginInboxRailReq;
 
       ncclGinOutboxCreateRequirement(
-        maxBlocks, log2Up(bufSize),
-        &symk->kcomm.ginOutbox, &ginOutboxReq
+          maxBlocks, log2Up(bufSize),
+          &symk->kcomm.ginOutbox, &ginOutboxReq
       );
       ginOutboxReq.next = reqs.resourceRequirementsList;
       reqs.resourceRequirementsList = &ginOutboxReq;
@@ -465,7 +465,7 @@ ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) {
       reqs.railGinBarrierCount = ncclSymkMaxBlocks;
 
       bool railedGinInitialized = (comm->sharedRes->ginState.connected &&
-                                    comm->sharedRes->ginState.ginConnectionType == NCCL_GIN_CONNECTION_RAIL);
+              comm->sharedRes->ginState.ginConnectionType == NCCL_GIN_CONNECTION_RAIL);
       reqs.ginConnectionType = railedGinInitialized ? NCCL_GIN_CONNECTION_RAIL : comm->globalGinSupport;
     }
 
@@ -485,27 +485,27 @@ ncclResult_t ncclSymkFinalize(struct ncclComm* comm) {
 static bool ncclSymkImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
   bool isFloat;
   switch (ty) {
-  case ncclFloat64:
-  case ncclFloat32:
-  case ncclFloat16:
-  case ncclBfloat16:
-  case ncclFloat8e4m3:
-  case ncclFloat8e5m2:
-    isFloat = true;
-    break;
-  default:
-    isFloat = false;
-    break;
+    case ncclFloat64:
+    case ncclFloat32:
+    case ncclFloat16:
+    case ncclBfloat16:
+    case ncclFloat8e4m3:
+    case ncclFloat8e5m2:
+      isFloat = true;
+      break;
+    default:
+      isFloat = false;
+      break;
   }
 
   switch (coll) {
-  case ncclFuncAllGather:
-    return true;
-  case ncclFuncAllReduce:
-  case ncclFuncReduceScatter:
-    return red == ncclDevSum && isFloat && ty != ncclFloat64;
-  default:
-    return false;
+    case ncclFuncAllGather:
+      return true;
+    case ncclFuncAllReduce:
+    case ncclFuncReduceScatter:
+      return red == ncclDevSum && isFloat && ty != ncclFloat64;
+    default:
+      return false;
   }
 }
 
@@ -517,24 +517,24 @@ static uint32_t ncclSymkMask(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDe
   bool hasLDMC = false;
   if (comm->symkState.hasLsaMultimem) {
     switch (ty) {
-    case ncclInt32:
-    case ncclUint32:
-    case ncclInt64:
-    case ncclUint64:
-    case ncclFloat16:
-    case ncclBfloat16:
-      hasLDMC = red == ncclDevSum || red == ncclDevMinMax;
-      break;
-    case ncclFloat8e4m3:
-    case ncclFloat8e5m2:
-      hasLDMC = red == ncclDevSum || red == ncclDevMinMax;
-      hasLDMC &= comm->compCap >= 100;
-      break;
-    case ncclFloat:
-    case ncclDouble:
-      hasLDMC = red == ncclDevSum;
-      break;
-    default: break;
+      case ncclInt32:
+      case ncclUint32:
+      case ncclInt64:
+      case ncclUint64:
+      case ncclFloat16:
+      case ncclBfloat16:
+        hasLDMC = red == ncclDevSum || red == ncclDevMinMax;
+        break;
+      case ncclFloat8e4m3:
+      case ncclFloat8e5m2:
+        hasLDMC = red == ncclDevSum || red == ncclDevMinMax;
+        hasLDMC &= comm->compCap >= 100;
+        break;
+      case ncclFloat:
+      case ncclDouble:
+        hasLDMC = red == ncclDevSum;
+        break;
+      default: break;
     }
   }
   if (!hasSTMC) kmask &= ~kernelMask_STMC;
@@ -556,7 +556,7 @@ static uint32_t ncclSymkMask(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDe
 }
 
 bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red,
-                       ncclDataType_t ty, size_t nElts) {
+    ncclDataType_t ty, size_t nElts) {
   if (!comm->isAllDirectNvlink)
     return false;
   if (!ncclSymkImplemented(coll, red, ty))
@@ -569,7 +569,7 @@ ncclResult_t ncclSymkPickKernel(
     struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty,
     size_t nEltsTotal, size_t nEltsMax, int nWorks, ncclSymRegType_t winRegType,
     float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks, int* nWarps, bool* forced
-  ) {
+) {
   uint32_t kmask = ncclSymkMask(comm, coll, red, ty, nEltsMax);
 
   *forced = !(kernelMask_user() == (1<<(int)ncclSymkKernelId_Count)-1);
@@ -619,7 +619,7 @@ const char* ncclSymkKernelIdToString(int kernelId) {
   return kernelName[kernelId];
 }
 
-int ncclSymkMaxChunkElts(struct ncclComm* comm, ncclSymkKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+int ncclSymkMaxChunkElts(struct ncclComm* /*comm*/, ncclSymkKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
   bool isReduce = 1 & ((kernelMask_AR|kernelMask_RS) >> (int)kernelId);
   int eltSize = ncclTypeSize(ty);
   int accMult = !isReduce ? 1 : eltSize < 4 ? 2 : 1;
@@ -628,7 +628,7 @@ int ncclSymkMaxChunkElts(struct ncclComm* comm, ncclSymkKernelId kernelId, int/*
 }
 
 /* this function fills in the devWork except nextWorkOffset */
-ncclResult_t ncclSymkMakeDevWork(struct ncclComm* comm, struct ncclTaskColl* task, struct ncclSymkDevWork* outDevWork) {
+ncclResult_t ncclSymkMakeDevWork(struct ncclComm* /*comm*/, struct ncclTaskColl* task, struct ncclSymkDevWork* outDevWork) {
   outDevWork->rootRank = task->root;
   outDevWork->redOpArg = task->opDev.scalarArg;
   outDevWork->nElts = task->count;

--- a/src/transport.cc
+++ b/src/transport.cc
@@ -25,7 +25,7 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
   struct ncclPeerInfo* myInfo = comm->peerInfo+comm->rank;
   struct ncclPeerInfo* peerInfo = comm->peerInfo+peer;
   struct ncclConnector* connector = (type == 1) ? comm->channels[channelId].peers[peer]->send + connIndex :
-                                                  comm->channels[channelId].peers[peer]->recv + connIndex;
+      comm->channels[channelId].peers[peer]->recv + connIndex;
   for (int t=0; t<NTRANSPORTS; t++) {
     struct ncclTransport *transport = ncclTransports[t];
     struct ncclTransportComm* transportComm = type == 1 ? &transport->send : &transport->recv;
@@ -78,7 +78,7 @@ NCCL_PARAM(ReportConnectProgress, "REPORT_CONNECT_PROGRESS", 0);
 // *directMode returns 1 if *any* two local ranks are managed by the same process.
 // *isAllCudaP2p returns 1 if all local ranks have CUDA P2P connectivity with each other, irrespective of the distance.
 ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP2p, bool* directMode,
-                                       bool* isAllCudaP2p) {
+    bool* isAllCudaP2p) {
   bool ncclP2pFlag = true;
   bool directFlag = false;
   bool cudaP2pFlag = true;
@@ -92,7 +92,7 @@ ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP
       int intermediateRank = -1;
       int cudaP2p = 0;
       NCCLCHECK(ncclTopoCheckP2p(comm, comm->topo, ipeerInfo->rank, jpeerInfo->rank,
-                                 &canConnect, NULL, &intermediateRank, &cudaP2p));
+        &canConnect, NULL, &intermediateRank, &cudaP2p));
       if (!canConnect || intermediateRank != -1) {
         ncclP2pFlag = false;
       }
@@ -111,7 +111,7 @@ ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP
   *directMode = directFlag;
   *isAllCudaP2p = cudaP2pFlag;
   INFO(NCCL_INIT, "Check P2P Type isAllDirectP2p %d directMode %d isAllCudaP2p %d",
-       *isAllDirectP2p, *directMode, *isAllCudaP2p);
+      *isAllDirectP2p, *directMode, *isAllCudaP2p);
   return ncclSuccess;
 }
 
@@ -196,25 +196,25 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
       while (!allChannelsConnected) {
         allChannelsConnected = true;
         for (int j=done+1; j<=i; j++) {
-          int recvPeer = (comm->rank - j + comm->nRanks) % comm->nRanks;
-          int sendPeer = (comm->rank + j) % comm->nRanks;
-          uint64_t recvMask = comm->connectRecv[recvPeer];
-          uint64_t sendMask = comm->connectSend[sendPeer];
+          int recvPeerJ = (comm->rank - j + comm->nRanks) % comm->nRanks;
+          int sendPeerJ = (comm->rank + j) % comm->nRanks;
+          uint64_t recvMaskJ = comm->connectRecv[recvPeerJ];
+          uint64_t sendMaskJ = comm->connectSend[sendPeerJ];
 
-          int p = j-(done+1);
+          int pJ = j-(done+1);
           int sendDataOffset = 0;
           int recvDataOffset = 0;
           for (int c=0; c<MAXCHANNELS; c++) {
             TIME_START(3);
-            if (sendMask & (1ULL<<c)) {
-              struct ncclConnector* conn = comm->channels[c].peers[sendPeer]->send + connIndex;
+            if (sendMaskJ & (1ULL<<c)) {
+              struct ncclConnector* conn = comm->channels[c].peers[sendPeerJ]->send + connIndex;
               // This connector hasn't completed connection yet
               if (conn->connected == 0) {
-                NCCLCHECKGOTO(conn->transportComm->connect(comm, sendData[p] + sendDataOffset, 1, comm->rank, conn), ret, fail);
+                NCCLCHECKGOTO(conn->transportComm->connect(comm, sendData[pJ] + sendDataOffset, 1, comm->rank, conn), ret, fail);
                 if (ret == ncclSuccess) {
                   conn->connected = 1;
-                  /* comm->channels[c].devPeers[sendPeer]->send[connIndex] is a device memory access. */
-                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[sendPeer]->send[connIndex], &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), ret, fail);
+                  /* comm->channels[c].devPeers[sendPeerJ]->send[connIndex] is a device memory access. */
+                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[sendPeerJ]->send[connIndex], &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), ret, fail);
                 } else if (ret == ncclInProgress) {
                   allChannelsConnected = false;
                 }
@@ -225,15 +225,15 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
 
             // Start with recv channels
             TIME_START(4);
-            if (recvMask & (1ULL<<c)) {
-              struct ncclConnector* conn = comm->channels[c].peers[recvPeer]->recv + connIndex;
+            if (recvMaskJ & (1ULL<<c)) {
+              struct ncclConnector* conn = comm->channels[c].peers[recvPeerJ]->recv + connIndex;
               // This connector hasn't completed connection yet
               if (conn->connected == 0) {
-                NCCLCHECKGOTO(conn->transportComm->connect(comm, recvData[p] + recvDataOffset, 1, comm->rank, conn), ret, fail);
+                NCCLCHECKGOTO(conn->transportComm->connect(comm, recvData[pJ] + recvDataOffset, 1, comm->rank, conn), ret, fail);
                 if (ret == ncclSuccess) {
                   conn->connected = 1;
-                  /* comm->channels[c].devPeers[recvPeer]->recv[connIndex] is a device memory access. */
-                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[recvPeer]->recv[connIndex], &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), ret, fail);
+                  /* comm->channels[c].devPeers[recvPeerJ]->recv[connIndex] is a device memory access. */
+                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[recvPeerJ]->recv[connIndex], &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), ret, fail);
                 } else if (ret == ncclInProgress) {
                   allChannelsConnected = false;
                 }
@@ -250,7 +250,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
             float elapsed = (now.tv_sec - timeStart.tv_sec) * 1.0 + (now.tv_usec - timeStart.tv_usec) * 1e-6;
             float remaining = elapsed * (comm->nRanks - done) / done;
             printf("%sP2p connect: %g%% Elapsed %d:%02d Remaining %d:%02d                                       ",
-              timeReported ? "\r" : "", done * 100.0 / comm->nRanks, ((int)elapsed) / 60, ((int)elapsed) % 60, ((int)remaining) / 60, ((int)remaining) % 60);
+                timeReported ? "\r" : "", done * 100.0 / comm->nRanks, ((int)elapsed) / 60, ((int)elapsed) % 60, ((int)remaining) / 60, ((int)remaining) % 60);
             fflush(stdout);
             timeReported = true;
             timeLast = now; // struct copy;
@@ -268,7 +268,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
     if (elapsed > 1.0) INFO(NCCL_PROFILE, "timings: rank %d nranks %d P2p connect done in %.2f", comm->rank, comm->nRanks, elapsed);
     if (timeReported) {
       printf("\rP2p connect done in %d:%02d                                                                       \n",
-             ((int)elapsed)/60, ((int)elapsed)%60);
+          ((int)elapsed)/60, ((int)elapsed)%60);
       fflush(stdout);
     }
   }
@@ -298,7 +298,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
 
   TIME_PRINT("P2P Setup/Connect");
 exit:
-  for(int i=0; i<maxPeers; ++i){
+  for(int i=0; i<maxPeers; ++i) {
     if(data[i]) free(data[i]);
   }
   free(data);
@@ -317,7 +317,7 @@ extern struct ncclTransport collNetTransport;
 
 // All ranks must participate in collNetSetup call
 // We do not NCCLCHECK this call because we would fall back to P2P network in case CollNet setup fails
-bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* collNetGraph, struct ncclChannel* channel, int masterRank, int masterPeer, int collNetGraphChannelId, int type, ncclConnect* connect) {
+bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* collNetGraph, struct ncclChannel* channel, int masterRank, int /*masterPeer*/, int collNetGraphChannelId, int type, ncclConnect* connect) {
   ncclResult_t ret = ncclSuccess;
   int rank = comm->rank;
   int nranks = comm->nRanks;
@@ -339,7 +339,7 @@ bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* coll
   struct ncclTransportComm* transportComm = (type == collNetRecv) ? &(collNetTransport.recv) : &(collNetTransport.send);
   conn->transportComm = transportComm;
   // setup
-  struct ncclConnect myConnect = { 0 };
+  struct ncclConnect myConnect = {};
   struct {
     int isMaster;
     ncclConnect connect;
@@ -387,7 +387,7 @@ cleanup:
 
 ncclResult_t ncclTransportCollNetCheck(struct ncclComm* comm, int collNetSetupFail) {
   // AllGather collNet setup results
-  int allGatherFailures[NCCL_MAX_LOCAL_RANKS] = {0};
+  int allGatherFailures[NCCL_MAX_LOCAL_RANKS] = {};
   allGatherFailures[comm->localRank] = collNetSetupFail;
   NCCLCHECK(bootstrapIntraNodeAllGather(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, allGatherFailures, sizeof(int)));
   for (int i=0; i<comm->localRanks; i++) {

--- a/src/transport/coll_net.cc
+++ b/src/transport/coll_net.cc
@@ -60,21 +60,21 @@ static_assert(sizeof(collNetSendConnectInfo) <= CONNECT_SIZE, "Collnet Send Conn
   (((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_DEVMEM) != 0)
 
 #define NCCL_NET_MAP_ADD_POINTER(mapStruct, shared, dev, memSize, offsetName) do { \
-    int bank = NCCL_NET_MAP_MASK_USED + (dev)*NCCL_NET_MAP_MASK_DEVMEM + (shared)*NCCL_NET_MAP_MASK_SHARED; \
+    int _bank = NCCL_NET_MAP_MASK_USED + (dev)*NCCL_NET_MAP_MASK_DEVMEM + (shared)*NCCL_NET_MAP_MASK_SHARED; \
     if ((shared) == 0) { \
       if (dev) { \
-        (mapStruct)->offsets.offsetName = bank + (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size; \
+        (mapStruct)->offsets.offsetName = _bank + (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size; \
         (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size += memSize; \
       } else { \
-        (mapStruct)->offsets.offsetName = bank + (mapStruct)->mems[NCCL_NET_MAP_HOSTMEM].size; \
+        (mapStruct)->offsets.offsetName = _bank + (mapStruct)->mems[NCCL_NET_MAP_HOSTMEM].size; \
         (mapStruct)->mems[NCCL_NET_MAP_HOSTMEM].size += memSize; \
       } \
     } else { \
-      (mapStruct)->offsets.offsetName = bank; \
+      (mapStruct)->offsets.offsetName = _bank; \
     } \
 } while (0);
 
-struct connectMapMem{
+struct connectMapMem {
   char* gpuPtr;
   char* cpuPtr;
   int size;
@@ -140,7 +140,7 @@ struct recvResources {
   size_t maxCollBytes;
 };
 
-static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+static ncclResult_t canConnect(int* ret, struct ncclComm* /*comm*/, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* /*info1*/, struct ncclPeerInfo* /*info2*/) {
   // This transport cannot be used for p2p
   *ret = 0;
   return ncclSuccess;
@@ -166,8 +166,8 @@ struct setupReq {
 
 /* Setup send connector, and return connect information for others in the coll
  * communicator to connect to me */
-static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* /*peerInfo*/, struct ncclConnect* /*connectInfo*/, struct ncclConnector* send, int channelId, int connIndex) {
+  struct setupReq req = {};
 
   int proxyRank;
   int64_t netId;
@@ -182,12 +182,12 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), NULL, 0));
 
   INFO(NCCL_INIT|NCCL_NET,"CollNet %02d/%1d : %d [send] via COLLNET/%s/%d%s%s", channelId, connIndex, myInfo->rank, collNetName(comm), req.netDev,
-      req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "");
+    req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "");
   return ncclSuccess;
 }
 
-static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* /*peerInfo*/, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
+  struct setupReq req = {};
 
   int proxyRank;
   int64_t netId;
@@ -206,7 +206,7 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), &info->collNetHandle, sizeof(collNetHandle_t)));
 
   INFO(NCCL_INIT|NCCL_NET,"CollNet %02d/%1d : %d [receive] via COLLNET/%s/%d%s%s", channelId, connIndex, myInfo->rank, collNetName(comm), req.netDev,
-      req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "");
+    req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "");
   return ncclSuccess;
 }
 
@@ -310,15 +310,15 @@ static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* conne
   return ncclSuccess;
 }
 
-static ncclResult_t sendFree(struct ncclComm* comm, struct ncclConnector* send) {
+static ncclResult_t sendFree(struct ncclComm* /*comm*/, struct ncclConnector* /*send*/) {
   return ncclSuccess;
 }
 
-static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) {
+static ncclResult_t recvFree(struct ncclComm* /*comm*/, struct ncclConnector* /*recv*/) {
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* /*respBuff*/, int /*respSize*/, int* /*done*/) {
   struct setupReq* req = (struct setupReq*)reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
 
@@ -372,8 +372,8 @@ static ncclResult_t sharedConnect(struct ncclProxyState* proxyState, int netDev,
       handlePtrs[i] = &(info->collNetHandle);
     }
     ncclResult_t ret = proxyState->ncclCollNet->connect((void**)handlePtrs, nranks, rank,
-          resources->collNetListenComms[netDev],
-          resources->collNetComms+netDev);
+      resources->collNetListenComms[netDev],
+      resources->collNetComms+netDev);
     free(handlePtrs);
     if (ret == ncclSuccess) {
       // Close listen comm
@@ -427,7 +427,7 @@ static ncclResult_t sharedBuffersDestroy(struct ncclCollNetSharedRes* collNet, s
   return ncclSuccess;
 }
 
-static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* /*done*/) {
   struct setupReq* req = (struct setupReq*)reqBuff;
   if (reqSize != sizeof (struct setupReq)) return ncclInternalError;
 
@@ -458,7 +458,7 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* /*done*/) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct collNetConnectArgs)) { WARN("sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
@@ -519,16 +519,16 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   if (resources->useGdr && resources->useDmaBuf) {
     CUCHECK(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)));
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                                       NCCL_PTR_CUDA, 0ULL, dmabuf_fd,
-                                                       &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
-                  ret, fail);
+      NCCL_PTR_CUDA, 0ULL, dmabuf_fd,
+      &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
+      ret, fail);
     (void)close(dmabuf_fd);
   } else // FALL-THROUGH to nv_peermem GDR path
 #endif
   {
     NCCLCHECK(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                            resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
-                                            &resources->sendMhandles[NCCL_PROTO_SIMPLE]));
+      resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+      &resources->sendMhandles[NCCL_PROTO_SIMPLE]));
   }
 
   *((struct connectMap**)respBuff) = &resources->map;
@@ -542,7 +542,7 @@ fail:
   goto exit;
 }
 
-static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* /*done*/) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct collNetConnectArgs)) { WARN("recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
@@ -597,16 +597,16 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   if (resources->useGdr && resources->useDmaBuf) {
     CUCHECK(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)));
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                                       NCCL_PTR_CUDA, 0ULL, dmabuf_fd,
-                                                       &resources->mhandles[NCCL_PROTO_SIMPLE]),
-                  ret, fail);
+      NCCL_PTR_CUDA, 0ULL, dmabuf_fd,
+      &resources->mhandles[NCCL_PROTO_SIMPLE]),
+      ret, fail);
     (void)close(dmabuf_fd);
   } else // FALL-THROUGH to nv_peermem GDR path
 #endif
   {
     NCCLCHECK(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                            resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
-                                            &resources->mhandles[NCCL_PROTO_SIMPLE]));
+      resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+      &resources->mhandles[NCCL_PROTO_SIMPLE]));
   }
 
   // Pass info to send side
@@ -698,7 +698,7 @@ static size_t calcAlgoOffset(struct ncclProxyArgs* args, int isAllNotOne, int su
 static ssize_t calcRegionOffset(
     struct ncclProxyArgs* args, int isRecvNotSend, int sub, uint64_t step,
     int side // 0=begin, 1=end
-  ) {
+) {
   struct ncclCollNetSharedRes* collNet = args->subs[0].connection->collNet;
   ssize_t slotSize = collNet->buffSize/NCCL_STEPS;
   ssize_t chunkSize = args->chunkSize;
@@ -711,7 +711,7 @@ static ssize_t calcRegionOffset(
     int sub0 = sub - (sub%COLLNET_GROUP_NSUBS);
     size_t off = sub0*slotSize;
     off += calcAlgoOffset(args, isAllNotOne, sub+side, step)
-         - calcAlgoOffset(args, isAllNotOne, sub0, step);
+        - calcAlgoOffset(args, isAllNotOne, sub0, step);
     return base + off;
   }
 }
@@ -719,7 +719,7 @@ static ssize_t calcRegionOffset(
 #define LAST_OF_GROUP(args, s) \
   ((s)%COLLNET_GROUP_NSUBS == COLLNET_GROUP_NSUBS-1 || (s) == (args)->nsubs-1)
 
-static constexpr int calcStepsPerGroup(int nGroups) {
+static constexpr int calcStepsPerGroup(int /*nGroups*/) {
   //return NCCL_STEPS/nGroups;
   return NCCL_STEPS;
 }
@@ -758,7 +758,7 @@ static ncclResult_t collNetRegIallreduce(struct ncclProxyState* proxyState, stru
   return ncclSuccess;
 }
 
-static ncclResult_t collNetIallreduce(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytes, ssize_t sendBeg, ssize_t recvBeg, void **request) {
+static ncclResult_t collNetIallreduce(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs* /*sub*/, ssize_t nBytes, ssize_t sendBeg, ssize_t recvBeg, void **request) {
   void *sendMhandle = resources->sendMhandles[NCCL_PROTO_SIMPLE];
   void *recvMhandle = resources->recvMhandles[NCCL_PROTO_SIMPLE];
   char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
@@ -766,8 +766,9 @@ static ncclResult_t collNetIallreduce(struct ncclProxyState* proxyState, struct 
   // non-UB iallreduce, region is intermediate buffer and sendBeg/recvBeg is the corresponding offset
   // for send and recv data. The send and recv mem handle are retrieved from resources.
   NCCLCHECK(proxyState->ncclCollNet->iallreduce(resources->collNetComm, region + sendBeg, region + recvBeg, nBytes / eltSize, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, sendMhandle, recvMhandle, request));
-  if (*request)
+  if (*request) {
     TRACE(NCCL_NET, "sendProxy [%ld/%d] Iallreduce posted size %ld sendBeg %ld recvBeg %ld req %p", (long)sub->transmitted, sub->nsteps, nBytes, sendBeg, recvBeg, *request);
+  }
   return ncclSuccess;
 }
 
@@ -813,7 +814,7 @@ static ncclResult_t collNetRegIallgather(struct ncclProxyState* proxyState, stru
   return ncclSuccess;
 }
 
-static ncclResult_t collNetIallgather(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytes, ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void *sendMhandle, void *recvMhandle, void **request) {
+static ncclResult_t collNetIallgather(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs* /*sub*/, ssize_t nBytes, ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void *sendMhandle, void *recvMhandle, void **request) {
   ncclNetSGE_t recvParts;
   ssize_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
   char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
@@ -825,8 +826,9 @@ static ncclResult_t collNetIallgather(struct ncclProxyState* proxyState, struct 
   // the global window offset of recv buffer. sendBeg and recvBeg are offset to the region
   // for intermediate data.
   NCCLCHECK(proxyState->ncclCollNet->iallgather(resources->collNetComm, region + sendBeg, 1, &recvParts, sizePerRank, allBeg, nBytes, sendMhandle, request));
-  if (*request)
+  if (*request) {
     TRACE(NCCL_NET, "sendProxy [%ld/%d] Iallgather posted sizePerRank %ld winOffset %ld recvSize %ld request %p", sub->transmitted, sub->nsteps, sizePerRank, allBeg, nBytes, *request);
+  }
   return ncclSuccess;
 }
 
@@ -869,7 +871,7 @@ static ncclResult_t collNetRegIreducescatter(struct ncclProxyState* proxyState, 
   return ncclSuccess;
 }
 
-static ncclResult_t collNetIreducescatter(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytes, ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void *sendMhandle, void *recvMhandle, void **request) {
+static ncclResult_t collNetIreducescatter(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs* /*sub*/, ssize_t nBytes, ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void *sendMhandle, void *recvMhandle, void **request) {
   ncclNetSGE_t sendParts;
   ssize_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
   char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
@@ -878,8 +880,9 @@ static ncclResult_t collNetIreducescatter(struct ncclProxyState* proxyState, str
   sendParts.size = nBytes;
   // non-UB ireducescatter is the same as non-UB iallgather but in the reverse direction.
   NCCLCHECK(proxyState->ncclCollNet->ireducescatter(resources->collNetComm, 1, &sendParts, region + recvBeg, sizePerRank, allBeg, nBytes, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, recvMhandle, request));
-  if (*request)
+  if (*request) {
     TRACE(NCCL_NET, "sendProxy [%ld/%d] Ireducescatter posted sizePerRank %ld winOffset %ld sendSize %ld request %p", sub->transmitted, sub->nsteps, sizePerRank, allBeg, nBytes, *request);
+  }
   return ncclSuccess;
 }
 
@@ -945,7 +948,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
       }
       // Enforce collective ordering of collnet ops.
       bool ordered = s==0 ? args->subs[args->nsubs-1].transmitted == sub->transmitted
-                          : sub->transmitted < (sub-1)->transmitted;
+          : sub->transmitted < (sub-1)->transmitted;
       if (ordered && (sub->transmitted < sub->received)) {
         if (LAST_OF_GROUP(args, s)) {
           int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
@@ -1162,7 +1165,7 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
       // reached the same point, otherwise we would start posting buffers to the send proxy before we're done
       // processing all the shared buffer.
       bool groupSync = s==0 ? args->subs[args->nsubs-1].done == sub->done
-                            : (sub-1)->done > sub->done;
+          : (sub-1)->done > sub->done;
       volatile uint64_t* sendHead = &resources->sendMem->head;
       int done = sub->reg && sub->isOneRPN ? 0 : sub->done;
       if (groupSync && sub->done < sub->transmitted && sub->base + done < *sendHead) {
@@ -1256,7 +1259,7 @@ struct ncclCollnetCleanupCallback {
   struct ncclReg *reg;
 };
 
-static ncclResult_t cleanupCollnet(struct ncclComm* comm, struct ncclCommCallback* cb) {
+static ncclResult_t cleanupCollnet(struct ncclComm* /*comm*/, struct ncclCommCallback* cb) {
   struct ncclCollnetCleanupCallback* obj = (struct ncclCollnetCleanupCallback*)cb;
   NCCLCHECK(ncclCommGraphDeregister(obj->comm, obj->reg));
   free(obj);
@@ -1356,7 +1359,7 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct collnetRegInfo));
   assert(respSize == sizeof(void*));
   int dmabuf_fd = -1;
-  #if CUDART_VERSION >= 11070
+#if CUDART_VERSION >= 11070
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
@@ -1660,7 +1663,7 @@ ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTop
           comm->collNetSupportMatrix[op][ty] = (accum == (1<<1));
         }
       }
-    matrix_end:
+matrix_end:
       free(matrix);
       if (ret != ncclSuccess) goto fail;
     } while (0);

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -48,21 +48,21 @@ static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too 
   (((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_DEVMEM) != 0)
 
 #define NCCL_NET_MAP_ADD_POINTER(mapStruct, shared, dev, memSize, offsetName) do { \
-    int bank = NCCL_NET_MAP_MASK_USED + (dev)*NCCL_NET_MAP_MASK_DEVMEM + (shared)*NCCL_NET_MAP_MASK_SHARED; \
+    int _bank = NCCL_NET_MAP_MASK_USED + (dev)*NCCL_NET_MAP_MASK_DEVMEM + (shared)*NCCL_NET_MAP_MASK_SHARED; \
     if ((shared) == 0) { \
       if (dev) { \
-        (mapStruct)->offsets.offsetName = bank + (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size; \
+        (mapStruct)->offsets.offsetName = _bank + (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size; \
         (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size += memSize; \
       } else { \
-        (mapStruct)->offsets.offsetName = bank + (mapStruct)->mems[NCCL_NET_MAP_HOSTMEM].size; \
+        (mapStruct)->offsets.offsetName = _bank + (mapStruct)->mems[NCCL_NET_MAP_HOSTMEM].size; \
         (mapStruct)->mems[NCCL_NET_MAP_HOSTMEM].size += memSize; \
       } \
     } else { \
-      (mapStruct)->offsets.offsetName = bank; \
+      (mapStruct)->offsets.offsetName = _bank; \
     } \
 } while (0);
 
-struct connectMapMem{
+struct connectMapMem {
   char* gpuPtr;
   char* cpuPtr;
   int size;
@@ -155,7 +155,7 @@ struct netRegInfo {
 };
 
 /* Determine if two peers can communicate with NET */
-static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
   *ret = 1;
   if (info1->hostHash == info2->hostHash) {
     // If on the same host, check intra-node net is not disabled.
@@ -201,7 +201,7 @@ static void populateCommNetAttrs(struct ncclComm* comm, struct ncclConnector* co
     netAttr->recvCommAttr.maxConcurrentPeers = maxConcPeers;
     netAttr->recvCommAttr.maxFlowsPerPeer = comm->p2pnChannelsPerPeer;
     netAttr->op = BIT(ncclFuncSend) | BIT(ncclFuncRecv) |
-                  BIT(ncclFuncAlltoAll) | BIT(ncclFuncScatter) | BIT(ncclFuncGather);
+        BIT(ncclFuncAlltoAll) | BIT(ncclFuncScatter) | BIT(ncclFuncGather);
   } else {
     size_t maxConcPeers = (NCCL_MAX_TREE_ARITY - 1) * 2;
     if (comm->nRanks < maxConcPeers) maxConcPeers = comm->nRanks;
@@ -213,16 +213,14 @@ static void populateCommNetAttrs(struct ncclComm* comm, struct ncclConnector* co
 }
 
 // Apply the netAttr to the netComm
-void setNetAttrs(struct ncclProxyState* proxyState, ncclNetAttr_t* netAttr)
-{
+void setNetAttrs(struct ncclProxyState* proxyState, ncclNetAttr_t* netAttr) {
   if (proxyState->ncclNet->setNetAttr) {
     proxyState->ncclNet->setNetAttr(proxyState->netContext, netAttr);
     proxyState->netAttr = *netAttr;
   }
 }
 
-void printNetAttrs(ncclNetAttr_t* netAttr, const char *task)
-{
+void printNetAttrs(ncclNetAttr_t* netAttr, const char* /*task*/) {
   const int opBufLen = ncclNumFuncs*32;
   char opBuf[opBufLen] = "";
   const int algoBufLen = NCCL_NUM_ALGORITHMS*32;
@@ -235,16 +233,15 @@ void printNetAttrs(ncclNetAttr_t* netAttr, const char *task)
   ncclBitsToString(netAttr->proto, MASK(NCCL_NUM_PROTOCOLS), ncclProtoToString, protoBuf, protoBufLen, "*");
 
   TRACE(NCCL_NET, "%s hints, send peers/flows: [%d-%d][%d-%d] recv peers/flows: [%d-%d][%d-%d] op: %s algo: %s proto: %s",
-        task, netAttr->sendCommAttr.minConcurrentPeers, netAttr->sendCommAttr.maxConcurrentPeers,
-        netAttr->sendCommAttr.minFlowsPerPeer, netAttr->sendCommAttr.maxFlowsPerPeer,
-        netAttr->recvCommAttr.minConcurrentPeers, netAttr->recvCommAttr.maxConcurrentPeers,
-        netAttr->recvCommAttr.minFlowsPerPeer, netAttr->recvCommAttr.maxFlowsPerPeer,
-        opBuf, algoBuf, protoBuf);
+      task, netAttr->sendCommAttr.minConcurrentPeers, netAttr->sendCommAttr.maxConcurrentPeers,
+      netAttr->sendCommAttr.minFlowsPerPeer, netAttr->sendCommAttr.maxFlowsPerPeer,
+      netAttr->recvCommAttr.minConcurrentPeers, netAttr->recvCommAttr.maxConcurrentPeers,
+      netAttr->recvCommAttr.minFlowsPerPeer, netAttr->recvCommAttr.maxFlowsPerPeer,
+      opBuf, algoBuf, protoBuf);
 }
 
 // Set the netAttr for a transfer operation
-void setXferNetAttrs(struct ncclProxyState* proxyState, struct ncclProxyArgs* args, int send)
-{
+void setXferNetAttrs(struct ncclProxyState* proxyState, struct ncclProxyArgs* args, int send) {
   ncclNetAttr_t netAttr;
 
   if (!proxyState->ncclNet->setNetAttr)
@@ -293,7 +290,7 @@ static inline int getHandleForAddressRangeFlags(ncclTopoGdrMode useGdr) {
 /* Determine if we will use this transport for this peer and return connect
  * information for this peer */
 static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+  struct setupReq req = {};
 
   send->conn.shared = req.shared = graph || connIndex == 0 ? 0 : ncclParamNetSharedBuffers() != -2 ? ncclParamNetSharedBuffers() : 1;
   req.channelId = channelId;
@@ -319,9 +316,9 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
         req.shared ? "/Shared" : "");
   } else {
     INFO(NCCL_INIT|NCCL_NET,"Channel %02d/%d : %d[%d] -> %d[%d] [send] via NET/%s/%d(%d)%s%s%s", channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, comm->ncclNet->name, req.netDev,
-        proxyRank,
-        req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "",
-        req.shared ? "/Shared" : "");
+      proxyRank,
+      req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "",
+      req.shared ? "/Shared" : "");
   }
   *((int*)connectInfo) = comm->topParentRanks[proxyRank];
   memcpy((uint8_t*)connectInfo + sizeof(ncclNetHandle_t), &req.useGdr, sizeof(int));
@@ -335,7 +332,7 @@ NCCL_PARAM(GdrCopyFlushEnable, "GDRCOPY_FLUSH_ENABLE", 0);
 
 /* Setup recv connector */
 static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+  struct setupReq req = {};
 
   recv->conn.shared = req.shared = graph || connIndex == 0 ? 0 : ncclParamNetSharedBuffers() != -2 ? ncclParamNetSharedBuffers() : 1;
   req.channelId = channelId;
@@ -371,7 +368,7 @@ static ncclResult_t netMapShm(struct ncclComm *comm, struct ncclProxyConnector* 
   return ncclSuccess;
 }
 
-static ncclResult_t netCreateShm(struct ncclProxyState* proxyState, struct connectMapMem* mem) {
+static ncclResult_t netCreateShm(struct ncclProxyState* /*proxyState*/, struct connectMapMem* mem) {
   NCCLCHECK(ncclShmAllocateShareableBuffer(mem->size, false, &mem->createDesc, (void**)&mem->cpuPtr, (void**)&mem->gpuPtr));
   return ncclSuccess;
 }
@@ -414,7 +411,7 @@ struct netRecvConnectArgs {
   ncclNetAttr_t netAttr;
 };
 
-static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int /*nranks*/, int /*rank*/, struct ncclConnector* send) {
   struct connectMap* map = (connectMap*) send->transportResources;
   void* opId;
   int recvUseGdr;
@@ -429,7 +426,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
     send->transportResources = map;
     opId = send;
     INFO(NCCL_PROXY, "sendConnect ncclProxyCallAsync opId=%p", opId);
-    netSendConnectArgs args = {0};
+    netSendConnectArgs args = {};
     memcpy(&args.handle, connectInfo, sizeof(ncclNetHandle_t));
 
     populateCommNetAttrs(comm, send, &args.netAttr);
@@ -467,10 +464,10 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
       map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr = NULL;
       // NET transport import: No ownerVA available, mark as Persist (do not release)
       NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank,
-                                             map->mems[NCCL_NET_MAP_DEVMEM].size,
-                                             &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                             (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
-                                             nullptr, ncclMemPersist));
+        map->mems[NCCL_NET_MAP_DEVMEM].size,
+        &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
+        (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
+        nullptr, ncclMemPersist));
       map->mems[NCCL_NET_MAP_DEVMEM].cpuPtr = NULL;
     }
     if (map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size) {
@@ -479,10 +476,10 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
         map->mems[NCCL_NET_MAP_SHARED_DEVMEM].gpuPtr = NULL;
         // NET transport shared import: No ownerVA, mark as Persist (do not release)
         NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank,
-                                               map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size,
-                                               &map->mems[NCCL_NET_MAP_SHARED_DEVMEM].ipcDesc,
-                                               sharedDevMemPtr,
-                                               nullptr, ncclMemPersist));
+          map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size,
+          &map->mems[NCCL_NET_MAP_SHARED_DEVMEM].ipcDesc,
+          sharedDevMemPtr,
+          nullptr, ncclMemPersist));
       }
       map->mems[NCCL_NET_MAP_SHARED_DEVMEM].gpuPtr = (char*)(*sharedDevMemPtr);
       map->mems[NCCL_NET_MAP_SHARED_DEVMEM].cpuPtr = NULL;
@@ -531,7 +528,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
 static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args);
 
 /* Connect to this peer */
-static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
+static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int /*nranks*/, int /*rank*/, struct ncclConnector* recv) {
   struct connectMap* map = (connectMap*) recv->transportResources;
   void* opId;
   int sendUseGdr;
@@ -545,8 +542,8 @@ static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* conne
     // Use recv connector as unique identifier
     opId = recv;
     INFO(NCCL_PROXY, "recvConnect ncclProxyCallAsync opId=%p &recv->proxyConn=%p connectInfo=%p",
-       opId, &recv->proxyConn, connectInfo);
-    netRecvConnectArgs args = {0};
+        opId, &recv->proxyConn, connectInfo);
+    netRecvConnectArgs args = {};
     args.proxyRank = *((int*)connectInfo);
 
     populateCommNetAttrs(comm, recv, &args.netAttr);
@@ -628,7 +625,7 @@ static ncclResult_t sendFree(struct ncclComm* comm, struct ncclConnector* send) 
   return ncclSuccess;
 }
 
-static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) {
+static ncclResult_t recvFree(struct ncclComm* /*comm*/, struct ncclConnector* recv) {
   if (recv->transportResources) free(recv->transportResources);
   return ncclSuccess;
 }
@@ -637,8 +634,8 @@ static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) 
 static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int cuda, int tpLocalRank, int type, int sameProcess,
     int nChannels, char** gpuPtr, char** cpuPtr, int* size, ncclIpcDesc *ipcDesc) {
   if (cuda == 0 && sameProcess == 0) {
-      WARN("PXN should not use host buffers for data");
-      return ncclInternalError;
+    WARN("PXN should not use host buffers for data");
+    return ncclInternalError;
   }
   struct ncclProxyProgressState* progressState = &proxyState->progressState;
   if (progressState->localPeers == NULL) {
@@ -715,7 +712,7 @@ static ncclResult_t proxySharedInit(struct ncclProxyConnection* connection, stru
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* /*respBuff*/, int respSize, int* done) {
   struct setupReq* req = (struct setupReq*) reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
 
@@ -847,7 +844,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       if (comms->sendComm[resources->channelId] == NULL
           && comms->activeConnect[resources->channelId] == (resources->tpLocalRank + 1)) {
         ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
-            comms->sendComm + resources->channelId, &resources->netDeviceHandle);
+                comms->sendComm + resources->channelId, &resources->netDeviceHandle);
       }
       resources->netSendComm = comms->sendComm[resources->channelId];
       if (comms->sendComm[resources->channelId]) comms->sendRefCount[resources->channelId]++;
@@ -894,8 +891,8 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
     struct connectMapMem* mapMem = map->mems+bank;
     NCCLCHECK(sharedNetBuffersInit(
-          proxyState, resources->useGdr, resources->tpLocalRank, 0, map->sameProcess, proxyState->p2pnChannels,
-          &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, &mapMem->ipcDesc));
+      proxyState, resources->useGdr, resources->tpLocalRank, 0, map->sameProcess, proxyState->p2pnChannels,
+      &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, &mapMem->ipcDesc));
     resources->buffSizes[NCCL_PROTO_SIMPLE] = mapMem->size;
 
     if (proxyState->allocP2pNetLLBuffers) {
@@ -914,7 +911,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       if (!map->sameProcess || ncclCuMemEnable()) {
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                 (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
+          (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
       } else {
         NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager));
       }
@@ -947,7 +944,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 
   // Don't give credits yet in shared mode.
   (resources->gdcSync ? *resources->gdcSync : resources->sendMem->head) =
-    (map->shared ? -NCCL_STEPS : 0);
+      (map->shared ? -NCCL_STEPS : 0);
   for (int i=0; i<NCCL_STEPS; i++) resources->recvMem->connFifo[i].size = -1;
 
   for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
@@ -1013,9 +1010,9 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
         comms->activeAccept[resources->channelId] = (resources->tpLocalRank + 1);
       //try connecting while comm is null
       if (comms->recvComm[resources->channelId] == NULL
-         && comms->activeAccept[resources->channelId] == (resources->tpLocalRank + 1)) {
+          && comms->activeAccept[resources->channelId] == (resources->tpLocalRank + 1)) {
         ret = proxyState->ncclNet->accept(resources->netListenComm,
-            comms->recvComm+resources->channelId, &resources->netDeviceHandle);
+                comms->recvComm+resources->channelId, &resources->netDeviceHandle);
       }
       resources->netRecvComm = comms->recvComm[resources->channelId];
       if (comms->recvComm[resources->channelId]) comms->recvRefCount[resources->channelId]++;
@@ -1061,8 +1058,8 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
     struct connectMapMem* mapMem = map->mems+bank;
     NCCLCHECK(sharedNetBuffersInit(
-          proxyState, resources->useGdr, resources->tpLocalRank, 1, 1, proxyState->p2pnChannels,
-          &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, NULL));
+      proxyState, resources->useGdr, resources->tpLocalRank, 1, 1, proxyState->p2pnChannels,
+      &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, NULL));
     resources->buffSizes[NCCL_PROTO_SIMPLE] = mapMem->size;
     NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
   }
@@ -1079,7 +1076,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     if (resources->shared == 0) {
       if (ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                 (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
+          (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
       } else {
         NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager));
       }
@@ -1541,18 +1538,18 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
             sub->received += args->sliceSteps;
             ncclProfilerRecordProxyStepEventState(s+i, args, receivedStepId, ncclProfilerProxyStepRecvFlushWait);
             if (step < sub->nsteps) {
-              struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
-              if (resources->useGdr) needFlush |= resources->needFlush;
+              struct recvNetResources* subRes = (struct recvNetResources*) (sub->connection->transportResources);
+              if (subRes->useGdr) needFlush |= subRes->needFlush;
             }
           }
           subGroup->requests[step%NCCL_STEPS] = NULL;
           if (totalSize > 0 && p == NCCL_PROTO_SIMPLE && needFlush) {
             // GDRCOPY support
-            struct recvNetResources* resources = (struct recvNetResources*) (subGroup->connection->transportResources);
-            if (resources->gdcFlush) {
+            struct recvNetResources* flushRes = (struct recvNetResources*) (subGroup->connection->transportResources);
+            if (flushRes->gdcFlush) {
 #if defined (__x86_64__)
               // Force a PCI-E read from GPU memory
-              asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
+              asm volatile ("mov (%0), %%eax" :: "l"(flushRes->gdcFlush) : "%eax", "memory");
 #else
               WARN("NET: GDR Flush only supported on x86_64");
               return ncclInternalError;
@@ -1562,12 +1559,12 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               for (int i=0; i<subGroup->groupSize; i++) {
                 struct ncclProxySubArgs* sub = subGroup + i;
                 if (step < sub->nsteps) {
-                  struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
-                  int stepSize = resources->buffSizes[p] / NCCL_STEPS;
-                  char* localBuff = NCCL_NET_MAP_GET_POINTER(&resources->map, cpu, buffs[p]);
+                  struct recvNetResources* subFlushRes = (struct recvNetResources*) (sub->connection->transportResources);
+                  int stepSize = subFlushRes->buffSizes[p] / NCCL_STEPS;
+                  char* localBuff = NCCL_NET_MAP_GET_POINTER(&subFlushRes->map, cpu, buffs[p]);
                   int buffSlot = (sub->base+sub->received-args->sliceSteps)%NCCL_STEPS;
-                  if (resources->shared) {
-                    ptrs[subCount] = sub->reg ? (char*)sub->recvbuff + step * NCCL_MAX_NET_SIZE : localBuff + resources->recvMem->connFifo[buffSlot].offset;
+                  if (subFlushRes->shared) {
+                    ptrs[subCount] = sub->reg ? (char*)sub->recvbuff + step * NCCL_MAX_NET_SIZE : localBuff + subFlushRes->recvMem->connFifo[buffSlot].offset;
                   } else {
                     if (sub->reg) {
                       sub->ringAlgo->getNextRecvAddr(step, (uint8_t**)&ptrs[subCount], NULL, &sub->recvMhandle);
@@ -1579,8 +1576,8 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
                   subCount++;
                 }
               }
-              struct recvNetResources* resources = (struct recvNetResources*) (subGroup->connection->transportResources);
-              NCCLCHECK(proxyState->ncclNet->iflush(resources->netRecvComm, subCount, ptrs, sizes, mhandles, subGroup->requests+(step%NCCL_STEPS)));
+              struct recvNetResources* groupFlushRes = (struct recvNetResources*) (subGroup->connection->transportResources);
+              NCCLCHECK(proxyState->ncclNet->iflush(groupFlushRes->netRecvComm, subCount, ptrs, sizes, mhandles, subGroup->requests+(step%NCCL_STEPS)));
             }
           }
           args->idle = 0;
@@ -1696,13 +1693,13 @@ static ncclResult_t netRegisterBuffer(ncclComm* comm, const void* userbuff, size
         if (peerConn->conn.flags & NCCL_DIRECT_NIC) {
           NCCLCHECKGOTO(ncclProxyCallBlocking(comm, peerProxyConn, ncclProxyMsgRegister, &info, sizeof(struct netRegInfo), &handle, sizeof(void*)), ret, fail);
           if (handle) {
-            struct ncclRegNetHandles* netHandle;
+            struct ncclRegNetHandles* newNetHandle;
             regRecord->state |= NET_REG_COMPLETE;
-            NCCLCHECK(ncclCalloc(&netHandle, 1));
-            netHandle->handle = handle;
-            netHandle->proxyConn = peerProxyConn;
-            netHandle->next = regRecord->netHandleHead;
-            regRecord->netHandleHead = netHandle;
+            NCCLCHECK(ncclCalloc(&newNetHandle, 1));
+            newNetHandle->handle = handle;
+            newNetHandle->proxyConn = peerProxyConn;
+            newNetHandle->next = regRecord->netHandleHead;
+            regRecord->netHandleHead = newNetHandle;
             outHandle[p] = handle;
             *outRegBufFlag = 1;
             INFO(NCCL_REG, "rank %d - NET register userbuff %p (handle %p), buffSize %ld", comm->rank, userbuff, handle, buffSize);
@@ -1757,7 +1754,7 @@ struct ncclNetCleanupCallback {
   struct ncclReg *reg;
 };
 
-static ncclResult_t cleanupNet(struct ncclComm* comm, struct ncclCommCallback* cb) {
+static ncclResult_t cleanupNet(struct ncclComm* /*comm*/, struct ncclCommCallback* cb) {
   struct ncclNetCleanupCallback* obj = (struct ncclNetCleanupCallback*)cb;
   NCCLCHECK(ncclCommGraphDeregister(obj->comm, obj->reg));
   free(obj);

--- a/src/transport/net_ib/connect.cc
+++ b/src/transport/net_ib/connect.cc
@@ -78,13 +78,11 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
 // GID Format
 // global:  |              64b  - subnet-prefix                |                 64b - EUI                          |
 // raw   :  | 10b fixed | 22b 0 | 16b FLID | 16b subnet-prefix |                 64b - EUI                          |
-static uint16_t ncclIbExtractLocalSubnetPrefix(uint64_t subnet_prefix)
-{
+static uint16_t ncclIbExtractLocalSubnetPrefix(uint64_t subnet_prefix) {
   return (be64toh(subnet_prefix) & 0xffff);
 }
 
-static int ncclIbExtractFlid (union ibv_gid *gid)
-{
+static int ncclIbExtractFlid (union ibv_gid *gid) {
   return ntohs(*((uint16_t*)((uintptr_t)(gid->raw) + 4)));
 }
 
@@ -119,7 +117,7 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
 
   INFO(NCCL_ENV, "NCCL_IB_ADDR_RANGE set by environment to %s", env);
 
-  char addrString[128] = { 0 };
+  char addrString[128] = {};
   snprintf(addrString, 128, "%s", env);
   char *addrStrPtr = addrString;
   char *maskStrPtr = strstr(addrString, "/");
@@ -218,8 +216,8 @@ static bool validGid(union ibv_gid* gid) {
 }
 
 static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum, int gidIndex, int* version) {
-  char gidRoceVerStr[16] = { 0 };
-  char roceTypePath[PATH_MAX] = { 0 };
+  char gidRoceVerStr[16] = {};
+  char roceTypePath[PATH_MAX] = {};
   snprintf(roceTypePath, sizeof(roceTypePath), "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d", deviceName, portNum, gidIndex);
 
   int fd = open(roceTypePath, O_RDONLY);
@@ -358,7 +356,7 @@ ncclResult_t ncclIbRtrQp(struct ibv_qp* qp, struct ncclIbGidInfo* sGidInfo, uint
   } else {
     //pick lid if subnet prefixs are same, FLID if they are not
     if (ncclIbExtractLocalSubnetPrefix(sGidInfo->localGid.global.subnet_prefix) ==
-        ncclIbExtractLocalSubnetPrefix(info->gid.global.subnet_prefix)) {
+      ncclIbExtractLocalSubnetPrefix(info->gid.global.subnet_prefix)) {
       qpAttr.ah_attr.is_global = 0;
       qpAttr.ah_attr.dlid = info->lid;
     } else {
@@ -397,7 +395,7 @@ ncclResult_t ncclIbRtsQp(struct ibv_qp* qp) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbListen(void* ctx, int dev, void* opaqueHandle, void** listenComm) {
+ncclResult_t ncclIbListen(void* /*ctx*/, int dev, void* opaqueHandle, void** listenComm) {
   ncclResult_t ret = ncclSuccess;
   struct ncclIbListenComm* comm;
   NCCLCHECK(ncclCalloc(&comm, 1));
@@ -430,7 +428,7 @@ fail:
 // establishment process.
 static ncclResult_t ncclIbSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta) {
   uint nqps = comm->base.nqps;
-  struct ncclIbQpCreateAttr qpCreateAttrs = {0};
+  struct ncclIbQpCreateAttr qpCreateAttrs = {};
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.accessFlags = IBV_ACCESS_REMOTE_WRITE;
   qpCreateAttrs.maxRecvWorkRequest = 0;
@@ -650,21 +648,21 @@ ib_recv_dev_list:
       if (comm->base.qps[q].devIndex == i) {
         if (devInfo->link_layer == IBV_LINK_LAYER_INFINIBAND) { // IB
           INFO(NCCL_NET,"NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d LID %d subnet-prefix %lu  FLID %d ctsFifoRkey=0x%x ctsFifoLkey=0x%x", __func__,
-               comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev",
-               dev, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid,
-               (uint64_t)devInfo->gid.global.subnet_prefix, ncclIbExtractFlid(&devInfo->gid), commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
+              comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev",
+              dev, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid,
+              (uint64_t)devInfo->gid.global.subnet_prefix, ncclIbExtractFlid(&devInfo->gid), commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
         } else { // RoCE
           INFO(NCCL_NET,"NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d GID %ld (%lX/%lX) ctsFifoRkey=0x%x ctsFifoLkey=0x%x", __func__,
-               comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev,
-               commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu,
-               (int64_t)commDev->base.gidInfo.localGidIndex,
-               (uint64_t)devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
+            comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev,
+            commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu,
+            (int64_t)commDev->base.gidInfo.localGidIndex,
+            (uint64_t)devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
         }
         // Log ECE info
         if (meta.qpInfo[q].ece_supported) {
           INFO(NCCL_NET,"NET/IB: %s: IbDev %d Port %d qp_num %d query_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x}", __func__,
-               commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn,
-               meta.qpInfo[q].ece_supported, meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask);
+              commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn,
+              meta.qpInfo[q].ece_supported, meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask);
         }
       }
     }
@@ -672,7 +670,7 @@ ib_recv_dev_list:
     if (link_layer != devInfo->link_layer) {
       int ibDev0 = comm->devs[0].base.ibDevN;
       WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+          commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -710,7 +708,7 @@ ib_connect:
     for (int i = 0; i < remMeta.ndevs; i++) {
       if (remMeta.devs[i].link_layer != link_layer) {
         WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-             NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+            NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
         return ncclInternalError;
       }
     }
@@ -764,7 +762,7 @@ fail:
 NCCL_PARAM(IbWarnRailLocal, "IB_WARN_RAIL_LOCAL", 0);
 
 ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDeviceProps_t* vProps2) {
-  ncclNetVDeviceProps_t  outVProps = {0};
+  ncclNetVDeviceProps_t  outVProps = {};
   ncclNetVDeviceProps_t* minVProps = vProps2;
   ncclNetVDeviceProps_t* maxVProps = vProps1;
   if (vProps2->ndevs > vProps1->ndevs) {
@@ -812,7 +810,7 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // side (sender) as part of the connection establishment process.
 static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta, struct ncclIbConnectionMetadata* meta) {
   uint nqps = rComm->base.nqps;
-  struct ncclIbQpCreateAttr qpCreateAttrs = {0};
+  struct ncclIbQpCreateAttr qpCreateAttrs = {};
   qpCreateAttrs.type = IBV_QPT_RC;
   // Remote Atomic operations are used for GIN!
   qpCreateAttrs.accessFlags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC;
@@ -888,15 +886,15 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       ncclIbRecvCommDev* rCommDev = &rComm->devs[i];
       ncclIbDev* ibDev = &ncclIbDevs[rCommDev->base.ibDevN];
 
-      struct ncclIbQpCreateAttr qpCreateAttrs = {0};
-      qpCreateAttrs.type = IBV_QPT_RC;
-      qpCreateAttrs.ibPort = ibDev->portNum;
-      qpCreateAttrs.cq = rCommDev->base.cq;
-      qpCreateAttrs.pd = rCommDev->base.pd;
-      qpCreateAttrs.accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
-      qpCreateAttrs.maxRecvWorkRequest = 0;
-      qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
-      NCCLCHECK(ncclIbCreateQp(&qpCreateAttrs, &rComm->base.stats, &rCommDev->gpuFlush.qp));
+      struct ncclIbQpCreateAttr flushQpAttrs = {};
+      flushQpAttrs.type = IBV_QPT_RC;
+      flushQpAttrs.ibPort = ibDev->portNum;
+      flushQpAttrs.cq = rCommDev->base.cq;
+      flushQpAttrs.pd = rCommDev->base.pd;
+      flushQpAttrs.accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
+      flushQpAttrs.maxRecvWorkRequest = 0;
+      flushQpAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+      NCCLCHECK(ncclIbCreateQp(&flushQpAttrs, &rComm->base.stats, &rCommDev->gpuFlush.qp));
       INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p",
           __func__,
           ibDev->portNum,
@@ -1042,7 +1040,7 @@ ib_recv:
 
   if (remMeta.ndevs != rComm->base.vProps.ndevs) {
     INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
-      mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, remMeta.ndevs);
+        mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, remMeta.ndevs);
   }
 
   // Metadata to send back to requestor (sender)
@@ -1070,7 +1068,7 @@ ib_recv:
     if (link_layer != ibDev->portAttr.link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
       WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+          ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -1081,7 +1079,7 @@ ib_recv:
     if (remMeta.devs[i].link_layer != link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
       WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+          NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -1099,7 +1097,7 @@ ib_recv:
   // Determine if Flush is enabled for this Comm. Must be done before creating
   // QPs. If Flush is enabled, extra QPs will be created for Flush operations.
   rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || ncclIbDmaBufSupport(lComm->dev) == ncclSuccess)
-                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;
+    && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;
 
   NCCLCHECKGOTO(ncclIbReceiverQpsCreateToRts(rComm, &remMeta, &meta), ret, fail);
   if (rComm->prepostReceiveWorkRequests) {
@@ -1203,7 +1201,7 @@ ncclResult_t ncclIbCloseSend(void* sendComm) {
       if (commDev->putSignalScratchpadMr != NULL)
         NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
       if (comm->base.resiliency) {
-         NCCLCHECK(ncclIbResiliencyDevDestroy(comm->base.resiliency, i));
+        NCCLCHECK(ncclIbResiliencyDevDestroy(comm->base.resiliency, i));
       }
       NCCLCHECK(ncclIbDestroyBase(&commDev->base));
     }

--- a/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_gpunetio.cpp
+++ b/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_gpunetio.cpp
@@ -59,1069 +59,1074 @@
 #define GPU_FULL_ASYNC_STORE_RELEASE_SUPPORT_COMPUTE_CAP_MAJOR 10
 
 struct doca_gpu_mtable {
-    uintptr_t base_addr;
-    size_t size_orig;
-    uintptr_t align_addr_gpu;
-    uintptr_t align_addr_cpu;
-    size_t size;
-    enum doca_gpu_mem_type mtype;
-    void *gdr_mh;
+  uintptr_t base_addr;
+  size_t size_orig;
+  uintptr_t align_addr_gpu;
+  uintptr_t align_addr_cpu;
+  size_t size;
+  enum doca_gpu_mem_type mtype;
+  void *gdr_mh;
 };
 
 struct doca_gpu_verbs_service {
-    pthread_t service_thread;
-    pthread_rwlock_t service_lock;
-    bool running;
-    std::set<struct doca_gpu_verbs_qp *> *qps;
+  pthread_t service_thread;
+  pthread_rwlock_t service_lock;
+  bool running;
+  std::set<struct doca_gpu_verbs_qp *> *qps;
 };
 
 static inline bool priv_query_async_store_release_support(void) {
-    int current_device;
-    int compute_cap_major;
-    cudaError_t status = cudaSuccess;
+  int current_device;
+  int compute_cap_major;
+  cudaError_t status = cudaSuccess;
 
-    status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaGetDevice(&current_device));
-    if (status != cudaSuccess) return false;
+  status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaGetDevice(&current_device));
+  if (status != cudaSuccess) return false;
 
-    status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaDeviceGetAttribute(
-        &compute_cap_major, cudaDevAttrComputeCapabilityMajor, current_device));
-    if (status != cudaSuccess) return false;
+  status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaDeviceGetAttribute(
+    &compute_cap_major, cudaDevAttrComputeCapabilityMajor, current_device));
+  if (status != cudaSuccess) return false;
 
-    return (compute_cap_major >= GPU_FULL_ASYNC_STORE_RELEASE_SUPPORT_COMPUTE_CAP_MAJOR);
-    return (compute_cap_major >= GPU_FULL_ASYNC_STORE_RELEASE_SUPPORT_COMPUTE_CAP_MAJOR);
+  return (compute_cap_major >= GPU_FULL_ASYNC_STORE_RELEASE_SUPPORT_COMPUTE_CAP_MAJOR);
+  return (compute_cap_major >= GPU_FULL_ASYNC_STORE_RELEASE_SUPPORT_COMPUTE_CAP_MAJOR);
 }
 
 bool priv_is_power_of_two(uint64_t x) { return x && (x & (x - 1)) == 0; }
 
 static size_t priv_get_page_size() {
-    auto ret = sysconf(_SC_PAGESIZE);
-    if (ret == -1) return 4096;  // 4KB, default Linux page size
+  auto ret = sysconf(_SC_PAGESIZE);
+  if (ret == -1) return 4096;  // 4KB, default Linux page size
 
-    return (size_t)ret;
+  return (size_t)ret;
 }
 
 doca_error_t doca_gpu_create(const char *gpu_bus_id, struct doca_gpu **gpu_dev) {
-    struct doca_gpu *gpu_dev_;
-    int dmabuf_supported;
-    CUresult res_drv = CUDA_SUCCESS;
-    cudaError_t res_cuda = cudaSuccess;
+  struct doca_gpu *gpu_dev_;
+  int dmabuf_supported;
+  CUresult res_drv = CUDA_SUCCESS;
+  cudaError_t res_cuda = cudaSuccess;
 
-    if (gpu_bus_id == nullptr || gpu_dev == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid input parameters.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (gpu_bus_id == nullptr || gpu_dev == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid input parameters.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    gpu_dev_ = (struct doca_gpu *)calloc(1, sizeof(struct doca_gpu));
-    if (gpu_dev_ == nullptr) {
-        DOCA_LOG(LOG_ERR, "error in %s: failed to allocate memory for doca_gpu", __func__);
-        return DOCA_ERROR_NO_MEMORY;
-    }
+  gpu_dev_ = (struct doca_gpu *)calloc(1, sizeof(struct doca_gpu));
+  if (gpu_dev_ == nullptr) {
+    DOCA_LOG(LOG_ERR, "error in %s: failed to allocate memory for doca_gpu", __func__);
+    return DOCA_ERROR_NO_MEMORY;
+  }
 
-    res_cuda =
-        DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaDeviceGetByPCIBusId(&gpu_dev_->cuda_dev, gpu_bus_id));
-    if (res_cuda != cudaSuccess) {
-        DOCA_LOG(LOG_ERR, "Invalid GPU bus id provided (ret %d).", res_drv);
-        goto exit_error;
-    }
+  res_cuda =
+      DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaDeviceGetByPCIBusId(&gpu_dev_->cuda_dev, gpu_bus_id));
+  if (res_cuda != cudaSuccess) {
+    DOCA_LOG(LOG_ERR, "Invalid GPU bus id provided (ret %d).", res_drv);
+    goto exit_error;
+  }
 
-    res_drv = doca_verbs_wrapper_cuDeviceGetAttribute(
-        &(dmabuf_supported), CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, gpu_dev_->cuda_dev);
-    if (res_drv != CUDA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "cuDeviceGetAttribute CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED returned %d.",
-                 res_drv);
-        goto exit_error;
-    }
+  res_drv = doca_verbs_wrapper_cuDeviceGetAttribute(
+          &(dmabuf_supported), CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, gpu_dev_->cuda_dev);
+  if (res_drv != CUDA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "cuDeviceGetAttribute CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED returned %d.",
+        res_drv);
+    goto exit_error;
+  }
 
-    (dmabuf_supported == 1 ? (gpu_dev_->support_dmabuf = true)
-                           : (gpu_dev_->support_dmabuf = false));
+  (dmabuf_supported == 1 ? (gpu_dev_->support_dmabuf = true)
+    : (gpu_dev_->support_dmabuf = false));
 
-    // status = gdaki_map_uar(guar);
-    // device_attr->support_uar_gpumem = (status == 0);
-    // did_map_uar = (status == 0);
+  // status = gdaki_map_uar(guar);
+  // device_attr->support_uar_gpumem = (status == 0);
+  // did_map_uar = (status == 0);
 
-    // TBD
-    gpu_dev_->support_wq_gpumem = true;
-    gpu_dev_->support_cq_gpumem = true;
-    gpu_dev_->support_uar_gpumem = true;
-    gpu_dev_->support_bf_uar = true;
-    gpu_dev_->support_async_store_release = priv_query_async_store_release_support();
-    gpu_dev_->support_gdrcopy = doca_gpu_gdrcopy_is_supported();
+  // TBD
+  gpu_dev_->support_wq_gpumem = true;
+  gpu_dev_->support_cq_gpumem = true;
+  gpu_dev_->support_uar_gpumem = true;
+  gpu_dev_->support_bf_uar = true;
+  gpu_dev_->support_async_store_release = priv_query_async_store_release_support();
+  gpu_dev_->support_gdrcopy = doca_gpu_gdrcopy_is_supported();
 
-    try {
-        gpu_dev_->mtable = new std::unordered_map<uintptr_t, struct doca_gpu_mtable *>();
-    } catch (...) {
-        DOCA_LOG(LOG_ERR, "mtable map allocation failed");
-        goto exit_error;
-    }
+  try {
+    gpu_dev_->mtable = new std::unordered_map<uintptr_t, struct doca_gpu_mtable *>();
+  } catch (...) {
+    DOCA_LOG(LOG_ERR, "mtable map allocation failed");
+    goto exit_error;
+  }
 
-    (*gpu_dev) = gpu_dev_;
+  (*gpu_dev) = gpu_dev_;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 
 exit_error:
-    free(gpu_dev_);
+  free(gpu_dev_);
 
-    return DOCA_ERROR_INITIALIZATION;
+  return DOCA_ERROR_INITIALIZATION;
 }
 
 doca_error_t doca_gpu_destroy(struct doca_gpu *gpu_dev) {
-    if (gpu_dev == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid input parameters.");
-        return DOCA_ERROR_INVALID_VALUE;
+  if (gpu_dev == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid input parameters.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+
+  if (gpu_dev->mtable != nullptr) {
+    if (gpu_dev->mtable->size() > 0) {
+      DOCA_LOG(LOG_ERR, "mtable map is not empty.");
+      return DOCA_ERROR_INVALID_VALUE;
     }
+    delete gpu_dev->mtable;
+  }
 
-    if (gpu_dev->mtable != nullptr) {
-        if (gpu_dev->mtable->size() > 0) {
-            DOCA_LOG(LOG_ERR, "mtable map is not empty.");
-            return DOCA_ERROR_INVALID_VALUE;
-        }
-        delete gpu_dev->mtable;
-    }
+  free(gpu_dev);
 
-    free(gpu_dev);
-
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_mem_alloc(struct doca_gpu *gpu_dev, size_t size, size_t alignment,
-                                enum doca_gpu_mem_type mtype, void **memptr_gpu,
-                                void **memptr_cpu) {
-    cudaError_t res;
-    CUresult res_drv;
-    int ret;
-    void *cudev_memptr_gpu_orig_ = 0;
-    void *cudev_memptr_gpu_ = 0;
-    struct doca_gpu_mtable *mentry;
-    unsigned int flag = 1;
-    const char *err_string;
-    void *memptr_cpu_ = nullptr;
-    doca_error_t status = DOCA_SUCCESS;
+    enum doca_gpu_mem_type mtype, void **memptr_gpu,
+    void **memptr_cpu) {
+  cudaError_t res;
+  CUresult res_drv;
+  int ret;
+  void *cudev_memptr_gpu_orig_ = 0;
+  void *cudev_memptr_gpu_ = 0;
+  struct doca_gpu_mtable *mentry;
+  unsigned int flag = 1;
+  const char *err_string;
+  void *memptr_cpu_ = nullptr;
+  doca_error_t status = DOCA_SUCCESS;
 
-    if (gpu_dev == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid DOCA GPUNetIO instance provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (gpu_dev == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid DOCA GPUNetIO instance provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (memptr_gpu == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid memptr_gpu provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (memptr_gpu == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid memptr_gpu provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (mtype != DOCA_GPU_MEM_TYPE_GPU && memptr_cpu == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid memptr_cpu provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (mtype != DOCA_GPU_MEM_TYPE_GPU && memptr_cpu == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid memptr_cpu provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (size == 0) {
-        DOCA_LOG(LOG_ERR, "Invalid size provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (size == 0) {
+    DOCA_LOG(LOG_ERR, "Invalid size provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (alignment == 0) alignment = priv_get_page_size();
+  if (alignment == 0) alignment = priv_get_page_size();
 
-    if (priv_is_power_of_two(alignment) == false) {
-        DOCA_LOG(LOG_ERR, "alignment %zd has to be power of 2.", alignment);
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (priv_is_power_of_two(alignment) == false) {
+    DOCA_LOG(LOG_ERR, "alignment %zd has to be power of 2.", alignment);
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    mentry = (struct doca_gpu_mtable *)calloc(1, sizeof(struct doca_gpu_mtable));
-    mentry->mtype = mtype;
-    mentry->size = size;
+  mentry = (struct doca_gpu_mtable *)calloc(1, sizeof(struct doca_gpu_mtable));
+  mentry->mtype = mtype;
+  mentry->size = size;
 
-    if (mtype == DOCA_GPU_MEM_TYPE_GPU_CPU && alignment != GPU_PAGE_SIZE) alignment = GPU_PAGE_SIZE;
+  if (mtype == DOCA_GPU_MEM_TYPE_GPU_CPU && alignment != GPU_PAGE_SIZE) alignment = GPU_PAGE_SIZE;
 
-    if (mtype == DOCA_GPU_MEM_TYPE_GPU) {
-        mentry->size_orig = mentry->size + alignment;
+  if (mtype == DOCA_GPU_MEM_TYPE_GPU) {
+    mentry->size_orig = mentry->size + alignment;
 
-        res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
+    res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
             cudaMalloc(&(cudev_memptr_gpu_orig_), mentry->size_orig));
-        if (res != cudaSuccess) {
-            err_string = cudaGetErrorString(res);
-            DOCA_LOG(LOG_ERR, "cudaMalloc current failed with %s size %zd", err_string,
-                     mentry->size_orig);
-            goto error;
-        }
-
-        /* Align memory address */
-        cudev_memptr_gpu_ = cudev_memptr_gpu_orig_;
-        if (alignment && ((uintptr_t)cudev_memptr_gpu_) % alignment)
-            cudev_memptr_gpu_ =
-                (void *)((uintptr_t)cudev_memptr_gpu_ +
-                         (alignment - (((uintptr_t)cudev_memptr_gpu_) % alignment)));
-
-        /* GPUDirect RDMA attribute required */
-        res_drv = doca_verbs_wrapper_cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                                           (CUdeviceptr)cudev_memptr_gpu_);
-        if (res_drv != CUDA_SUCCESS) {
-            DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree(cudev_memptr_gpu_orig_));
-            DOCA_LOG(LOG_ERR, "Could not set SYNC MEMOP attribute for GPU memory at %lx, err %d",
-                     (uintptr_t)cudev_memptr_gpu_, res);
-            status = DOCA_ERROR_DRIVER;
-            goto error;
-        }
-
-        mentry->base_addr = (uintptr_t)cudev_memptr_gpu_orig_;
-        mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
-        mentry->align_addr_cpu = 0;
-    } else if (mtype == DOCA_GPU_MEM_TYPE_GPU_CPU) {
-        if (gpu_dev->support_gdrcopy == true) {
-            mentry->size_orig = mentry->size + alignment;
-
-            res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
-                cudaMalloc(&(cudev_memptr_gpu_orig_), mentry->size_orig));
-            if (res != cudaSuccess) {
-                err_string = cudaGetErrorString(res);
-                DOCA_LOG(LOG_ERR, "cudaMalloc current failed with %s", err_string);
-                status = DOCA_ERROR_DRIVER;
-                goto error;
-            }
-
-            /* Align memory address */
-            cudev_memptr_gpu_ = cudev_memptr_gpu_orig_;
-            if (alignment && ((uintptr_t)cudev_memptr_gpu_) % alignment)
-                cudev_memptr_gpu_ =
-                    (void *)((uintptr_t)cudev_memptr_gpu_ +
-                             (alignment - (((uintptr_t)cudev_memptr_gpu_) % alignment)));
-
-            /* GPUDirect RDMA attribute required */
-            res_drv = doca_verbs_wrapper_cuPointerSetAttribute(
-                &flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, (CUdeviceptr)cudev_memptr_gpu_);
-            if (res_drv != CUDA_SUCCESS) {
-                DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree(cudev_memptr_gpu_orig_));
-                DOCA_LOG(LOG_ERR,
-                         "Could not set SYNC MEMOP attribute for GPU memory at %lx, err %d",
-                         (uintptr_t)cudev_memptr_gpu_, res);
-                status = DOCA_ERROR_DRIVER;
-                goto error;
-            }
-
-            mentry->base_addr = (uintptr_t)cudev_memptr_gpu_orig_;
-            mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
-            mentry->align_addr_cpu = 0;
-
-            ret =
-                doca_gpu_gdrcopy_create_mapping((void *)mentry->align_addr_gpu, mentry->size,
-                                                &mentry->gdr_mh, (void **)&mentry->align_addr_cpu);
-            if (ret) {
-                DOCA_LOG(LOG_ERR, "Error mapping GPU memory at %lx to CPU", mentry->align_addr_gpu);
-                status = DOCA_ERROR_DRIVER;
-                goto error;
-            }
-        } else {
-            DOCA_LOG(LOG_WARNING,
-                     "GDRCopy not enabled, can't allocate memory type DOCA_GPU_MEM_TYPE_GPU_CPU. "
-                     "Using DOCA_GPU_MEM_TYPE_CPU_GPU mode instead");
-
-            mentry->size_orig = mentry->size;
-
-            memptr_cpu_ = (uint8_t *)calloc(alignment, mentry->size_orig);
-            if (memptr_cpu_ == nullptr) {
-                DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory.");
-                status = DOCA_ERROR_DRIVER;
-                goto error;
-            }
-
-            res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
-                memptr_cpu_, mentry->size_orig, cudaHostRegisterPortable | cudaHostRegisterMapped));
-            if (res != cudaSuccess) {
-                DOCA_LOG(LOG_ERR, "Could register CPU memory to CUDA %lx, err %d",
-                         (uintptr_t)memptr_cpu_, res);
-                free(memptr_cpu_);
-                status = DOCA_ERROR_DRIVER;
-                goto error;
-            }
-
-            mentry->base_addr = (uintptr_t)memptr_cpu_;
-
-            res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
-                cudaHostGetDevicePointer(&cudev_memptr_gpu_, memptr_cpu_, 0));
-            if (res != cudaSuccess) {
-                DOCA_LOG(LOG_ERR, "Could get GPU device ptr for CPU memory %lx, err %d",
-                         (uintptr_t)memptr_cpu_, res);
-                free(memptr_cpu_);
-                status = DOCA_ERROR_DRIVER;
-                goto error;
-            }
-
-            mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
-            mentry->align_addr_cpu = (uintptr_t)memptr_cpu_;
-        }
-
-    } else if (mtype == DOCA_GPU_MEM_TYPE_CPU_GPU) {
-        mentry->size_orig = mentry->size;
-
-        memptr_cpu_ = (uint8_t *)calloc(alignment, mentry->size_orig);
-        if (memptr_cpu_ == nullptr) {
-            DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory.");
-            status = DOCA_ERROR_DRIVER;
-            goto error;
-        }
-
-        res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
-            memptr_cpu_, mentry->size_orig, cudaHostRegisterPortable | cudaHostRegisterMapped));
-        if (res != cudaSuccess) {
-            DOCA_LOG(LOG_ERR, "Could register CPU memory to CUDA %lx, err %d",
-                     (uintptr_t)memptr_cpu_, res);
-            free(memptr_cpu_);
-            status = DOCA_ERROR_DRIVER;
-            goto error;
-        }
-
-        mentry->base_addr = (uintptr_t)memptr_cpu_;
-
-        res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
-            cudaHostGetDevicePointer(&cudev_memptr_gpu_, memptr_cpu_, 0));
-        if (res != cudaSuccess) {
-            DOCA_LOG(LOG_ERR, "Could get GPU device ptr for CPU memory %lx, err %d",
-                     (uintptr_t)memptr_cpu_, res);
-            free(memptr_cpu_);
-            status = DOCA_ERROR_DRIVER;
-            goto error;
-        }
-
-        mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
-        mentry->align_addr_cpu = (uintptr_t)memptr_cpu_;
+    if (res != cudaSuccess) {
+      err_string = cudaGetErrorString(res);
+      DOCA_LOG(LOG_ERR, "cudaMalloc current failed with %s size %zd", err_string,
+          mentry->size_orig);
+      goto error;
     }
 
-    *memptr_gpu = (void *)mentry->align_addr_gpu;
-    if (memptr_cpu) *memptr_cpu = (void *)mentry->align_addr_cpu;
+    /* Align memory address */
+    cudev_memptr_gpu_ = cudev_memptr_gpu_orig_;
+    if (alignment && ((uintptr_t)cudev_memptr_gpu_) % alignment)
+      cudev_memptr_gpu_ =
+          (void *)((uintptr_t)cudev_memptr_gpu_ +
+        (alignment - (((uintptr_t)cudev_memptr_gpu_) % alignment)));
 
-    // DOCA_LOG(LOG_DEBUG, "New memory: Orig %lx GPU %lx CPU %lx type %d size %zd\n",
-    // 	      mentry->base_addr,
-    // 	      mentry->align_addr_gpu,
-    // 	      mentry->align_addr_cpu,
-    // 	      mentry->mtype,
-    // 	      mentry->size);
+    /* GPUDirect RDMA attribute required */
+    res_drv = doca_verbs_wrapper_cuPointerSetAttribute(&flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+            (CUdeviceptr)cudev_memptr_gpu_);
+    if (res_drv != CUDA_SUCCESS) {
+      DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree(cudev_memptr_gpu_orig_));
+      DOCA_LOG(LOG_ERR, "Could not set SYNC MEMOP attribute for GPU memory at %lx, err %d",
+          (uintptr_t)cudev_memptr_gpu_, res);
+      status = DOCA_ERROR_DRIVER;
+      goto error;
+    }
 
-    try {
-        gpu_dev->mtable->insert({mentry->align_addr_gpu, mentry});
-    } catch (...) {
-        DOCA_LOG(LOG_ERR, "mtable map insert failed");
+    mentry->base_addr = (uintptr_t)cudev_memptr_gpu_orig_;
+    mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
+    mentry->align_addr_cpu = 0;
+  } else if (mtype == DOCA_GPU_MEM_TYPE_GPU_CPU) {
+    if (gpu_dev->support_gdrcopy == true) {
+      mentry->size_orig = mentry->size + alignment;
+
+      res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
+              cudaMalloc(&(cudev_memptr_gpu_orig_), mentry->size_orig));
+      if (res != cudaSuccess) {
+        err_string = cudaGetErrorString(res);
+        DOCA_LOG(LOG_ERR, "cudaMalloc current failed with %s", err_string);
         status = DOCA_ERROR_DRIVER;
         goto error;
+      }
+
+      /* Align memory address */
+      cudev_memptr_gpu_ = cudev_memptr_gpu_orig_;
+      if (alignment && ((uintptr_t)cudev_memptr_gpu_) % alignment)
+        cudev_memptr_gpu_ =
+            (void *)((uintptr_t)cudev_memptr_gpu_ +
+          (alignment - (((uintptr_t)cudev_memptr_gpu_) % alignment)));
+
+      /* GPUDirect RDMA attribute required */
+      res_drv = doca_verbs_wrapper_cuPointerSetAttribute(
+              &flag, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, (CUdeviceptr)cudev_memptr_gpu_);
+      if (res_drv != CUDA_SUCCESS) {
+        DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree(cudev_memptr_gpu_orig_));
+        DOCA_LOG(LOG_ERR,
+            "Could not set SYNC MEMOP attribute for GPU memory at %lx, err %d",
+            (uintptr_t)cudev_memptr_gpu_, res);
+        status = DOCA_ERROR_DRIVER;
+        goto error;
+      }
+
+      mentry->base_addr = (uintptr_t)cudev_memptr_gpu_orig_;
+      mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
+      mentry->align_addr_cpu = 0;
+
+      ret =
+          doca_gpu_gdrcopy_create_mapping((void *)mentry->align_addr_gpu, mentry->size,
+        &mentry->gdr_mh, (void **)&mentry->align_addr_cpu);
+      if (ret) {
+        DOCA_LOG(LOG_ERR, "Error mapping GPU memory at %lx to CPU", mentry->align_addr_gpu);
+        status = DOCA_ERROR_DRIVER;
+        goto error;
+      }
+    } else {
+      DOCA_LOG(LOG_WARNING,
+          "GDRCopy not enabled, can't allocate memory type DOCA_GPU_MEM_TYPE_GPU_CPU. "
+          "Using DOCA_GPU_MEM_TYPE_CPU_GPU mode instead");
+
+      mentry->size_orig = mentry->size;
+
+      memptr_cpu_ = (uint8_t *)calloc(alignment, mentry->size_orig);
+      if (memptr_cpu_ == nullptr) {
+        DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory.");
+        status = DOCA_ERROR_DRIVER;
+        goto error;
+      }
+
+      res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
+        memptr_cpu_, mentry->size_orig, cudaHostRegisterPortable | cudaHostRegisterMapped));
+      if (res != cudaSuccess) {
+        DOCA_LOG(LOG_ERR, "Could register CPU memory to CUDA %lx, err %d",
+            (uintptr_t)memptr_cpu_, res);
+        free(memptr_cpu_);
+        status = DOCA_ERROR_DRIVER;
+        goto error;
+      }
+
+      mentry->base_addr = (uintptr_t)memptr_cpu_;
+
+      res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
+              cudaHostGetDevicePointer(&cudev_memptr_gpu_, memptr_cpu_, 0));
+      if (res != cudaSuccess) {
+        DOCA_LOG(LOG_ERR, "Could get GPU device ptr for CPU memory %lx, err %d",
+            (uintptr_t)memptr_cpu_, res);
+        free(memptr_cpu_);
+        status = DOCA_ERROR_DRIVER;
+        goto error;
+      }
+
+      mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
+      mentry->align_addr_cpu = (uintptr_t)memptr_cpu_;
     }
 
-    return DOCA_SUCCESS;
+  } else if (mtype == DOCA_GPU_MEM_TYPE_CPU_GPU) {
+    mentry->size_orig = mentry->size;
+
+    memptr_cpu_ = (uint8_t *)calloc(alignment, mentry->size_orig);
+    if (memptr_cpu_ == nullptr) {
+      DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory.");
+      status = DOCA_ERROR_DRIVER;
+      goto error;
+    }
+
+    res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
+      memptr_cpu_, mentry->size_orig, cudaHostRegisterPortable | cudaHostRegisterMapped));
+    if (res != cudaSuccess) {
+      DOCA_LOG(LOG_ERR, "Could register CPU memory to CUDA %lx, err %d",
+          (uintptr_t)memptr_cpu_, res);
+      free(memptr_cpu_);
+      status = DOCA_ERROR_DRIVER;
+      goto error;
+    }
+
+    mentry->base_addr = (uintptr_t)memptr_cpu_;
+
+    res = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
+            cudaHostGetDevicePointer(&cudev_memptr_gpu_, memptr_cpu_, 0));
+    if (res != cudaSuccess) {
+      DOCA_LOG(LOG_ERR, "Could get GPU device ptr for CPU memory %lx, err %d",
+          (uintptr_t)memptr_cpu_, res);
+      free(memptr_cpu_);
+      status = DOCA_ERROR_DRIVER;
+      goto error;
+    }
+
+    mentry->align_addr_gpu = (uintptr_t)cudev_memptr_gpu_;
+    mentry->align_addr_cpu = (uintptr_t)memptr_cpu_;
+  }
+
+  *memptr_gpu = (void *)mentry->align_addr_gpu;
+  if (memptr_cpu) *memptr_cpu = (void *)mentry->align_addr_cpu;
+
+  // DOCA_LOG(LOG_DEBUG, "New memory: Orig %lx GPU %lx CPU %lx type %d size %zd\n",
+  // 	      mentry->base_addr,
+  // 	      mentry->align_addr_gpu,
+  // 	      mentry->align_addr_cpu,
+  // 	      mentry->mtype,
+  // 	      mentry->size);
+
+  try {
+    gpu_dev->mtable->insert({mentry->align_addr_gpu, mentry});
+  } catch (...) {
+    DOCA_LOG(LOG_ERR, "mtable map insert failed");
+    status = DOCA_ERROR_DRIVER;
+    goto error;
+  }
+
+  return DOCA_SUCCESS;
 
 error:
-    free(mentry);
-    return status;
+  free(mentry);
+  return status;
 }
 
 doca_error_t doca_gpu_mem_free(struct doca_gpu *gpu_dev, void *memptr_gpu) {
-    struct doca_gpu_mtable *mentry;
-    cudaError_t res_cuda;
+  struct doca_gpu_mtable *mentry;
+  cudaError_t res_cuda;
 
-    if (gpu_dev == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid DOCA GPUNetIO instance provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (gpu_dev == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid DOCA GPUNetIO instance provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (memptr_gpu == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid memptr_gpu provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (memptr_gpu == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid memptr_gpu provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    std::unordered_map<uint64_t, struct doca_gpu_mtable *>::const_iterator it =
-        gpu_dev->mtable->find((uintptr_t)memptr_gpu);
-    if (it == gpu_dev->mtable->end()) {
-        DOCA_LOG(LOG_ERR, "memptr_gpu = %p was not allocated by DOCA GPUNetIO.", memptr_gpu);
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  std::unordered_map<uint64_t, struct doca_gpu_mtable *>::const_iterator it =
+      gpu_dev->mtable->find((uintptr_t)memptr_gpu);
+  if (it == gpu_dev->mtable->end()) {
+    DOCA_LOG(LOG_ERR, "memptr_gpu = %p was not allocated by DOCA GPUNetIO.", memptr_gpu);
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    mentry = it->second;
+  mentry = it->second;
 
-    if (mentry->mtype == DOCA_GPU_MEM_TYPE_GPU)
-        DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree((void *)mentry->base_addr));
-    else if (mentry->mtype == DOCA_GPU_MEM_TYPE_GPU_CPU) {
-        if (gpu_dev->support_gdrcopy)
-            doca_gpu_gdrcopy_destroy_mapping(mentry->gdr_mh, (void *)mentry->align_addr_cpu,
-                                             mentry->size);
-        DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree((void *)mentry->base_addr));
-    } else {
-        res_cuda = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister((void *)mentry->base_addr));
-        if (res_cuda != cudaSuccess)
-            DOCA_LOG(LOG_ERR, "Error unregistering GPU memory at %p", (void *)mentry->base_addr);
-        free((void *)mentry->base_addr);
-    }
+  if (mentry->mtype == DOCA_GPU_MEM_TYPE_GPU)
+    DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree((void *)mentry->base_addr));
+  else if (mentry->mtype == DOCA_GPU_MEM_TYPE_GPU_CPU) {
+    if (gpu_dev->support_gdrcopy)
+      doca_gpu_gdrcopy_destroy_mapping(mentry->gdr_mh, (void *)mentry->align_addr_cpu,
+        mentry->size);
+    DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaFree((void *)mentry->base_addr));
+  } else {
+    res_cuda = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister((void *)mentry->base_addr));
+    if (res_cuda != cudaSuccess)
+      DOCA_LOG(LOG_ERR, "Error unregistering GPU memory at %p", (void *)mentry->base_addr);
+    free((void *)mentry->base_addr);
+  }
 
-    gpu_dev->mtable->erase(it);
-    free(mentry);
+  gpu_dev->mtable->erase(it);
+  free(mentry);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_dmabuf_fd(struct doca_gpu *gpu_dev, void *memptr_gpu, size_t size,
-                                int *dmabuf_fd) {
+    int *dmabuf_fd) {
 #if DOCA_GPUNETIO_HAVE_CUDA_DMABUF == 1
-    CUresult res_drv = CUDA_SUCCESS;
+  CUresult res_drv = CUDA_SUCCESS;
 
-    if (gpu_dev == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid DOCA GPUNetIO instance provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (gpu_dev == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid DOCA GPUNetIO instance provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (gpu_dev->support_dmabuf == false) {
-        DOCA_LOG(LOG_ERR, "DMABuf not supported on this system by this CUDA installation.");
-        return DOCA_ERROR_NOT_SUPPORTED;
-    }
-
-    if (dmabuf_fd == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid DMABuf fd pointer provided.");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-
-    res_drv = doca_verbs_wrapper_cuMemGetHandleForAddressRange(
-        dmabuf_fd, (CUdeviceptr)memptr_gpu, size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
-    if (res_drv != CUDA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "cuMemGetHandleForAddressRange returned %d.", res_drv);
-        return DOCA_ERROR_NOT_SUPPORTED;
-    }
-
-    return DOCA_SUCCESS;
-#else
+  if (gpu_dev->support_dmabuf == false) {
+    DOCA_LOG(LOG_ERR, "DMABuf not supported on this system by this CUDA installation.");
     return DOCA_ERROR_NOT_SUPPORTED;
+  }
+
+  if (dmabuf_fd == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid DMABuf fd pointer provided.");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+
+  res_drv = doca_verbs_wrapper_cuMemGetHandleForAddressRange(
+          dmabuf_fd, (CUdeviceptr)memptr_gpu, size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+  if (res_drv != CUDA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "cuMemGetHandleForAddressRange returned %d.", res_drv);
+    return DOCA_ERROR_NOT_SUPPORTED;
+  }
+
+  return DOCA_SUCCESS;
+#else
+  return DOCA_ERROR_NOT_SUPPORTED;
 #endif
 }
 
 static std::mutex registered_uar_mutex;
 
 doca_error_t doca_gpu_verbs_can_gpu_register_uar(void *db, bool *out_can_register) {
-    std::lock_guard<std::mutex> lock(registered_uar_mutex);
-    cudaError_t cuda_status = cudaSuccess;
-    static bool can_register = false;
-    static bool registration_checked = false;
+  std::lock_guard<std::mutex> lock(registered_uar_mutex);
+  cudaError_t cuda_status = cudaSuccess;
+  static bool can_register = false;
+  static bool registration_checked = false;
 
-    if (out_can_register == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  if (out_can_register == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    if (!registration_checked) {
-        if (db == nullptr) return DOCA_ERROR_INVALID_VALUE;
-        cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
-            db, DOCA_VERBS_DB_UAR_SIZE,
-            cudaHostRegisterPortable | cudaHostRegisterMapped | cudaHostRegisterIoMemory));
+  if (!registration_checked) {
+    if (db == nullptr) return DOCA_ERROR_INVALID_VALUE;
+    cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
+      db, DOCA_VERBS_DB_UAR_SIZE,
+      cudaHostRegisterPortable | cudaHostRegisterMapped | cudaHostRegisterIoMemory));
 
-        can_register =
-            (cuda_status == cudaSuccess || cuda_status == cudaErrorHostMemoryAlreadyRegistered);
+    can_register =
+        (cuda_status == cudaSuccess || cuda_status == cudaErrorHostMemoryAlreadyRegistered);
 
-        if (cuda_status == cudaSuccess) DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister(db));
-        registration_checked = true;
-    }
+    if (cuda_status == cudaSuccess) DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister(db));
+    registration_checked = true;
+  }
 
-    *out_can_register = can_register;
+  *out_can_register = can_register;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 static std::unordered_map<void *, unsigned int> registered_uar_refcount;
 
 doca_error_t doca_gpu_verbs_export_uar(uint64_t *sq_db, uint64_t **uar_addr_gpu) {
-    std::lock_guard<std::mutex> lock(registered_uar_mutex);
+  std::lock_guard<std::mutex> lock(registered_uar_mutex);
 
-    void *ptr = nullptr;
-    cudaError_t cuda_status = cudaSuccess;
-    bool registered = false;
-    void *uar_key;
+  void *ptr = nullptr;
+  cudaError_t cuda_status = cudaSuccess;
+  bool registered = false;
+  void *uar_key;
 
-    if (sq_db == nullptr || uar_addr_gpu == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  if (sq_db == nullptr || uar_addr_gpu == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    uar_key = (void *)sq_db;
-    if (registered_uar_refcount.find(uar_key) == registered_uar_refcount.end()) {
-        registered_uar_refcount[uar_key] = 0;
-    }
+  uar_key = (void *)sq_db;
+  if (registered_uar_refcount.find(uar_key) == registered_uar_refcount.end()) {
+    registered_uar_refcount[uar_key] = 0;
+  }
 
-    if (registered_uar_refcount[uar_key] == 0) {
-        cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
-            sq_db, DOCA_VERBS_DB_UAR_SIZE,
-            cudaHostRegisterPortable | cudaHostRegisterMapped | cudaHostRegisterIoMemory));
-        if (cuda_status != cudaSuccess) {
-            DOCA_LOG(LOG_ERR,
-                     "Function cudaHostRegister (err %d) "
-                     "failed on addr %p size %d",
-                     cuda_status, (void *)sq_db, DOCA_VERBS_DB_UAR_SIZE);
-            goto out;
-        }
-        registered = true;
-    }
-
-    cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostGetDevicePointer(&ptr, sq_db, 0));
+  if (registered_uar_refcount[uar_key] == 0) {
+    cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostRegister(
+      sq_db, DOCA_VERBS_DB_UAR_SIZE,
+      cudaHostRegisterPortable | cudaHostRegisterMapped | cudaHostRegisterIoMemory));
     if (cuda_status != cudaSuccess) {
-        DOCA_LOG(LOG_ERR,
-                 "Function cudaHostGetDevicePointer (err %d) "
-                 "failed on addr %p size %d",
-                 cuda_status, (void *)sq_db, DOCA_VERBS_DB_UAR_SIZE);
-        goto out;
+      DOCA_LOG(LOG_ERR,
+          "Function cudaHostRegister (err %d) "
+          "failed on addr %p size %d",
+          cuda_status, (void *)sq_db, DOCA_VERBS_DB_UAR_SIZE);
+      goto out;
     }
+    registered = true;
+  }
 
-    registered_uar_refcount[uar_key]++;
+  cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostGetDevicePointer(&ptr, sq_db, 0));
+  if (cuda_status != cudaSuccess) {
+    DOCA_LOG(LOG_ERR,
+        "Function cudaHostGetDevicePointer (err %d) "
+        "failed on addr %p size %d",
+        cuda_status, (void *)sq_db, DOCA_VERBS_DB_UAR_SIZE);
+    goto out;
+  }
 
-    *uar_addr_gpu = (uint64_t *)ptr;
+  registered_uar_refcount[uar_key]++;
+
+  *uar_addr_gpu = (uint64_t *)ptr;
 
 out:
-    if (cuda_status != cudaSuccess) {
-        if (registered) DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister(sq_db));
-        return DOCA_ERROR_DRIVER;
-    }
+  if (cuda_status != cudaSuccess) {
+    if (registered) DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister(sq_db));
+    return DOCA_ERROR_DRIVER;
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_verbs_unexport_uar(uint64_t *uar_addr_gpu) {
-    std::lock_guard<std::mutex> lock(registered_uar_mutex);
+  std::lock_guard<std::mutex> lock(registered_uar_mutex);
 
-    cudaError_t cuda_status = cudaSuccess;
-    void *uar_key;
+  cudaError_t cuda_status = cudaSuccess;
+  void *uar_key;
 
-    if (uar_addr_gpu == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  if (uar_addr_gpu == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    uar_key = (void *)uar_addr_gpu;
-    if (registered_uar_refcount.find(uar_key) == registered_uar_refcount.end()) {
-        DOCA_LOG(LOG_ERR, "UAR address %p not found in registered_uar_refcount", uar_addr_gpu);
-        return DOCA_ERROR_INVALID_VALUE;
+  uar_key = (void *)uar_addr_gpu;
+  if (registered_uar_refcount.find(uar_key) == registered_uar_refcount.end()) {
+    DOCA_LOG(LOG_ERR, "UAR address %p not found in registered_uar_refcount", uar_addr_gpu);
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  registered_uar_refcount[uar_key]--;
+  if (registered_uar_refcount[uar_key] == 0) {
+    registered_uar_refcount.erase(uar_key);
+    cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister(uar_addr_gpu));
+    if (cuda_status != cudaSuccess) {
+      DOCA_LOG(LOG_ERR, "Failed to unregister UAR address %p", uar_addr_gpu);
+      return DOCA_ERROR_DRIVER;
     }
-    registered_uar_refcount[uar_key]--;
-    assert(registered_uar_refcount[uar_key] >= 0);
-    if (registered_uar_refcount[uar_key] == 0) {
-        registered_uar_refcount.erase(uar_key);
-        cuda_status = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaHostUnregister(uar_addr_gpu));
-        if (cuda_status != cudaSuccess) {
-            DOCA_LOG(LOG_ERR, "Failed to unregister UAR address %p", uar_addr_gpu);
-            return DOCA_ERROR_DRIVER;
-        }
-    }
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_verbs_export_qp(struct doca_gpu *gpu_dev, struct doca_verbs_qp *qp,
-                                      enum doca_gpu_dev_verbs_nic_handler nic_handler,
-                                      void *gpu_qp_umem_dev_ptr, struct doca_verbs_cq *cq_sq,
-                                      enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext,
-                                      struct doca_gpu_verbs_qp **qp_out) {
-    doca_error_t status = DOCA_SUCCESS;
-    struct doca_gpu_dev_verbs_qp *qp_cpu_ = nullptr;
-    struct doca_gpu_verbs_qp *qp_gverbs = nullptr;
-    void *rq_wqe_daddr;
-    uint32_t rq_wqe_num;
-    uint32_t rcv_wqe_size;
-    uint64_t *sq_db;
-    uint32_t sq_wqe_num;
-    uint64_t *uar_db_reg = NULL;
-    uint32_t *arm_dbr = NULL;
-    uint32_t *cq_dbrec;
-    uint32_t *dbrec;
-    struct doca_verbs_qp_init_attr *verbs_qp_init_attr_out = nullptr;
-    struct doca_verbs_qp_attr *verbs_qp_attr_out = nullptr;
-    enum doca_verbs_qp_send_dbr_mode send_dbr_mode;
-    bool nic_handler_must_be_cpu_proxy = false;
+    enum doca_gpu_dev_verbs_nic_handler nic_handler,
+    void * /*gpu_qp_umem_dev_ptr*/, struct doca_verbs_cq *cq_sq,
+    enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext,
+    struct doca_gpu_verbs_qp **qp_out) {
+  doca_error_t status = DOCA_SUCCESS;
+  struct doca_gpu_dev_verbs_qp *qp_cpu_ = nullptr;
+  struct doca_gpu_verbs_qp *qp_gverbs = nullptr;
+  void *rq_wqe_daddr;
+  uint32_t rq_wqe_num;
+  uint32_t rcv_wqe_size;
+  uint64_t *sq_db;
+  uint32_t sq_wqe_num;
+  uint64_t *uar_db_reg = NULL;
+  uint32_t *arm_dbr = NULL;
+  uint32_t *cq_dbrec;
+  uint32_t *dbrec;
+  struct doca_verbs_qp_init_attr *verbs_qp_init_attr_out = nullptr;
+  struct doca_verbs_qp_attr *verbs_qp_attr_out = nullptr;
+  enum doca_verbs_qp_send_dbr_mode send_dbr_mode;
+  bool nic_handler_must_be_cpu_proxy = false;
 
-    if (gpu_dev == nullptr || qp == nullptr || qp_out == nullptr || cq_sq == nullptr) {
-        DOCA_LOG(LOG_ERR, "Invalid arguments provided.");
-        status = DOCA_ERROR_INVALID_VALUE;
-        goto out;
+  if (gpu_dev == nullptr || qp == nullptr || qp_out == nullptr || cq_sq == nullptr) {
+    DOCA_LOG(LOG_ERR, "Invalid arguments provided.");
+    status = DOCA_ERROR_INVALID_VALUE;
+    goto out;
+  }
+
+  if ((nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_NO_DBR) &&
+    (send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR)) {
+    DOCA_LOG(LOG_ERR,
+        "DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_NO_DBR cannot be used with "
+        "DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR");
+    status = DOCA_ERROR_INVALID_VALUE;
+    goto out;
+  }
+
+  if ((send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) &&
+    !gpu_dev->support_gdrcopy) {
+    DOCA_LOG(LOG_ERR, "SW-emulated no DBR feature is not supported without GDRCopy");
+    status = DOCA_ERROR_INVALID_VALUE;
+    goto out;
+  }
+
+  qp_gverbs = (struct doca_gpu_verbs_qp *)calloc(1, sizeof(struct doca_gpu_verbs_qp));
+  if (qp_gverbs == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory");
+    status = DOCA_ERROR_NO_MEMORY;
+    goto out;
+  }
+
+  qp_gverbs->qp_cpu =
+      (struct doca_gpu_dev_verbs_qp *)calloc(1, sizeof(struct doca_gpu_dev_verbs_qp));
+  if (qp_gverbs->qp_cpu == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory");
+    status = DOCA_ERROR_NO_MEMORY;
+    goto out;
+  }
+
+  qp_cpu_ = qp_gverbs->qp_cpu;
+
+  // Should this be propagated to GPU?
+  if (qp->get_uar_mtype() == DOCA_VERBS_UAR_ALLOCATION_TYPE_BLUEFLAME)
+    gpu_dev->support_bf_uar = true;
+
+  // Check QP and CQ same size!!!!
+
+  doca_verbs_qp_get_wq(qp,
+      (void **)&(qp_cpu_->sq_wqe_daddr),  // broken for external umem
+      &sq_wqe_num,
+      (void **)&(rq_wqe_daddr),  // broken for external umem
+      &rq_wqe_num, &rcv_wqe_size);
+
+  dbrec = reinterpret_cast<uint32_t *>(doca_verbs_qp_get_dbr_addr(qp));
+
+  qp_cpu_->sq_wqe_num = (uint16_t)sq_wqe_num;
+  qp_cpu_->sq_wqe_mask = qp_cpu_->sq_wqe_num - 1;
+  qp_cpu_->sq_num = doca_verbs_qp_get_qpn(qp);
+  qp_cpu_->sq_num_shift8 = qp_cpu_->sq_num << 8;
+  qp_cpu_->sq_num_shift8_be = htobe32(qp_cpu_->sq_num_shift8);
+  qp_cpu_->sq_num_shift8_be_1ds = htobe32(qp_cpu_->sq_num_shift8 | 1);
+  qp_cpu_->sq_num_shift8_be_2ds = htobe32(qp_cpu_->sq_num_shift8 | 2);
+  qp_cpu_->sq_num_shift8_be_3ds = htobe32(qp_cpu_->sq_num_shift8 | 3);
+  qp_cpu_->sq_num_shift8_be_4ds = htobe32(qp_cpu_->sq_num_shift8 | 4);
+  qp_cpu_->sq_wqe_pi = 0;
+  qp_cpu_->sq_rsvd_index = 0;
+  qp_cpu_->sq_ready_index = 0;
+  qp_cpu_->sq_lock = 0;
+  qp_cpu_->sq_dbrec = (__be32 *)(dbrec + DOCA_GPUNETIO_IB_MLX5_SND_DBR);
+  qp_cpu_->mem_type = DOCA_GPUNETIO_VERBS_MEM_TYPE_GPU;
+  qp_gverbs->cpu_db = nullptr;
+  qp_gverbs->sq_db = nullptr;
+  qp_gverbs->sq_wqe_pi_last = 0;
+  qp_gverbs->cpu_proxy = false;
+  qp_gverbs->qp_gpu = nullptr;
+  qp_gverbs->send_dbr_mode_ext = send_dbr_mode_ext;
+  qp_gverbs->qp = qp;
+
+  status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr_out);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Can't create QP init attr structure.");
+    goto out;
+  }
+
+  status = doca_verbs_qp_attr_create(&verbs_qp_attr_out);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Can't create QP attr structure.");
+    goto out;
+  }
+
+  status = doca_verbs_qp_query(qp, verbs_qp_attr_out, verbs_qp_init_attr_out);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Can't query QP.");
+    goto out;
+  }
+
+  send_dbr_mode = doca_verbs_qp_init_attr_get_send_dbr_mode(verbs_qp_init_attr_out);
+  if (((send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR) &&
+    (send_dbr_mode != DOCA_VERBS_QP_SEND_DBR_MODE_DBR_VALID)) ||
+    ((send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW) &&
+    (send_dbr_mode != DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT))) {
+    DOCA_LOG(LOG_ERR, "Invalid send_dbr_mode_ext.");
+    status = DOCA_ERROR_INVALID_VALUE;
+    goto out;
+  }
+
+  sq_db = reinterpret_cast<uint64_t *>(doca_verbs_qp_get_uar_addr(qp));
+
+  if (nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY) {
+    status = doca_gpu_verbs_export_uar(sq_db, (uint64_t **)&(qp_cpu_->sq_db));
+    if (status != DOCA_SUCCESS && nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO) {
+      DOCA_LOG(LOG_ERR, "Can't export UAR to GPU.");
+      goto out;
     }
+  }
 
-    if ((nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_NO_DBR) &&
-        (send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR)) {
-        DOCA_LOG(LOG_ERR,
-                 "DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_NO_DBR cannot be used with "
-                 "DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR");
-        status = DOCA_ERROR_INVALID_VALUE;
-        goto out;
-    }
+  if ((status != DOCA_SUCCESS && nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO) ||
+    nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY) {
+    DOCA_LOG(LOG_WARNING, "Enabling CPU proxy mode");
 
-    if ((send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) &&
-        !gpu_dev->support_gdrcopy) {
-        DOCA_LOG(LOG_ERR, "SW-emulated no DBR feature is not supported without GDRCopy");
-        status = DOCA_ERROR_INVALID_VALUE;
-        goto out;
-    }
-
-    qp_gverbs = (struct doca_gpu_verbs_qp *)calloc(1, sizeof(struct doca_gpu_verbs_qp));
-    if (qp_gverbs == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory");
-        status = DOCA_ERROR_NO_MEMORY;
-        goto out;
-    }
-
-    qp_gverbs->qp_cpu =
-        (struct doca_gpu_dev_verbs_qp *)calloc(1, sizeof(struct doca_gpu_dev_verbs_qp));
-    if (qp_gverbs->qp_cpu == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to allocate CPU memory");
-        status = DOCA_ERROR_NO_MEMORY;
-        goto out;
-    }
-
-    qp_cpu_ = qp_gverbs->qp_cpu;
-
-    // Should this be propagated to GPU?
-    if (qp->get_uar_mtype() == DOCA_VERBS_UAR_ALLOCATION_TYPE_BLUEFLAME)
-        gpu_dev->support_bf_uar = true;
-
-    // Check QP and CQ same size!!!!
-
-    doca_verbs_qp_get_wq(qp,
-                         (void **)&(qp_cpu_->sq_wqe_daddr),  // broken for external umem
-                         &sq_wqe_num,
-                         (void **)&(rq_wqe_daddr),  // broken for external umem
-                         &rq_wqe_num, &rcv_wqe_size);
-
-    dbrec = reinterpret_cast<uint32_t *>(doca_verbs_qp_get_dbr_addr(qp));
-
-    qp_cpu_->sq_wqe_num = (uint16_t)sq_wqe_num;
-    qp_cpu_->sq_wqe_mask = qp_cpu_->sq_wqe_num - 1;
-    qp_cpu_->sq_num = doca_verbs_qp_get_qpn(qp);
-    qp_cpu_->sq_num_shift8 = qp_cpu_->sq_num << 8;
-    qp_cpu_->sq_num_shift8_be = htobe32(qp_cpu_->sq_num_shift8);
-    qp_cpu_->sq_num_shift8_be_1ds = htobe32(qp_cpu_->sq_num_shift8 | 1);
-    qp_cpu_->sq_num_shift8_be_2ds = htobe32(qp_cpu_->sq_num_shift8 | 2);
-    qp_cpu_->sq_num_shift8_be_3ds = htobe32(qp_cpu_->sq_num_shift8 | 3);
-    qp_cpu_->sq_num_shift8_be_4ds = htobe32(qp_cpu_->sq_num_shift8 | 4);
-    qp_cpu_->sq_wqe_pi = 0;
-    qp_cpu_->sq_rsvd_index = 0;
-    qp_cpu_->sq_ready_index = 0;
-    qp_cpu_->sq_lock = 0;
-    qp_cpu_->sq_dbrec = (__be32 *)(dbrec + DOCA_GPUNETIO_IB_MLX5_SND_DBR);
-    qp_cpu_->mem_type = DOCA_GPUNETIO_VERBS_MEM_TYPE_GPU;
-    qp_gverbs->cpu_db = nullptr;
-    qp_gverbs->sq_db = nullptr;
-    qp_gverbs->sq_wqe_pi_last = 0;
-    qp_gverbs->cpu_proxy = false;
-    qp_gverbs->qp_gpu = nullptr;
-    qp_gverbs->send_dbr_mode_ext = send_dbr_mode_ext;
-    qp_gverbs->qp = qp;
-
-    status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr_out);
+    status = doca_gpu_mem_alloc(gpu_dev, sizeof(uint64_t), priv_get_page_size(),
+      DOCA_GPU_MEM_TYPE_CPU_GPU, (void **)&(qp_gverbs->cpu_db),
+      (void **)&(qp_gverbs->cpu_db));
     if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Can't create QP init attr structure.");
-        goto out;
+      DOCA_LOG(LOG_ERR, "Failed to alloc GPU memory for CPU proxy DB");
+      goto out;
     }
 
-    status = doca_verbs_qp_attr_create(&verbs_qp_attr_out);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Can't create QP attr structure.");
-        goto out;
+    *(qp_gverbs->cpu_db) = 0;
+    qp_cpu_->sq_db = qp_gverbs->cpu_db;
+    qp_gverbs->cpu_proxy = true;
+    qp_gverbs->sq_num_shift8_be = qp_cpu_->sq_num_shift8_be;
+    qp_gverbs->sq_dbrec = qp_cpu_->sq_dbrec;
+    qp_gverbs->sq_db = sq_db;
+    qp_cpu_->nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY;
+    nic_handler_must_be_cpu_proxy = true;
+  }
+
+  if (!nic_handler_must_be_cpu_proxy) {
+    if (send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) {
+      assert(gpu_dev->support_gdrcopy);
+      qp_gverbs->sq_dbrec = qp_cpu_->sq_dbrec;
+      qp_gverbs->sq_db = sq_db;
+      qp_gverbs->cpu_proxy = true;
     }
+    if (nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO) {
+      if ((send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT) ||
+        (send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED))
+        qp_cpu_->nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_NO_DBR;
+      else
+        qp_cpu_->nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB;
+    } else
+      qp_cpu_->nic_handler = nic_handler;
+  }
 
-    status = doca_verbs_qp_query(qp, verbs_qp_attr_out, verbs_qp_init_attr_out);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Can't query QP.");
-        goto out;
-    }
+  doca_verbs_cq_get_wq(cq_sq, (void **)&(qp_cpu_->cq_sq.cqe_daddr), &(qp_cpu_->cq_sq.cqe_num),
+    &(qp_cpu_->cq_sq.cqe_size));
 
-    send_dbr_mode = doca_verbs_qp_init_attr_get_send_dbr_mode(verbs_qp_init_attr_out);
-    if (((send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR) &&
-         (send_dbr_mode != DOCA_VERBS_QP_SEND_DBR_MODE_DBR_VALID)) ||
-        ((send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW) &&
-         (send_dbr_mode != DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT))) {
-        DOCA_LOG(LOG_ERR, "Invalid send_dbr_mode_ext.");
-        status = DOCA_ERROR_INVALID_VALUE;
-        goto out;
-    }
+  doca_verbs_cq_get_dbr_addr(cq_sq, &uar_db_reg, (uint32_t **)&(cq_dbrec), &arm_dbr);
 
-    sq_db = reinterpret_cast<uint64_t *>(doca_verbs_qp_get_uar_addr(qp));
+  qp_cpu_->cq_sq.dbrec = (__be32 *)cq_dbrec;
+  qp_cpu_->cq_sq.cq_num = doca_verbs_cq_get_cqn(cq_sq);
+  qp_cpu_->cq_sq.cqe_mask = (qp_cpu_->cq_sq.cqe_num - 1);
+  qp_cpu_->cq_sq.cqe_ci = 0;
+  qp_cpu_->cq_sq.cqe_rsvd = 0;
+  qp_cpu_->cq_sq.mem_type = DOCA_GPUNETIO_VERBS_MEM_TYPE_GPU;
 
-    if (nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY) {
-        status = doca_gpu_verbs_export_uar(sq_db, (uint64_t **)&(qp_cpu_->sq_db));
-        if (status != DOCA_SUCCESS && nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO) {
-            DOCA_LOG(LOG_ERR, "Can't export UAR to GPU.");
-            goto out;
-        }
-    }
+  qp_gverbs->gpu_dev = gpu_dev;
 
-    if ((status != DOCA_SUCCESS && nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO) ||
-        nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY) {
-        DOCA_LOG(LOG_WARNING, "Enabling CPU proxy mode");
-
-        status = doca_gpu_mem_alloc(gpu_dev, sizeof(uint64_t), priv_get_page_size(),
-                                    DOCA_GPU_MEM_TYPE_CPU_GPU, (void **)&(qp_gverbs->cpu_db),
-                                    (void **)&(qp_gverbs->cpu_db));
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to alloc GPU memory for CPU proxy DB");
-            goto out;
-        }
-
-        *(qp_gverbs->cpu_db) = 0;
-        qp_cpu_->sq_db = qp_gverbs->cpu_db;
-        qp_gverbs->cpu_proxy = true;
-        qp_gverbs->sq_num_shift8_be = qp_cpu_->sq_num_shift8_be;
-        qp_gverbs->sq_dbrec = qp_cpu_->sq_dbrec;
-        qp_gverbs->sq_db = sq_db;
-        qp_cpu_->nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY;
-        nic_handler_must_be_cpu_proxy = true;
-    }
-
-    if (!nic_handler_must_be_cpu_proxy) {
-        if (send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) {
-            assert(gpu_dev->support_gdrcopy);
-            qp_gverbs->sq_dbrec = qp_cpu_->sq_dbrec;
-            qp_gverbs->sq_db = sq_db;
-            qp_gverbs->cpu_proxy = true;
-        }
-        if (nic_handler == DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO) {
-            if ((send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT) ||
-                (send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED))
-                qp_cpu_->nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_NO_DBR;
-            else
-                qp_cpu_->nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB;
-        } else
-            qp_cpu_->nic_handler = nic_handler;
-    }
-
-    doca_verbs_cq_get_wq(cq_sq, (void **)&(qp_cpu_->cq_sq.cqe_daddr), &(qp_cpu_->cq_sq.cqe_num),
-                         &(qp_cpu_->cq_sq.cqe_size));
-
-    doca_verbs_cq_get_dbr_addr(cq_sq, &uar_db_reg, (uint32_t **)&(cq_dbrec), &arm_dbr);
-
-    qp_cpu_->cq_sq.dbrec = (__be32 *)cq_dbrec;
-    qp_cpu_->cq_sq.cq_num = doca_verbs_cq_get_cqn(cq_sq);
-    qp_cpu_->cq_sq.cqe_mask = (qp_cpu_->cq_sq.cqe_num - 1);
-    qp_cpu_->cq_sq.cqe_ci = 0;
-    qp_cpu_->cq_sq.cqe_rsvd = 0;
-    qp_cpu_->cq_sq.mem_type = DOCA_GPUNETIO_VERBS_MEM_TYPE_GPU;
-
-    qp_gverbs->gpu_dev = gpu_dev;
-
-    *qp_out = qp_gverbs;
+  *qp_out = qp_gverbs;
 
 out:
-    if (status != DOCA_SUCCESS) {
-        if (verbs_qp_attr_out) doca_verbs_qp_attr_destroy(verbs_qp_attr_out);
+  if (status != DOCA_SUCCESS) {
+    if (verbs_qp_attr_out) doca_verbs_qp_attr_destroy(verbs_qp_attr_out);
 
-        if (verbs_qp_init_attr_out) doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr_out);
+    if (verbs_qp_init_attr_out) doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr_out);
 
-        if (qp_gverbs) {
-            if (qp_gverbs->qp_cpu) {
-                if (qp_gverbs->qp_cpu->sq_db &&
-                    (qp_gverbs->qp_cpu->nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY))
-                    doca_gpu_verbs_unexport_uar(qp_gverbs->qp_cpu->sq_db);
-                free(qp_gverbs->qp_cpu);
-            }
-            free(qp_gverbs);
-        }
+    if (qp_gverbs) {
+      if (qp_gverbs->qp_cpu) {
+        if (qp_gverbs->qp_cpu->sq_db &&
+            (qp_gverbs->qp_cpu->nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY))
+          doca_gpu_verbs_unexport_uar(qp_gverbs->qp_cpu->sq_db);
+        free(qp_gverbs->qp_cpu);
+      }
+      free(qp_gverbs);
     }
+  }
 
-    return status;
+  return status;
 }
 
 doca_error_t doca_gpu_verbs_get_qp_dev(struct doca_gpu_verbs_qp *qp,
-                                       struct doca_gpu_dev_verbs_qp **qp_gpu) {
-    doca_error_t status = DOCA_SUCCESS;
-    int custatus = 0;
+    struct doca_gpu_dev_verbs_qp **qp_gpu) {
+  doca_error_t status = DOCA_SUCCESS;
+  int custatus = 0;
 
-    enum doca_gpu_mem_type mtype;
+  enum doca_gpu_mem_type mtype;
 
-    if (qp == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  if (qp == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    assert(qp->qp_cpu);
+  assert(qp->qp_cpu);
 
-    if (qp->qp_gpu == nullptr) {
-        mtype = (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED)
-                    ? DOCA_GPU_MEM_TYPE_GPU_CPU
-                    : DOCA_GPU_MEM_TYPE_GPU;
-        status = doca_gpu_mem_alloc(qp->gpu_dev, sizeof(struct doca_gpu_dev_verbs_qp),
-                                    priv_get_page_size(), mtype, (void **)&qp->qp_gpu,
-                                    (void **)&qp->qp_gpu_h);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to alloc gpu memory for qp_gpu");
-            return status;
-        }
-
-        custatus = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaMemcpy(
-            qp->qp_gpu, qp->qp_cpu, sizeof(struct doca_gpu_dev_verbs_qp), cudaMemcpyHostToDevice));
-        if (custatus != cudaSuccess) {
-            DOCA_LOG(LOG_ERR, "cuMemcpyHtoD failed");
-            doca_gpu_mem_free(qp->gpu_dev, qp->qp_gpu);
-            qp->qp_gpu = nullptr;
-            qp->qp_gpu_h = nullptr;
-            return DOCA_ERROR_DRIVER;
-        }
-
-        if (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) {
-            assert(qp->gpu_dev->support_gdrcopy);
-            qp->cpu_db = &qp->qp_gpu_h->sq_wqe_pi;
-        }
+  if (qp->qp_gpu == nullptr) {
+    mtype = (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED)
+        ? DOCA_GPU_MEM_TYPE_GPU_CPU
+        : DOCA_GPU_MEM_TYPE_GPU;
+    status = doca_gpu_mem_alloc(qp->gpu_dev, sizeof(struct doca_gpu_dev_verbs_qp),
+      priv_get_page_size(), mtype, (void **)&qp->qp_gpu,
+      (void **)&qp->qp_gpu_h);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to alloc gpu memory for qp_gpu");
+      return status;
     }
 
-    *qp_gpu = qp->qp_gpu;
+    custatus = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(cudaMemcpy(
+      qp->qp_gpu, qp->qp_cpu, sizeof(struct doca_gpu_dev_verbs_qp), cudaMemcpyHostToDevice));
+    if (custatus != cudaSuccess) {
+      DOCA_LOG(LOG_ERR, "cuMemcpyHtoD failed");
+      doca_gpu_mem_free(qp->gpu_dev, qp->qp_gpu);
+      qp->qp_gpu = nullptr;
+      qp->qp_gpu_h = nullptr;
+      return DOCA_ERROR_DRIVER;
+    }
 
-    return DOCA_SUCCESS;
+    if (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) {
+      assert(qp->gpu_dev->support_gdrcopy);
+      qp->cpu_db = &qp->qp_gpu_h->sq_wqe_pi;
+    }
+  }
+
+  *qp_gpu = qp->qp_gpu;
+
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_verbs_unexport_qp(struct doca_gpu *gpu_dev,
-                                        struct doca_gpu_verbs_qp *qp_gverbs) {
-    if (gpu_dev == nullptr || qp_gverbs == nullptr) return DOCA_ERROR_INVALID_VALUE;
+    struct doca_gpu_verbs_qp *qp_gverbs) {
+  if (gpu_dev == nullptr || qp_gverbs == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    if (qp_gverbs->cpu_db &&
-        (qp_gverbs->send_dbr_mode_ext != DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED))
-        doca_gpu_mem_free(gpu_dev, qp_gverbs->cpu_db);
+  if (qp_gverbs->cpu_db &&
+      (qp_gverbs->send_dbr_mode_ext != DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED))
+    doca_gpu_mem_free(gpu_dev, qp_gverbs->cpu_db);
 
-    if (qp_gverbs->qp_cpu) {
-        if (qp_gverbs->qp_cpu->nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY)
-            doca_gpu_verbs_unexport_uar(qp_gverbs->qp_cpu->sq_db);
-        free(qp_gverbs->qp_cpu);
-    }
+  if (qp_gverbs->qp_cpu) {
+    if (qp_gverbs->qp_cpu->nic_handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_CPU_PROXY)
+      doca_gpu_verbs_unexport_uar(qp_gverbs->qp_cpu->sq_db);
+    free(qp_gverbs->qp_cpu);
+  }
 
-    if (qp_gverbs->qp_gpu) {
-        doca_gpu_mem_free(gpu_dev, qp_gverbs->qp_gpu);
-        qp_gverbs->qp_gpu = nullptr;
-        qp_gverbs->qp_gpu_h = nullptr;
-    }
+  if (qp_gverbs->qp_gpu) {
+    doca_gpu_mem_free(gpu_dev, qp_gverbs->qp_gpu);
+    qp_gverbs->qp_gpu = nullptr;
+    qp_gverbs->qp_gpu_h = nullptr;
+  }
 
-    free(qp_gverbs);
+  free(qp_gverbs);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_verbs_export_multi_qps_dev(struct doca_gpu *gpu_dev,
-                                                 struct doca_gpu_verbs_qp **qps,
-                                                 unsigned int num_qps,
-                                                 struct doca_gpu_dev_verbs_qp **out_qp_gpus) {
-    doca_error_t status = DOCA_SUCCESS;
-    int custatus = 0;
+    struct doca_gpu_verbs_qp **qps,
+    unsigned int num_qps,
+    struct doca_gpu_dev_verbs_qp **out_qp_gpus) {
+  doca_error_t status = DOCA_SUCCESS;
+  int custatus = 0;
 
-    enum doca_gpu_mem_type mtype;
-    struct doca_gpu_dev_verbs_qp *qp_gpus_d = nullptr;
-    struct doca_gpu_dev_verbs_qp *qp_cpus = nullptr;
-    struct doca_gpu_dev_verbs_qp *qp_gpus_h = nullptr;
-    struct doca_gpu_verbs_qp *qp;
-    bool need_cpu_mapping = false;
+  enum doca_gpu_mem_type mtype;
+  struct doca_gpu_dev_verbs_qp *qp_gpus_d = nullptr;
+  struct doca_gpu_dev_verbs_qp *qp_cpus = nullptr;
+  struct doca_gpu_dev_verbs_qp *qp_gpus_h = nullptr;
+  struct doca_gpu_verbs_qp *qp;
+  bool need_cpu_mapping = false;
 
-    unsigned int qp_idx;
+  unsigned int qp_idx;
 
-    if (gpu_dev == nullptr || qps == nullptr || num_qps == 0 || out_qp_gpus == nullptr) {
-        status = DOCA_ERROR_INVALID_VALUE;
-        goto out;
+  if (gpu_dev == nullptr || qps == nullptr || num_qps == 0 || out_qp_gpus == nullptr) {
+    status = DOCA_ERROR_INVALID_VALUE;
+    goto out;
+  }
+
+  for (qp_idx = 0; qp_idx < num_qps; qp_idx++) {
+    qp = qps[qp_idx];
+    assert(qp->qp_cpu != nullptr);
+    need_cpu_mapping |=
+        (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED);
+  }
+
+  if (need_cpu_mapping) assert(gpu_dev->support_gdrcopy);
+
+  mtype = need_cpu_mapping ? DOCA_GPU_MEM_TYPE_GPU_CPU : DOCA_GPU_MEM_TYPE_GPU;
+  status = doca_gpu_mem_alloc(gpu_dev, sizeof(struct doca_gpu_dev_verbs_qp) * num_qps,
+    GPU_PAGE_SIZE, mtype, (void **)&qp_gpus_d, (void **)&qp_cpus);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to alloc gpu memory for qp_gpus");
+    goto out;
+  }
+
+  qp_gpus_h =
+      (struct doca_gpu_dev_verbs_qp *)calloc(num_qps, sizeof(struct doca_gpu_dev_verbs_qp));
+  if (qp_gpus_h == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to allocate memory for qp_gpus_h");
+    goto out;
+  }
+
+  for (qp_idx = 0; qp_idx < num_qps; qp_idx++) {
+    qp = qps[qp_idx];
+    assert(qp->qp_cpu != nullptr);
+    qp->qp_gpu = &(qp_gpus_d[qp_idx]);
+    if (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) {
+      qp->qp_gpu_h = &(qp_cpus[qp_idx]);
+      qp->cpu_db = &qp->qp_gpu_h->sq_wqe_pi;
     }
+    memcpy(&qp_gpus_h[qp_idx], qp->qp_cpu, sizeof(struct doca_gpu_dev_verbs_qp));
+  }
 
-    for (unsigned int qp_idx = 0; qp_idx < num_qps; qp_idx++) {
-        qp = qps[qp_idx];
-        assert(qp->qp_cpu != nullptr);
-        need_cpu_mapping |=
-            (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED);
-    }
+  custatus = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
+          cudaMemcpy(qp_gpus_d, qp_gpus_h, sizeof(struct doca_gpu_dev_verbs_qp) * num_qps,
+    cudaMemcpyHostToDevice));
+  if (custatus != cudaSuccess) {
+    DOCA_LOG(LOG_ERR, "cuMemcpyHtoD failed");
+    status = DOCA_ERROR_DRIVER;
+    goto out;
+  }
 
-    if (need_cpu_mapping) assert(gpu_dev->support_gdrcopy);
-
-    mtype = need_cpu_mapping ? DOCA_GPU_MEM_TYPE_GPU_CPU : DOCA_GPU_MEM_TYPE_GPU;
-    status = doca_gpu_mem_alloc(gpu_dev, sizeof(struct doca_gpu_dev_verbs_qp) * num_qps,
-                                GPU_PAGE_SIZE, mtype, (void **)&qp_gpus_d, (void **)&qp_cpus);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to alloc gpu memory for qp_gpus");
-        goto out;
-    }
-
-    qp_gpus_h =
-        (struct doca_gpu_dev_verbs_qp *)calloc(num_qps, sizeof(struct doca_gpu_dev_verbs_qp));
-    if (qp_gpus_h == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to allocate memory for qp_gpus_h");
-        goto out;
-    }
-
-    for (qp_idx = 0; qp_idx < num_qps; qp_idx++) {
-        qp = qps[qp_idx];
-        assert(qp->qp_cpu != nullptr);
-        qp->qp_gpu = &(qp_gpus_d[qp_idx]);
-        if (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) {
-            qp->qp_gpu_h = &(qp_cpus[qp_idx]);
-            qp->cpu_db = &qp->qp_gpu_h->sq_wqe_pi;
-        }
-        memcpy(&qp_gpus_h[qp_idx], qp->qp_cpu, sizeof(struct doca_gpu_dev_verbs_qp));
-    }
-
-    custatus = DOCA_VERBS_CUDA_CALL_CLEAR_ERROR(
-        cudaMemcpy(qp_gpus_d, qp_gpus_h, sizeof(struct doca_gpu_dev_verbs_qp) * num_qps,
-                   cudaMemcpyHostToDevice));
-    if (custatus != cudaSuccess) {
-        DOCA_LOG(LOG_ERR, "cuMemcpyHtoD failed");
-        status = DOCA_ERROR_DRIVER;
-        goto out;
-    }
-
-    *out_qp_gpus = qp_gpus_d;
+  *out_qp_gpus = qp_gpus_d;
 
 out:
-    if (status != DOCA_SUCCESS) {
-        if (qp_gpus_d) doca_gpu_mem_free(gpu_dev, qp_gpus_d);
-    }
-    if (qp_gpus_h) free(qp_gpus_h);
-    return status;
+  if (status != DOCA_SUCCESS) {
+    if (qp_gpus_d) doca_gpu_mem_free(gpu_dev, qp_gpus_d);
+  }
+  if (qp_gpus_h) free(qp_gpus_h);
+  return status;
 }
 
 doca_error_t doca_gpu_verbs_unexport_multi_qps_dev(struct doca_gpu *gpu_dev,
-                                                   struct doca_gpu_verbs_qp **qps,
-                                                   unsigned int num_qps,
-                                                   struct doca_gpu_dev_verbs_qp *qp_gpus) {
-    doca_error_t status = DOCA_SUCCESS;
-    if (gpu_dev == nullptr || qps == nullptr || num_qps == 0 || qp_gpus == nullptr)
-        return DOCA_ERROR_INVALID_VALUE;
+    struct doca_gpu_verbs_qp **qps,
+    unsigned int num_qps,
+    struct doca_gpu_dev_verbs_qp *qp_gpus) {
+  doca_error_t status = DOCA_SUCCESS;
+  if (gpu_dev == nullptr || qps == nullptr || num_qps == 0 || qp_gpus == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
 
-    for (unsigned int qp_idx = 0; qp_idx < num_qps; qp_idx++) {
-        struct doca_gpu_verbs_qp *qp = qps[qp_idx];
-        qp->qp_gpu = nullptr;
-        qp->qp_gpu_h = nullptr;
-    }
+  for (unsigned int qp_idx = 0; qp_idx < num_qps; qp_idx++) {
+    struct doca_gpu_verbs_qp *qp = qps[qp_idx];
+    qp->qp_gpu = nullptr;
+    qp->qp_gpu_h = nullptr;
+  }
 
-    status = doca_gpu_mem_free(gpu_dev, qp_gpus);
-    return status;
+  status = doca_gpu_mem_free(gpu_dev, qp_gpus);
+  return status;
 }
 
 static inline void priv_cpu_proxy_progress_full_assisted(struct doca_gpu_verbs_qp *qp) {
-    uint32_t tmp_db = 0;
-    __be32 dbr_val;
+  uint32_t tmp_db = 0;
+  __be32 dbr_val;
 
-    tmp_db = (uint32_t) * ((volatile uint64_t *)qp->cpu_db);
-    if (tmp_db != qp->sq_wqe_pi_last) {
-        struct doca_gpu_dev_verbs_wqe_ctrl_seg ctrl_seg = {.opmod_idx_opcode = htobe32(tmp_db << 8),
-                                                           .qpn_ds = qp->sq_num_shift8_be};
+  tmp_db = (uint32_t) * ((volatile uint64_t *)qp->cpu_db);
+  if (tmp_db != qp->sq_wqe_pi_last) {
+    struct doca_gpu_dev_verbs_wqe_ctrl_seg ctrl_seg = {.opmod_idx_opcode = htobe32(tmp_db << 8),
+                                                         .qpn_ds = qp->sq_num_shift8_be,
+                                                         .signature_fm_ce_se = 0,
+                                                         .imm = 0
+    };
 
-        if (!qp->send_dbr_mode_ext) {
-            dbr_val = htobe32(tmp_db & 0xffff);
+    if (!qp->send_dbr_mode_ext) {
+      dbr_val = htobe32(tmp_db & 0xffff);
 
-            // Ring the DB ASAP.
-            // The second DB ringing happens after the fence. This is used when the NIC enters a
-            // recovery state and it needs to read DBR.
-            *((volatile uint64_t *)qp->sq_db) = *((volatile uint64_t *)&ctrl_seg);
-            *((volatile uint32_t *)qp->sq_dbrec) = dbr_val;
-            std::atomic_thread_fence(std::memory_order_release);
-        }
-        *((volatile uint64_t *)qp->sq_db) = *((volatile uint64_t *)&ctrl_seg);
-
-        qp->sq_wqe_pi_last = tmp_db;
+      // Ring the DB ASAP.
+      // The second DB ringing happens after the fence. This is used when the NIC enters a
+      // recovery state and it needs to read DBR.
+      *((volatile uint64_t *)qp->sq_db) = *((volatile uint64_t *)&ctrl_seg);
+      *((volatile uint32_t *)qp->sq_dbrec) = dbr_val;
+      std::atomic_thread_fence(std::memory_order_release);
     }
+    *((volatile uint64_t *)qp->sq_db) = *((volatile uint64_t *)&ctrl_seg);
+
+    qp->sq_wqe_pi_last = tmp_db;
+  }
 }
 
 static inline void priv_cpu_proxy_progress_dbr_assisted(struct doca_gpu_verbs_qp *qp) {
-    uint32_t tmp_db = 0;
-    __be32 dbr_val;
+  uint32_t tmp_db = 0;
+  __be32 dbr_val;
 
-    tmp_db = (uint32_t) * ((volatile uint64_t *)qp->cpu_db);
-    if (tmp_db != qp->sq_wqe_pi_last) {
-        struct doca_gpu_dev_verbs_wqe_ctrl_seg ctrl_seg = {.opmod_idx_opcode = htobe32(tmp_db << 8),
-                                                           .qpn_ds = qp->sq_num_shift8_be};
+  tmp_db = (uint32_t) * ((volatile uint64_t *)qp->cpu_db);
+  if (tmp_db != qp->sq_wqe_pi_last) {
+    struct doca_gpu_dev_verbs_wqe_ctrl_seg ctrl_seg = {.opmod_idx_opcode = htobe32(tmp_db << 8),
+                                                         .qpn_ds = qp->sq_num_shift8_be,
+                                                         .signature_fm_ce_se = 0,
+                                                         .imm = 0
+    };
 
-        dbr_val = htobe32(tmp_db & 0xffff);
-        *((volatile uint32_t *)qp->sq_dbrec) = dbr_val;
-        std::atomic_thread_fence(std::memory_order_release);
-        *((volatile uint64_t *)qp->sq_db) = *((volatile uint64_t *)&ctrl_seg);
+    dbr_val = htobe32(tmp_db & 0xffff);
+    *((volatile uint32_t *)qp->sq_dbrec) = dbr_val;
+    std::atomic_thread_fence(std::memory_order_release);
+    *((volatile uint64_t *)qp->sq_db) = *((volatile uint64_t *)&ctrl_seg);
 
-        qp->sq_wqe_pi_last = tmp_db;
-    }
+    qp->sq_wqe_pi_last = tmp_db;
+  }
 }
 
 doca_error_t doca_gpu_verbs_cpu_proxy_progress(struct doca_gpu_verbs_qp *qp) {
-    if (qp == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  if (qp == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    if (qp->cpu_proxy != true) return DOCA_ERROR_NOT_SUPPORTED;
+  if (qp->cpu_proxy != true) return DOCA_ERROR_NOT_SUPPORTED;
 
-    if (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED)
-        priv_cpu_proxy_progress_dbr_assisted(qp);
-    else
-        priv_cpu_proxy_progress_full_assisted(qp);
+  if (qp->send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED)
+    priv_cpu_proxy_progress_dbr_assisted(qp);
+  else
+    priv_cpu_proxy_progress_full_assisted(qp);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 static void *priv_service_mainloop(void *args) {
-    struct doca_gpu_verbs_service *service = (struct doca_gpu_verbs_service *)args;
-    const unsigned int num_loops = 1000;
+  struct doca_gpu_verbs_service *service = (struct doca_gpu_verbs_service *)args;
+  const unsigned int num_loops = 1000;
 
-    while (service->running) {
-        pthread_rwlock_rdlock(&service->service_lock);
-        for (unsigned int i = 0; i < num_loops; i++) {
-            for (auto qp : *service->qps) {
-                doca_gpu_verbs_cpu_proxy_progress(qp);
-            }
-        }
-        pthread_rwlock_unlock(&service->service_lock);
-        sched_yield();
+  while (service->running) {
+    pthread_rwlock_rdlock(&service->service_lock);
+    for (unsigned int i = 0; i < num_loops; i++) {
+      for (auto qp : *service->qps) {
+        doca_gpu_verbs_cpu_proxy_progress(qp);
+      }
     }
+    pthread_rwlock_unlock(&service->service_lock);
+    sched_yield();
+  }
 
-    return nullptr;
+  return nullptr;
 }
 
 doca_error_t doca_gpu_verbs_create_service(doca_gpu_verbs_service_t *out_service) {
-    int status = 0;
-    doca_error_t doca_status = DOCA_SUCCESS;
-    struct doca_gpu_verbs_service *service = nullptr;
+  int status = 0;
+  doca_error_t doca_status = DOCA_SUCCESS;
+  struct doca_gpu_verbs_service *service = nullptr;
 
-    if (out_service == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  if (out_service == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    service = (struct doca_gpu_verbs_service *)calloc(1, sizeof(struct doca_gpu_verbs_service));
-    if (service == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to allocate memory for service");
-        doca_status = DOCA_ERROR_NO_MEMORY;
-        goto out;
-    }
+  service = (struct doca_gpu_verbs_service *)calloc(1, sizeof(struct doca_gpu_verbs_service));
+  if (service == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to allocate memory for service");
+    doca_status = DOCA_ERROR_NO_MEMORY;
+    goto out;
+  }
 
-    status = pthread_rwlock_init(&service->service_lock, nullptr);
-    if (status != 0) {
-        DOCA_LOG(LOG_ERR, "Failed to initialize service lock");
-        doca_status = DOCA_ERROR_DRIVER;
-        goto out;
-    }
+  status = pthread_rwlock_init(&service->service_lock, nullptr);
+  if (status != 0) {
+    DOCA_LOG(LOG_ERR, "Failed to initialize service lock");
+    doca_status = DOCA_ERROR_DRIVER;
+    goto out;
+  }
 
-    service->running = true;
-    service->qps = new std::set<struct doca_gpu_verbs_qp *>();
-    status = pthread_create(&service->service_thread, nullptr, priv_service_mainloop, service);
-    if (status != 0) {
-        DOCA_LOG(LOG_ERR, "Failed to create service thread");
-        doca_status = DOCA_ERROR_DRIVER;
-        goto out;
-    }
+  service->running = true;
+  service->qps = new std::set<struct doca_gpu_verbs_qp *>();
+  status = pthread_create(&service->service_thread, nullptr, priv_service_mainloop, service);
+  if (status != 0) {
+    DOCA_LOG(LOG_ERR, "Failed to create service thread");
+    doca_status = DOCA_ERROR_DRIVER;
+    goto out;
+  }
 
-    *out_service = service;
+  *out_service = service;
 
 out:
-    if (status) {
-        if (service->qps) delete service->qps;
-        if (service) free(service);
-    }
-    return doca_status;
+  if (status) {
+    if (service->qps) delete service->qps;
+    if (service) free(service);
+  }
+  return doca_status;
 }
 
 doca_error_t doca_gpu_verbs_service_monitor_qp(doca_gpu_verbs_service_t service,
-                                               struct doca_gpu_verbs_qp *qp) {
-    struct doca_gpu_verbs_service *service_ = (struct doca_gpu_verbs_service *)service;
-    if (service == nullptr || qp == nullptr) return DOCA_ERROR_INVALID_VALUE;
+    struct doca_gpu_verbs_qp *qp) {
+  struct doca_gpu_verbs_service *service_ = (struct doca_gpu_verbs_service *)service;
+  if (service == nullptr || qp == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    pthread_rwlock_wrlock(&service_->service_lock);
-    service_->qps->insert(qp);
-    pthread_rwlock_unlock(&service_->service_lock);
+  pthread_rwlock_wrlock(&service_->service_lock);
+  service_->qps->insert(qp);
+  pthread_rwlock_unlock(&service_->service_lock);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_verbs_destroy_service(doca_gpu_verbs_service_t service) {
-    struct doca_gpu_verbs_service *service_ = (struct doca_gpu_verbs_service *)service;
-    if (service == nullptr) return DOCA_ERROR_INVALID_VALUE;
+  struct doca_gpu_verbs_service *service_ = (struct doca_gpu_verbs_service *)service;
+  if (service == nullptr) return DOCA_ERROR_INVALID_VALUE;
 
-    service_->running = false;
-    pthread_join(service_->service_thread, nullptr);
-    pthread_rwlock_destroy(&service_->service_lock);
-    delete service_->qps;
-    free(service_);
+  service_->running = false;
+  pthread_join(service_->service_thread, nullptr);
+  pthread_rwlock_destroy(&service_->service_lock);
+  delete service_->qps;
+  free(service_);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_gpu_verbs_query_last_error(struct doca_gpu_verbs_qp *qp,
-                                             struct doca_gpu_verbs_qp_error_info *error_info) {
-    doca_error_t status = DOCA_SUCCESS;
+    struct doca_gpu_verbs_qp_error_info *error_info) {
+  doca_error_t status = DOCA_SUCCESS;
 
-    if (qp == nullptr || qp->qp == nullptr || error_info == nullptr)
-        return DOCA_ERROR_INVALID_VALUE;
+  if (qp == nullptr || qp->qp == nullptr || error_info == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
 
-    memset(error_info, 0, sizeof(struct doca_gpu_verbs_qp_error_info));
+  memset(error_info, 0, sizeof(struct doca_gpu_verbs_qp_error_info));
 
-    struct doca_verbs_qp_attr qp_attr;
-    struct doca_verbs_qp_init_attr qp_init_attr;
-    status = doca_verbs_qp_query(qp->qp, &qp_attr, &qp_init_attr);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query QP");
-        return status;
-    }
+  struct doca_verbs_qp_attr qp_attr;
+  struct doca_verbs_qp_init_attr qp_init_attr;
+  status = doca_verbs_qp_query(qp->qp, &qp_attr, &qp_init_attr);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query QP");
+    return status;
+  }
 
-    error_info->has_error = (qp_attr.current_state == DOCA_VERBS_QP_STATE_ERR);
+  error_info->has_error = (qp_attr.current_state == DOCA_VERBS_QP_STATE_ERR);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }

--- a/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_device_attr.cpp
+++ b/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_device_attr.cpp
@@ -57,24 +57,24 @@
 namespace {
 
 uint16_t translate_gid_table_size(uint16_t gid_table_size_prm) {
-    switch (gid_table_size_prm) {
-        case PRIV_DOCA_MLX5_GID_TABLE_8_ENTRIES:
-            return 8;
-        case PRIV_DOCA_MLX5_GID_TABLE_16_ENTRIES:
-            return 16;
-        case PRIV_DOCA_MLX5_GID_TABLE_32_ENTRIES:
-            return 32;
-        case PRIV_DOCA_MLX5_GID_TABLE_64_ENTRIES:
-            return 64;
-        case PRIV_DOCA_MLX5_GID_TABLE_128_ENTRIES:
-            return 128;
-        default:
-            // Shouldn't reach this
-            return 0;
-    }
+  switch (gid_table_size_prm) {
+    case PRIV_DOCA_MLX5_GID_TABLE_8_ENTRIES:
+      return 8;
+    case PRIV_DOCA_MLX5_GID_TABLE_16_ENTRIES:
+      return 16;
+    case PRIV_DOCA_MLX5_GID_TABLE_32_ENTRIES:
+      return 32;
+    case PRIV_DOCA_MLX5_GID_TABLE_64_ENTRIES:
+      return 64;
+    case PRIV_DOCA_MLX5_GID_TABLE_128_ENTRIES:
+      return 128;
+    default:
+      // Shouldn't reach this
+      return 0;
+  }
 
-    // Shouldn't reach this
-    return 0;
+  // Shouldn't reach this
+  return 0;
 }
 
 } /* namespace */
@@ -84,103 +84,103 @@ uint16_t translate_gid_table_size(uint16_t gid_table_size_prm) {
  *********************************************************************************************************************/
 
 doca_verbs_device_attr::doca_verbs_device_attr(struct ibv_context *ibv_ctx) {
-    try {
-        query_caps(ibv_ctx);
-    } catch (...) {
-        DOCA_LOG(LOG_ERR, "Failed to create device_attr");
-        throw;
-    }
+  try {
+    query_caps(ibv_ctx);
+  } catch (...) {
+    DOCA_LOG(LOG_ERR, "Failed to create device_attr");
+    throw;
+  }
 }
 
 void doca_verbs_device_attr::query_caps(struct ibv_context *ibv_ctx) {
-    struct ibv_device_attr device_attr {};
-    bool has_hca_cap_2 = false;
-    auto ret = doca_verbs_wrapper_ibv_query_device(ibv_ctx, &device_attr);
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query device attr");
-        throw ret;
-    }
+  struct ibv_device_attr device_attr {};
+  bool has_hca_cap_2 = false;
+  auto ret = doca_verbs_wrapper_ibv_query_device(ibv_ctx, &device_attr);
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query device attr");
+    throw ret;
+  }
 
-    m_max_qp = device_attr.max_qp;
-    m_max_qp_wr = device_attr.max_qp_wr;
-    m_max_sge = device_attr.max_sge;
-    m_max_cq = device_attr.max_cq;
-    m_max_cqe = device_attr.max_cqe;
-    m_max_mr = device_attr.max_mr;
-    m_max_pd = device_attr.max_pd;
-    m_max_ah = device_attr.max_ah;
-    m_max_srq = device_attr.max_srq;
-    m_max_srq_wr = device_attr.max_srq_wr;
-    m_max_srq_sge = device_attr.max_srq_sge;
-    m_max_pkeys = device_attr.max_pkeys;
-    m_phys_port_cnt = device_attr.phys_port_cnt;
-    m_send_dbr_mode_no_dbr_ext = 0;
+  m_max_qp = device_attr.max_qp;
+  m_max_qp_wr = device_attr.max_qp_wr;
+  m_max_sge = device_attr.max_sge;
+  m_max_cq = device_attr.max_cq;
+  m_max_cqe = device_attr.max_cqe;
+  m_max_mr = device_attr.max_mr;
+  m_max_pd = device_attr.max_pd;
+  m_max_ah = device_attr.max_ah;
+  m_max_srq = device_attr.max_srq;
+  m_max_srq_wr = device_attr.max_srq_wr;
+  m_max_srq_sge = device_attr.max_srq_sge;
+  m_max_pkeys = device_attr.max_pkeys;
+  m_phys_port_cnt = device_attr.phys_port_cnt;
+  m_send_dbr_mode_no_dbr_ext = 0;
 
-    uint32_t in[MLX5_ST_SZ_DW(query_hca_cap_in)] = {0};
-    uint32_t out[MLX5_ST_SZ_DW(query_hca_cap_out)] = {0};
+  uint32_t in[MLX5_ST_SZ_DW(query_hca_cap_in)] = {};
+  uint32_t out[MLX5_ST_SZ_DW(query_hca_cap_out)] = {};
 
-    DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
-    DEVX_SET(query_hca_cap_in, in, op_mod,
-             PRIV_DOCA_MLX5_HCA_CAP_OPMOD_GET_CUR | MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE);
+  DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
+  DEVX_SET(query_hca_cap_in, in, op_mod,
+      PRIV_DOCA_MLX5_HCA_CAP_OPMOD_GET_CUR | MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE);
 
-    ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ibv_ctx, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query device capabilities");
-        throw ret;
-    }
+  ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ibv_ctx, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query device capabilities");
+    throw ret;
+  }
 
-    m_port_type = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.port_type);
-    if (m_port_type == MLX5_CAP_PORT_TYPE_IB)
-        m_gid_table_size = translate_gid_table_size(
+  m_port_type = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.port_type);
+  if (m_port_type == MLX5_CAP_PORT_TYPE_IB)
+    m_gid_table_size = translate_gid_table_size(
             DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.gid_table_size));
-    m_is_qp_rc_supported = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.rc);
-    m_is_rts2rts_qp_dscp_supported =
-        DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.rts2rts_qp_dscp);
-    m_max_sq_desc_size = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.max_wqe_sz_sq);
-    m_max_rq_desc_size = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.max_wqe_sz_rq);
-    m_max_send_wqebb = 1 << DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.log_max_qp_sz);
+  m_is_qp_rc_supported = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.rc);
+  m_is_rts2rts_qp_dscp_supported =
+      DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.rts2rts_qp_dscp);
+  m_max_sq_desc_size = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.max_wqe_sz_sq);
+  m_max_rq_desc_size = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.max_wqe_sz_rq);
+  m_max_send_wqebb = 1 << DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.log_max_qp_sz);
 
-    has_hca_cap_2 = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.hca_cap_2);
+  has_hca_cap_2 = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.hca_cap_2);
 
+  memset(in, 0, sizeof(in));
+  memset(out, 0, sizeof(out));
+
+  DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
+  DEVX_SET(query_hca_cap_in, in, op_mod,
+      PRIV_DOCA_MLX5_HCA_CAP_OPMOD_GET_CUR | MLX5_SET_HCA_CAP_OP_MOD_ROCE);
+
+  ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ibv_ctx, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query ROCE capabilities");
+    throw ret;
+  }
+
+  if (m_port_type == MLX5_CAP_PORT_TYPE_ETH)
+    m_gid_table_size =
+        DEVX_GET(query_hca_cap_out, out, capability.roce_caps.roce_address_table_size);
+  m_min_udp_sport =
+      DEVX_GET(query_hca_cap_out, out, capability.roce_caps.r_roce_min_src_udp_port);
+  m_max_udp_sport =
+      DEVX_GET(query_hca_cap_out, out, capability.roce_caps.r_roce_max_src_udp_port);
+
+  if (has_hca_cap_2) {
     memset(in, 0, sizeof(in));
     memset(out, 0, sizeof(out));
 
     DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
-    DEVX_SET(query_hca_cap_in, in, op_mod,
-             PRIV_DOCA_MLX5_HCA_CAP_OPMOD_GET_CUR | MLX5_SET_HCA_CAP_OP_MOD_ROCE);
+    DEVX_SET(
+        query_hca_cap_in, in, op_mod,
+        PRIV_DOCA_MLX5_HCA_CAP_OPMOD_GET_CUR | MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE_CAP_2);
 
     ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ibv_ctx, in, sizeof(in), out, sizeof(out));
     if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query ROCE capabilities");
-        throw ret;
+      DOCA_LOG(LOG_ERR, "Failed to query ROCE capabilities");
+      throw ret;
     }
 
-    if (m_port_type == MLX5_CAP_PORT_TYPE_ETH)
-        m_gid_table_size =
-            DEVX_GET(query_hca_cap_out, out, capability.roce_caps.roce_address_table_size);
-    m_min_udp_sport =
-        DEVX_GET(query_hca_cap_out, out, capability.roce_caps.r_roce_min_src_udp_port);
-    m_max_udp_sport =
-        DEVX_GET(query_hca_cap_out, out, capability.roce_caps.r_roce_max_src_udp_port);
-
-    if (has_hca_cap_2) {
-        memset(in, 0, sizeof(in));
-        memset(out, 0, sizeof(out));
-
-        DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
-        DEVX_SET(
-            query_hca_cap_in, in, op_mod,
-            PRIV_DOCA_MLX5_HCA_CAP_OPMOD_GET_CUR | MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE_CAP_2);
-
-        ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ibv_ctx, in, sizeof(in), out, sizeof(out));
-        if (ret != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to query ROCE capabilities");
-            throw ret;
-        }
-
-        m_send_dbr_mode_no_dbr_ext =
-            DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap_2.send_dbr_mode_no_dbr_ext);
-    }
+    m_send_dbr_mode_no_dbr_ext =
+        DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap_2.send_dbr_mode_no_dbr_ext);
+  }
 }
 
 /**********************************************************************************************************************
@@ -188,107 +188,107 @@ void doca_verbs_device_attr::query_caps(struct ibv_context *ibv_ctx) {
  *********************************************************************************************************************/
 
 doca_error_t doca_verbs_query_device(struct ibv_context *context,
-                                     struct doca_verbs_device_attr **verbs_device_attr) {
-    if (context == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to query doca_verbs_device_attr. param context=NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_device_attr **verbs_device_attr) {
+  if (context == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to query doca_verbs_device_attr. param context=NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (verbs_device_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to query doca_verbs_device_attr. param verbs_device_attr=NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_device_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to query doca_verbs_device_attr. param verbs_device_attr=NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    try {
-        *verbs_device_attr = new doca_verbs_device_attr(context);
-        return DOCA_SUCCESS;
-    } catch (doca_error_t err) {
-        return err;
-    }
+  try {
+    *verbs_device_attr = new doca_verbs_device_attr(context);
+    return DOCA_SUCCESS;
+  } catch (doca_error_t err) {
+    return err;
+  }
 }
 
 doca_error_t doca_verbs_device_attr_free(struct doca_verbs_device_attr *verbs_device_attr) {
-    if (verbs_device_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to free doca_verbs_device_attr. param verbs_device_attr=NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_device_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to free doca_verbs_device_attr. param verbs_device_attr=NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    delete (verbs_device_attr);
-    return DOCA_SUCCESS;
+  delete (verbs_device_attr);
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_device_attr_get_max_qp(const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_qp;
+  return verbs_device_attr->m_max_qp;
 }
 
 uint32_t doca_verbs_device_attr_get_max_qp_wr(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_qp_wr;
+  return verbs_device_attr->m_max_qp_wr;
 }
 
 uint32_t doca_verbs_device_attr_get_max_sge(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_sge;
+  return verbs_device_attr->m_max_sge;
 }
 
 uint32_t doca_verbs_device_attr_get_max_cq(const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_cq;
+  return verbs_device_attr->m_max_cq;
 }
 
 uint32_t doca_verbs_device_attr_get_max_cqe(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_cqe;
+  return verbs_device_attr->m_max_cqe;
 }
 
 uint32_t doca_verbs_device_attr_get_max_mr(const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_mr;
+  return verbs_device_attr->m_max_mr;
 }
 
 uint32_t doca_verbs_device_attr_get_max_pd(const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_pd;
+  return verbs_device_attr->m_max_pd;
 }
 
 uint32_t doca_verbs_device_attr_get_max_ah(const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_ah;
+  return verbs_device_attr->m_max_ah;
 }
 
 uint32_t doca_verbs_device_attr_get_max_srq(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_srq;
+  return verbs_device_attr->m_max_srq;
 }
 
 uint32_t doca_verbs_device_attr_get_max_srq_wr(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_srq_wr;
+  return verbs_device_attr->m_max_srq_wr;
 }
 
 uint32_t doca_verbs_device_attr_get_max_srq_sge(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_srq_sge;
+  return verbs_device_attr->m_max_srq_sge;
 }
 
 uint16_t doca_verbs_device_attr_get_max_pkeys(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_max_pkeys;
+  return verbs_device_attr->m_max_pkeys;
 }
 
 doca_error_t doca_verbs_device_attr_get_is_qp_type_supported(
     const struct doca_verbs_device_attr *verbs_device_attr, uint32_t qp_type) {
-    switch (qp_type) {
-        case DOCA_VERBS_QP_TYPE_RC:
-            return verbs_device_attr->m_is_qp_rc_supported ? DOCA_SUCCESS
-                                                           : DOCA_ERROR_NOT_SUPPORTED;
-            break;
-        default:
-            DOCA_LOG(LOG_ERR, "Failed to check if QP type is supported. param QP type is invalid");
-            return DOCA_ERROR_INVALID_VALUE;
-    }
+  switch (qp_type) {
+    case DOCA_VERBS_QP_TYPE_RC:
+      return verbs_device_attr->m_is_qp_rc_supported ? DOCA_SUCCESS
+          : DOCA_ERROR_NOT_SUPPORTED;
+      break;
+    default:
+      DOCA_LOG(LOG_ERR, "Failed to check if QP type is supported. param QP type is invalid");
+      return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    // Shouldn't reach this
-    return DOCA_ERROR_UNEXPECTED;
+  // Shouldn't reach this
+  return DOCA_ERROR_UNEXPECTED;
 }
 
 uint8_t doca_verbs_device_attr_get_send_dbr_mode_no_dbr_ext(
     const struct doca_verbs_device_attr *verbs_device_attr) {
-    return verbs_device_attr->m_send_dbr_mode_no_dbr_ext;
+  return verbs_device_attr->m_send_dbr_mode_no_dbr_ext;
 }

--- a/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_qp.cpp
+++ b/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_qp.cpp
@@ -62,21 +62,21 @@
 #define PRIV_DOCA_GID_BYTE_LENGTH 16
 
 enum {
-    PRIV_DOCA_MLX5_QP_OPT_PARAM_RRE = (1 << 1),
-    PRIV_DOCA_MLX5_QP_OPT_PARAM_RWE = (1 << 3),
-    PRIV_DOCA_MLX5_QP_OPT_PARAM_PKEY_INDEX = (1 << 4),
-    PRIV_DOCA_MLX5_QP_OPT_PARAM_MIN_RNR_NAK = (1 << 6),
-    PRIV_DOCA_MLX5_QP_OPT_PARAM_PORT_NUM = (1 << 16),
-    PRIV_DOCA_MLX5_QP_OPT_DSCP = (1 << 17),
-    PRIV_DOCA_MLX5_QP_OPT_SGID_INDEX = (1 << 23),
+  PRIV_DOCA_MLX5_QP_OPT_PARAM_RRE = (1 << 1),
+  PRIV_DOCA_MLX5_QP_OPT_PARAM_RWE = (1 << 3),
+  PRIV_DOCA_MLX5_QP_OPT_PARAM_PKEY_INDEX = (1 << 4),
+  PRIV_DOCA_MLX5_QP_OPT_PARAM_MIN_RNR_NAK = (1 << 6),
+  PRIV_DOCA_MLX5_QP_OPT_PARAM_PORT_NUM = (1 << 16),
+  PRIV_DOCA_MLX5_QP_OPT_DSCP = (1 << 17),
+  PRIV_DOCA_MLX5_QP_OPT_SGID_INDEX = (1 << 23),
 };
 
 enum doca_verbs_qp_state_mod {
-    DOCA_VERBS_QP_RST2INIT,
-    DOCA_VERBS_QP_INIT2INIT,
-    DOCA_VERBS_QP_INIT2RTR,
-    DOCA_VERBS_QP_RTR2RTS,
-    DOCA_VERBS_QP_RTS2RTS,
+  DOCA_VERBS_QP_RST2INIT,
+  DOCA_VERBS_QP_INIT2INIT,
+  DOCA_VERBS_QP_INIT2RTR,
+  DOCA_VERBS_QP_RTR2RTS,
+  DOCA_VERBS_QP_RTS2RTS,
 };
 
 /*********************************************************************************************************************
@@ -119,411 +119,411 @@ using query_qp_in = uint32_t[MLX5_ST_SZ_DW(query_qp_in)];
 using query_qp_out = uint32_t[MLX5_ST_SZ_DW(query_qp_out)];
 
 int rst2init_requested_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(PKEY_INDEX) | QP_ATTR(PORT_NUM) | QP_ATTR(ALLOW_REMOTE_WRITE) |
-        QP_ATTR(ALLOW_REMOTE_READ),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(PKEY_INDEX) | QP_ATTR(PORT_NUM) | QP_ATTR(ALLOW_REMOTE_WRITE) |
+  QP_ATTR(ALLOW_REMOTE_READ),
 };
 
 int init2rtr_requested_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(RQ_PSN) | QP_ATTR(DEST_QP_NUM) | QP_ATTR(PATH_MTU) | QP_ATTR(AH_ATTR) |
-        QP_ATTR(MIN_RNR_TIMER),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(RQ_PSN) | QP_ATTR(DEST_QP_NUM) | QP_ATTR(PATH_MTU) | QP_ATTR(AH_ATTR) |
+  QP_ATTR(MIN_RNR_TIMER),
 };
 
 int rtr2rts_requested_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(SQ_PSN) | QP_ATTR(ACK_TIMEOUT) | QP_ATTR(RETRY_CNT) | QP_ATTR(RNR_RETRY),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(SQ_PSN) | QP_ATTR(ACK_TIMEOUT) | QP_ATTR(RETRY_CNT) | QP_ATTR(RNR_RETRY),
 };
 
 int init2init_optional_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(PKEY_INDEX) | QP_ATTR(PORT_NUM) |
-        QP_ATTR(ALLOW_REMOTE_WRITE) | QP_ATTR(ALLOW_REMOTE_READ),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(PKEY_INDEX) | QP_ATTR(PORT_NUM) |
+  QP_ATTR(ALLOW_REMOTE_WRITE) | QP_ATTR(ALLOW_REMOTE_READ),
 };
 
 int init2rtr_optional_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(PKEY_INDEX) |
-        QP_ATTR(ALLOW_REMOTE_WRITE) | QP_ATTR(ALLOW_REMOTE_READ),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(PKEY_INDEX) |
+  QP_ATTR(ALLOW_REMOTE_WRITE) | QP_ATTR(ALLOW_REMOTE_READ),
 };
 
 int rtr2rts_optional_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(MIN_RNR_TIMER) |
-        QP_ATTR(ALLOW_REMOTE_WRITE),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(MIN_RNR_TIMER) |
+  QP_ATTR(ALLOW_REMOTE_WRITE),
 };
 
 int rts2rts_optional_attr[DOCA_VERBS_QP_TYPE_RC + 1] = {
-    /* [DOCA_VERBS_QP_TYPE_RC] */
-    QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(ALLOW_REMOTE_WRITE) |
-        QP_ATTR(ALLOW_REMOTE_READ) | QP_ATTR(MIN_RNR_TIMER) | QP_ATTR(AH_ATTR),
+  /* [DOCA_VERBS_QP_TYPE_RC] */
+  QP_ATTR(CURRENT_STATE) | QP_ATTR(NEXT_STATE) | QP_ATTR(ALLOW_REMOTE_WRITE) |
+  QP_ATTR(ALLOW_REMOTE_READ) | QP_ATTR(MIN_RNR_TIMER) | QP_ATTR(AH_ATTR),
 };
 
 const char *qp_attr_to_string(int attr) {
-    switch (attr) {
-        case DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE:
-            return "ALLOW_REMOTE_WRITE";
-        case DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ:
-            return "ALLOW_REMOTE_READ";
-        case DOCA_VERBS_QP_ATTR_PKEY_INDEX:
-            return "PKEY_INDEX";
-        case DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER:
-            return "MIN_RNR_TIMER";
-        case DOCA_VERBS_QP_ATTR_PORT_NUM:
-            return "PORT_NUM";
-        case DOCA_VERBS_QP_ATTR_NEXT_STATE:
-            return "NEXT_STATE";
-        case DOCA_VERBS_QP_ATTR_CURRENT_STATE:
-            return "CURRENT_STATE";
-        case DOCA_VERBS_QP_ATTR_PATH_MTU:
-            return "PATH_MTU";
-        case DOCA_VERBS_QP_ATTR_RQ_PSN:
-            return "RQ_PSN";
-        case DOCA_VERBS_QP_ATTR_SQ_PSN:
-            return "SQ_PSN";
-        case DOCA_VERBS_QP_ATTR_DEST_QP_NUM:
-            return "DEST_QP_NUM";
-        case DOCA_VERBS_QP_ATTR_ACK_TIMEOUT:
-            return "ACK_TIMEOUT";
-        case DOCA_VERBS_QP_ATTR_RETRY_CNT:
-            return "RETRY_CNT";
-        case DOCA_VERBS_QP_ATTR_RNR_RETRY:
-            return "RNR_RETRY";
-        case DOCA_VERBS_QP_ATTR_AH_ATTR:
-            return "AH_ATTR";
-        default:
-            break;
-    }
+  switch (attr) {
+    case DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE:
+      return "ALLOW_REMOTE_WRITE";
+    case DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ:
+      return "ALLOW_REMOTE_READ";
+    case DOCA_VERBS_QP_ATTR_PKEY_INDEX:
+      return "PKEY_INDEX";
+    case DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER:
+      return "MIN_RNR_TIMER";
+    case DOCA_VERBS_QP_ATTR_PORT_NUM:
+      return "PORT_NUM";
+    case DOCA_VERBS_QP_ATTR_NEXT_STATE:
+      return "NEXT_STATE";
+    case DOCA_VERBS_QP_ATTR_CURRENT_STATE:
+      return "CURRENT_STATE";
+    case DOCA_VERBS_QP_ATTR_PATH_MTU:
+      return "PATH_MTU";
+    case DOCA_VERBS_QP_ATTR_RQ_PSN:
+      return "RQ_PSN";
+    case DOCA_VERBS_QP_ATTR_SQ_PSN:
+      return "SQ_PSN";
+    case DOCA_VERBS_QP_ATTR_DEST_QP_NUM:
+      return "DEST_QP_NUM";
+    case DOCA_VERBS_QP_ATTR_ACK_TIMEOUT:
+      return "ACK_TIMEOUT";
+    case DOCA_VERBS_QP_ATTR_RETRY_CNT:
+      return "RETRY_CNT";
+    case DOCA_VERBS_QP_ATTR_RNR_RETRY:
+      return "RNR_RETRY";
+    case DOCA_VERBS_QP_ATTR_AH_ATTR:
+      return "AH_ATTR";
+    default:
+      break;
+  }
 
-    return "UNKNOWN";
+  return "UNKNOWN";
 }
 
 void print_if_missing_attr(int required_attr_mask, int attr_mask, int attr_to_check) {
-    if ((required_attr_mask & attr_to_check) != 0 && (attr_mask & attr_to_check) == 0)
-        DOCA_LOG(LOG_ERR, "%s is required but diabled in attr_mask (%d)",
-                 qp_attr_to_string(attr_to_check), attr_mask);
+  if ((required_attr_mask & attr_to_check) != 0 && (attr_mask & attr_to_check) == 0)
+    DOCA_LOG(LOG_ERR, "%s is required but diabled in attr_mask (%d)",
+      qp_attr_to_string(attr_to_check), attr_mask);
 }
 
 void print_missing_attrs(int required_attr_mask, int attr_mask) {
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_PKEY_INDEX);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_PORT_NUM);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_NEXT_STATE);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_CURRENT_STATE);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_PATH_MTU);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_RQ_PSN);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_SQ_PSN);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_DEST_QP_NUM);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_ACK_TIMEOUT);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_RETRY_CNT);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_RNR_RETRY);
-    print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_AH_ATTR);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_PKEY_INDEX);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_PORT_NUM);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_NEXT_STATE);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_CURRENT_STATE);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_PATH_MTU);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_RQ_PSN);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_SQ_PSN);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_DEST_QP_NUM);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_ACK_TIMEOUT);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_RETRY_CNT);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_RNR_RETRY);
+  print_if_missing_attr(required_attr_mask, attr_mask, DOCA_VERBS_QP_ATTR_AH_ATTR);
 }
 
 bool is_X2rst_attrs_valid(int attr_mask) {
-    int valid_attr = (DOCA_VERBS_QP_ATTR_CURRENT_STATE | DOCA_VERBS_QP_ATTR_NEXT_STATE);
+  int valid_attr = (DOCA_VERBS_QP_ATTR_CURRENT_STATE | DOCA_VERBS_QP_ATTR_NEXT_STATE);
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool is_X2err_attrs_valid(int attr_mask) {
-    int valid_attr = (DOCA_VERBS_QP_ATTR_CURRENT_STATE | DOCA_VERBS_QP_ATTR_NEXT_STATE);
+  int valid_attr = (DOCA_VERBS_QP_ATTR_CURRENT_STATE | DOCA_VERBS_QP_ATTR_NEXT_STATE);
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool is_rst2init_attrs_valid(int attr_mask, uint32_t qp_type) {
-    int required_attr = rst2init_requested_attr[qp_type];
-    int valid_attr =
-        required_attr | DOCA_VERBS_QP_ATTR_CURRENT_STATE | DOCA_VERBS_QP_ATTR_NEXT_STATE;
+  int required_attr = rst2init_requested_attr[qp_type];
+  int valid_attr =
+      required_attr | DOCA_VERBS_QP_ATTR_CURRENT_STATE | DOCA_VERBS_QP_ATTR_NEXT_STATE;
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    if ((required_attr & attr_mask) != required_attr) {
-        print_missing_attrs(required_attr, attr_mask);
-        return false;
-    }
+  if ((required_attr & attr_mask) != required_attr) {
+    print_missing_attrs(required_attr, attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool is_init2init_attrs_valid(int attr_mask, uint32_t qp_type) {
-    int valid_attr = init2init_optional_attr[qp_type];
+  int valid_attr = init2init_optional_attr[qp_type];
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool is_init2rtr_attrs_valid(int attr_mask, uint32_t qp_type) {
-    int required_attr = init2rtr_requested_attr[qp_type];
-    int valid_attr = required_attr | init2rtr_optional_attr[qp_type];
+  int required_attr = init2rtr_requested_attr[qp_type];
+  int valid_attr = required_attr | init2rtr_optional_attr[qp_type];
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    if ((required_attr & attr_mask) != required_attr) {
-        print_missing_attrs(required_attr, attr_mask);
-        return false;
-    }
+  if ((required_attr & attr_mask) != required_attr) {
+    print_missing_attrs(required_attr, attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool is_rtr2rts_attrs_valid(int attr_mask, uint32_t qp_type) {
-    int required_attr = rtr2rts_requested_attr[qp_type];
-    int valid_attr = required_attr | rtr2rts_optional_attr[qp_type];
+  int required_attr = rtr2rts_requested_attr[qp_type];
+  int valid_attr = required_attr | rtr2rts_optional_attr[qp_type];
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    if ((required_attr & attr_mask) != required_attr) {
-        print_missing_attrs(required_attr, attr_mask);
-        return false;
-    }
+  if ((required_attr & attr_mask) != required_attr) {
+    print_missing_attrs(required_attr, attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool is_rts2rts_attrs_valid(int attr_mask, uint32_t qp_type) {
-    int valid_attr = rts2rts_optional_attr[qp_type];
+  int valid_attr = rts2rts_optional_attr[qp_type];
 
-    if (attr_mask & ~(valid_attr)) {
-        DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
-        return false;
-    }
+  if (attr_mask & ~(valid_attr)) {
+    DOCA_LOG(LOG_ERR, "attr_mask contains invalid bit attr_masks (attr_mask=%d)", attr_mask);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 void convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(
     int attr_mask, int &mlx5_opt_mask, doca_verbs_qp_state_mod state_mod) {
-    mlx5_opt_mask = 0;
+  mlx5_opt_mask = 0;
 
-    static const int valid_opt_mask[] = {
-        // RST2INIT
-        0,
-        // INIT2INIT
-        DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
-            DOCA_VERBS_QP_ATTR_PKEY_INDEX | DOCA_VERBS_QP_ATTR_PORT_NUM,
-        // INIT2RTR
-        DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
-            DOCA_VERBS_QP_ATTR_PKEY_INDEX,
-        // RTR2RTS
-        DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER,
-        // RTS2RTS
-        DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
-            DOCA_VERBS_QP_ATTR_AH_ATTR | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER,
-    };
+  static const int valid_opt_mask[] = {
+    // RST2INIT
+    0,
+    // INIT2INIT
+    DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
+    DOCA_VERBS_QP_ATTR_PKEY_INDEX | DOCA_VERBS_QP_ATTR_PORT_NUM,
+    // INIT2RTR
+    DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
+    DOCA_VERBS_QP_ATTR_PKEY_INDEX,
+    // RTR2RTS
+    DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER,
+    // RTS2RTS
+    DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ |
+    DOCA_VERBS_QP_ATTR_AH_ATTR | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER,
+  };
 
-    attr_mask &= valid_opt_mask[state_mod];
+  attr_mask &= valid_opt_mask[state_mod];
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_PKEY_INDEX)
-        mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_PKEY_INDEX;
+  if (attr_mask & DOCA_VERBS_QP_ATTR_PKEY_INDEX)
+    mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_PKEY_INDEX;
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
-        mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_MIN_RNR_NAK;
+  if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
+    mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_MIN_RNR_NAK;
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_PORT_NUM)
-        mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_PORT_NUM;
+  if (attr_mask & DOCA_VERBS_QP_ATTR_PORT_NUM)
+    mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_PORT_NUM;
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR)
-        mlx5_opt_mask |= (PRIV_DOCA_MLX5_QP_OPT_SGID_INDEX | PRIV_DOCA_MLX5_QP_OPT_DSCP);
+  if (attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR)
+    mlx5_opt_mask |= (PRIV_DOCA_MLX5_QP_OPT_SGID_INDEX | PRIV_DOCA_MLX5_QP_OPT_DSCP);
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE) {
-        mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_RWE;
-    }
+  if (attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE) {
+    mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_RWE;
+  }
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) {
-        mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_RRE;
-    }
+  if (attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) {
+    mlx5_opt_mask |= PRIV_DOCA_MLX5_QP_OPT_PARAM_RRE;
+  }
 }
 
 doca_error_t query_roce_version(struct ibv_context *ctx, uint8_t sgid_index,
-                                uint8_t &roce_version) noexcept {
-    uint32_t in[MLX5_ST_SZ_DW(query_roce_address_in)] = {0};
-    constexpr auto out_size =
-        MLX5_ST_SZ_DW(query_roce_address_out) + MLX5_ST_SZ_DW(roce_addr_layout);
-    uint32_t out[out_size] = {0};
+    uint8_t &roce_version) noexcept {
+  uint32_t in[MLX5_ST_SZ_DW(query_roce_address_in)] = {};
+  constexpr auto out_size =
+      MLX5_ST_SZ_DW(query_roce_address_out) + MLX5_ST_SZ_DW(roce_addr_layout);
+  uint32_t out[out_size] = {};
 
-    DEVX_SET(query_roce_address_in, &in, opcode, MLX5_CMD_OP_QUERY_ROCE_ADDRESS);
-    DEVX_SET(query_roce_address_in, &in, roce_address_index, sgid_index);
+  DEVX_SET(query_roce_address_in, &in, opcode, MLX5_CMD_OP_QUERY_ROCE_ADDRESS);
+  DEVX_SET(query_roce_address_in, &in, roce_address_index, sgid_index);
 
-    auto ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query roce version");
-        return DOCA_ERROR_DRIVER;
-    }
+  auto ret = doca_verbs_wrapper_mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query roce version");
+    return DOCA_ERROR_DRIVER;
+  }
 
-    roce_version = DEVX_GET(query_roce_address_out, out, roce_address[0].roce_version);
+  roce_version = DEVX_GET(query_roce_address_out, out, roce_address[0].roce_version);
 
-    DOCA_LOG(LOG_INFO, "roce_version = %d", roce_version);
+  DOCA_LOG(LOG_INFO, "roce_version = %d", roce_version);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t convert_doca_mtu_size_to_prm_mtu_size(doca_verbs_mtu_size mtu_size,
-                                                   uint32_t &prm_mtu_size) noexcept {
-    switch (mtu_size) {
-        case DOCA_VERBS_MTU_SIZE_256_BYTES:
-            prm_mtu_size = MLX5_QPC_MTU_256_BYTES;
-            break;
-        case DOCA_VERBS_MTU_SIZE_512_BYTES:
-            prm_mtu_size = MLX5_QPC_MTU_512_BYTES;
-            break;
-        case DOCA_VERBS_MTU_SIZE_1K_BYTES:
-            prm_mtu_size = MLX5_QPC_MTU_1K_BYTES;
-            break;
-        case DOCA_VERBS_MTU_SIZE_2K_BYTES:
-            prm_mtu_size = MLX5_QPC_MTU_2K_BYTES;
-            break;
-        case DOCA_VERBS_MTU_SIZE_4K_BYTES:
-            prm_mtu_size = MLX5_QPC_MTU_4K_BYTES;
-            break;
-        case DOCA_VERBS_MTU_SIZE_RAW_ETHERNET:
-            prm_mtu_size = MLX5_QPC_MTU_RAW_ETHERNET_QP;
-            break;
-        default:
-            DOCA_LOG(LOG_ERR, "Can't convert invalid DOCA mtu size=%d", mtu_size);
-            return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t &prm_mtu_size) noexcept {
+  switch (mtu_size) {
+    case DOCA_VERBS_MTU_SIZE_256_BYTES:
+      prm_mtu_size = MLX5_QPC_MTU_256_BYTES;
+      break;
+    case DOCA_VERBS_MTU_SIZE_512_BYTES:
+      prm_mtu_size = MLX5_QPC_MTU_512_BYTES;
+      break;
+    case DOCA_VERBS_MTU_SIZE_1K_BYTES:
+      prm_mtu_size = MLX5_QPC_MTU_1K_BYTES;
+      break;
+    case DOCA_VERBS_MTU_SIZE_2K_BYTES:
+      prm_mtu_size = MLX5_QPC_MTU_2K_BYTES;
+      break;
+    case DOCA_VERBS_MTU_SIZE_4K_BYTES:
+      prm_mtu_size = MLX5_QPC_MTU_4K_BYTES;
+      break;
+    case DOCA_VERBS_MTU_SIZE_RAW_ETHERNET:
+      prm_mtu_size = MLX5_QPC_MTU_RAW_ETHERNET_QP;
+      break;
+    default:
+      DOCA_LOG(LOG_ERR, "Can't convert invalid DOCA mtu size=%d", mtu_size);
+      return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t convert_prm_mtu_size_to_doca_verbs_mtu_size(uint32_t prm_mtu_size,
-                                                         doca_verbs_mtu_size &mtu_size) noexcept {
-    switch (prm_mtu_size) {
-        case MLX5_QPC_MTU_256_BYTES:
-            mtu_size = DOCA_VERBS_MTU_SIZE_256_BYTES;
-            break;
-        case MLX5_QPC_MTU_512_BYTES:
-            mtu_size = DOCA_VERBS_MTU_SIZE_512_BYTES;
-            break;
-        case MLX5_QPC_MTU_1K_BYTES:
-            mtu_size = DOCA_VERBS_MTU_SIZE_1K_BYTES;
-            break;
-        case MLX5_QPC_MTU_2K_BYTES:
-            mtu_size = DOCA_VERBS_MTU_SIZE_2K_BYTES;
-            break;
-        case MLX5_QPC_MTU_4K_BYTES:
-            mtu_size = DOCA_VERBS_MTU_SIZE_4K_BYTES;
-            break;
-        case MLX5_QPC_MTU_RAW_ETHERNET_QP:
-            mtu_size = DOCA_VERBS_MTU_SIZE_RAW_ETHERNET;
-            break;
-        default:
-            DOCA_LOG(LOG_ERR, "Can't convert invalid prm mtu size=%d", mtu_size);
-            return DOCA_ERROR_INVALID_VALUE;
-    }
+    doca_verbs_mtu_size &mtu_size) noexcept {
+  switch (prm_mtu_size) {
+    case MLX5_QPC_MTU_256_BYTES:
+      mtu_size = DOCA_VERBS_MTU_SIZE_256_BYTES;
+      break;
+    case MLX5_QPC_MTU_512_BYTES:
+      mtu_size = DOCA_VERBS_MTU_SIZE_512_BYTES;
+      break;
+    case MLX5_QPC_MTU_1K_BYTES:
+      mtu_size = DOCA_VERBS_MTU_SIZE_1K_BYTES;
+      break;
+    case MLX5_QPC_MTU_2K_BYTES:
+      mtu_size = DOCA_VERBS_MTU_SIZE_2K_BYTES;
+      break;
+    case MLX5_QPC_MTU_4K_BYTES:
+      mtu_size = DOCA_VERBS_MTU_SIZE_4K_BYTES;
+      break;
+    case MLX5_QPC_MTU_RAW_ETHERNET_QP:
+      mtu_size = DOCA_VERBS_MTU_SIZE_RAW_ETHERNET;
+      break;
+    default:
+      DOCA_LOG(LOG_ERR, "Can't convert invalid prm mtu size=%d", mtu_size);
+      return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 int random_in_range(int min, int max) { return min + rand() % (max - min + 1); }
 
 doca_error_t resolve_remote_mac(ibv_pd *pd_handle, uint8_t local_port_num, uint32_t local_gid_index,
-                                uint8_t remote_gid[PRIV_DOCA_GID_BYTE_LENGTH], uint8_t hop_limit,
-                                uint8_t is_global,
-                                uint8_t mac[PRIV_DOCA_MAC_BYTE_LENGTH]) noexcept {
-    struct ibv_ah_attr attr = {};
+    uint8_t remote_gid[PRIV_DOCA_GID_BYTE_LENGTH], uint8_t hop_limit,
+    uint8_t is_global,
+    uint8_t mac[PRIV_DOCA_MAC_BYTE_LENGTH]) noexcept {
+  struct ibv_ah_attr attr = {};
 
-    attr.port_num = local_port_num;
-    attr.grh.sgid_index = local_gid_index;
-    memcpy(attr.grh.dgid.raw, remote_gid, PRIV_DOCA_GID_BYTE_LENGTH);
-    attr.grh.hop_limit = hop_limit;
-    attr.is_global = is_global;
+  attr.port_num = local_port_num;
+  attr.grh.sgid_index = local_gid_index;
+  memcpy(attr.grh.dgid.raw, remote_gid, PRIV_DOCA_GID_BYTE_LENGTH);
+  attr.grh.hop_limit = hop_limit;
+  attr.is_global = is_global;
 
-    struct ibv_ah *ah;
-    auto ah_ret = doca_verbs_wrapper_ibv_create_ah(pd_handle, &attr, &ah);
-    if (ah_ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to create ibv_ah. ret=%d", ah_ret);
-        return ah_ret;
+  struct ibv_ah *ah;
+  auto ah_ret = doca_verbs_wrapper_ibv_create_ah(pd_handle, &attr, &ah);
+  if (ah_ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to create ibv_ah. ret=%d", ah_ret);
+    return ah_ret;
+  }
+
+  struct mlx5dv_obj dv_obj {};
+  struct mlx5dv_ah dv_ah {};
+
+  dv_obj.ah.in = ah;
+  dv_obj.ah.out = &dv_ah;
+
+  auto ret = doca_verbs_wrapper_mlx5dv_init_obj(&dv_obj, MLX5DV_OBJ_AH);
+  if (ret != DOCA_SUCCESS) {
+    auto destroy_ret = doca_verbs_wrapper_ibv_destroy_ah(ah);
+    if (destroy_ret != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to destroy ibv_ah. ret=%d", destroy_ret);
     }
+    DOCA_LOG(LOG_ERR, "Failed to initialize mlx5dv_ah from ibv_ah. ret=%d", ret);
+    return DOCA_ERROR_DRIVER;
+  }
 
-    struct mlx5dv_obj dv_obj {};
-    struct mlx5dv_ah dv_ah {};
-
-    dv_obj.ah.in = ah;
-    dv_obj.ah.out = &dv_ah;
-
-    auto ret = doca_verbs_wrapper_mlx5dv_init_obj(&dv_obj, MLX5DV_OBJ_AH);
-    if (ret != DOCA_SUCCESS) {
-        auto destroy_ret = doca_verbs_wrapper_ibv_destroy_ah(ah);
-        if (destroy_ret != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to destroy ibv_ah. ret=%d", destroy_ret);
-        }
-        DOCA_LOG(LOG_ERR, "Failed to initialize mlx5dv_ah from ibv_ah. ret=%d", ret);
-        return DOCA_ERROR_DRIVER;
+  // Check needed for coverity
+  if (dv_ah.av == nullptr) {
+    auto destroy_ret = doca_verbs_wrapper_ibv_destroy_ah(ah);
+    if (destroy_ret != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to destroy ibv_ah. ret=%d", destroy_ret);
     }
+    DOCA_LOG(LOG_ERR, "Failed to initialize mlx5dv_ah from ibv_ah mlx5dv_ah::av is NULL");
+    return DOCA_ERROR_DRIVER;
+  }
 
-    // Check needed for coverity
-    if (dv_ah.av == nullptr) {
-        auto destroy_ret = doca_verbs_wrapper_ibv_destroy_ah(ah);
-        if (destroy_ret != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to destroy ibv_ah. ret=%d", destroy_ret);
-        }
-        DOCA_LOG(LOG_ERR, "Failed to initialize mlx5dv_ah from ibv_ah mlx5dv_ah::av is NULL");
-        return DOCA_ERROR_DRIVER;
-    }
+  memcpy(mac, dv_ah.av->rmac, PRIV_DOCA_MAC_BYTE_LENGTH);
 
-    memcpy(mac, dv_ah.av->rmac, PRIV_DOCA_MAC_BYTE_LENGTH);
+  auto destroy_ah_status = doca_verbs_wrapper_ibv_destroy_ah(ah);
+  if (destroy_ah_status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to destroy ibv_ah. ret=%d", destroy_ah_status);
+    return destroy_ah_status;
+  }
 
-    auto destroy_ah_status = doca_verbs_wrapper_ibv_destroy_ah(ah);
-    if (destroy_ah_status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to destroy ibv_ah. ret=%d", destroy_ah_status);
-        return destroy_ah_status;
-    }
-
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t convert_prm_qp_state_to_doca_verbs_qp_state(uint32_t qp_state,
-                                                         doca_verbs_qp_state &state) {
-    switch (qp_state) {
-        case MLX5_QPC_STATE_RST:
-            state = DOCA_VERBS_QP_STATE_RST;
-            break;
-        case MLX5_QPC_STATE_INIT:
-            state = DOCA_VERBS_QP_STATE_INIT;
-            break;
-        case MLX5_QPC_STATE_RTR:
-            state = DOCA_VERBS_QP_STATE_RTR;
-            break;
-        case MLX5_QPC_STATE_RTS:
-            state = DOCA_VERBS_QP_STATE_RTS;
-            break;
-        case MLX5_QPC_STATE_ERR:
-            state = DOCA_VERBS_QP_STATE_ERR;
-            break;
-        default:
-            DOCA_LOG(LOG_ERR, "Can't convert invalid prm qp state=%d", qp_state);
-            return DOCA_ERROR_INVALID_VALUE;
-    }
+    doca_verbs_qp_state &state) {
+  switch (qp_state) {
+    case MLX5_QPC_STATE_RST:
+      state = DOCA_VERBS_QP_STATE_RST;
+      break;
+    case MLX5_QPC_STATE_INIT:
+      state = DOCA_VERBS_QP_STATE_INIT;
+      break;
+    case MLX5_QPC_STATE_RTR:
+      state = DOCA_VERBS_QP_STATE_RTR;
+      break;
+    case MLX5_QPC_STATE_RTS:
+      state = DOCA_VERBS_QP_STATE_RTS;
+      break;
+    case MLX5_QPC_STATE_ERR:
+      state = DOCA_VERBS_QP_STATE_ERR;
+      break;
+    default:
+      DOCA_LOG(LOG_ERR, "Can't convert invalid prm qp state=%d", qp_state);
+      return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 } /* namespace */
@@ -533,124 +533,124 @@ doca_error_t convert_prm_qp_state_to_doca_verbs_qp_state(uint32_t qp_state,
  *********************************************************************************************************************/
 
 bool doca_verbs_qp::is_qp_attr_state_valid(enum doca_verbs_qp_state state) noexcept {
-    switch (state) {
-        case DOCA_VERBS_QP_STATE_RST:
-        case DOCA_VERBS_QP_STATE_INIT:
-        case DOCA_VERBS_QP_STATE_RTR:
-        case DOCA_VERBS_QP_STATE_RTS:
-        case DOCA_VERBS_QP_STATE_ERR:
-            return true;
-        default:
-            DOCA_LOG(LOG_ERR, "state is invalid (value is %u)", state);
-            return false;
-    }
+  switch (state) {
+    case DOCA_VERBS_QP_STATE_RST:
+    case DOCA_VERBS_QP_STATE_INIT:
+    case DOCA_VERBS_QP_STATE_RTR:
+    case DOCA_VERBS_QP_STATE_RTS:
+    case DOCA_VERBS_QP_STATE_ERR:
+      return true;
+    default:
+      DOCA_LOG(LOG_ERR, "state is invalid (value is %u)", state);
+      return false;
+  }
 
-    // Shouldn't reach this
-    return true;
+  // Shouldn't reach this
+  return true;
 }
 
 bool doca_verbs_qp::is_qp_attr_path_mtu_valid(enum doca_verbs_mtu_size path_mtu) noexcept {
-    switch (path_mtu) {
-        case DOCA_VERBS_MTU_SIZE_256_BYTES:
-        case DOCA_VERBS_MTU_SIZE_512_BYTES:
-        case DOCA_VERBS_MTU_SIZE_1K_BYTES:
-        case DOCA_VERBS_MTU_SIZE_2K_BYTES:
-        case DOCA_VERBS_MTU_SIZE_4K_BYTES:
-            return true;
-        default:
-            DOCA_LOG(LOG_ERR, "path_mtu is invalid (value is %u)", path_mtu);
-            return false;
-    }
+  switch (path_mtu) {
+    case DOCA_VERBS_MTU_SIZE_256_BYTES:
+    case DOCA_VERBS_MTU_SIZE_512_BYTES:
+    case DOCA_VERBS_MTU_SIZE_1K_BYTES:
+    case DOCA_VERBS_MTU_SIZE_2K_BYTES:
+    case DOCA_VERBS_MTU_SIZE_4K_BYTES:
+      return true;
+    default:
+      DOCA_LOG(LOG_ERR, "path_mtu is invalid (value is %u)", path_mtu);
+      return false;
+  }
 
-    // Shouldn't reach this
-    return true;
+  // Shouldn't reach this
+  return true;
 }
 
 // No value of PSN causes a value (we print a warning and mask it in case of overflow)
 uint32_t doca_verbs_qp::is_qp_attr_queue_psn_valid(uint32_t psn) noexcept {
-    if (psn & ~0xffffff) {
-        DOCA_LOG(LOG_ERR, "PSN value overflow (max is %x). Masking to 24 bits", 0xffffff);
-        psn &= 0xffffff;
-    }
+  if (psn & ~0xffffff) {
+    DOCA_LOG(LOG_ERR, "PSN value overflow (max is %x). Masking to 24 bits", 0xffffff);
+    psn &= 0xffffff;
+  }
 
-    return psn;
+  return psn;
 }
 
 bool doca_verbs_qp::is_qp_attr_ah_add_type_valid(enum doca_verbs_addr_type addr_type) noexcept {
-    switch (addr_type) {
-        case DOCA_VERBS_ADDR_TYPE_IPv4:
-        case DOCA_VERBS_ADDR_TYPE_IPv6:
-        case DOCA_VERBS_ADDR_TYPE_IB_GRH:
-        case DOCA_VERBS_ADDR_TYPE_IB_NO_GRH:
-            return true;
-        default:
-            DOCA_LOG(LOG_ERR, "addr_type is invalid (value is %u)", addr_type);
-            return false;
-    }
+  switch (addr_type) {
+    case DOCA_VERBS_ADDR_TYPE_IPv4:
+    case DOCA_VERBS_ADDR_TYPE_IPv6:
+    case DOCA_VERBS_ADDR_TYPE_IB_GRH:
+    case DOCA_VERBS_ADDR_TYPE_IB_NO_GRH:
+      return true;
+    default:
+      DOCA_LOG(LOG_ERR, "addr_type is invalid (value is %u)", addr_type);
+      return false;
+  }
 
-    // Shouldn't reach this
-    return true;
+  // Shouldn't reach this
+  return true;
 }
 
 bool doca_verbs_qp::is_qp_attr_ah_sgid_index_valid(uint8_t sgid_index) noexcept {
-    if (sgid_index >= m_verbs_device_attr->m_gid_table_size) {
-        DOCA_LOG(LOG_ERR, "sgid_index should be less than %u (value is %u)",
-                 m_verbs_device_attr->m_gid_table_size - 1, sgid_index);
-        return false;
-    }
+  if (sgid_index >= m_verbs_device_attr->m_gid_table_size) {
+    DOCA_LOG(LOG_ERR, "sgid_index should be less than %u (value is %u)",
+      m_verbs_device_attr->m_gid_table_size - 1, sgid_index);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool doca_verbs_qp::is_qp_attr_pkey_index_valid(uint16_t pkey_index) noexcept {
-    if (pkey_index > m_verbs_device_attr->m_max_pkeys) {
-        DOCA_LOG(LOG_ERR, "pkey_index should be less than %u (value is %u)",
-                 m_verbs_device_attr->m_max_pkeys, pkey_index);
-        return false;
-    }
+  if (pkey_index > m_verbs_device_attr->m_max_pkeys) {
+    DOCA_LOG(LOG_ERR, "pkey_index should be less than %u (value is %u)",
+      m_verbs_device_attr->m_max_pkeys, pkey_index);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool doca_verbs_qp::is_qp_attr_port_num_valid(uint16_t port_num) noexcept {
-    if (port_num > m_verbs_device_attr->m_phys_port_cnt || port_num < 1) {
-        DOCA_LOG(LOG_ERR, "port_num should be from %u to %u (value is %u)", 1,
-                 m_verbs_device_attr->m_phys_port_cnt, port_num);
-        return false;
-    }
+  if (port_num > m_verbs_device_attr->m_phys_port_cnt || port_num < 1) {
+    DOCA_LOG(LOG_ERR, "port_num should be from %u to %u (value is %u)", 1,
+      m_verbs_device_attr->m_phys_port_cnt, port_num);
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool doca_verbs_qp::is_qp_attr_valid(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                     int attr_mask) noexcept {
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_CURRENT_STATE) &&
-        !is_qp_attr_state_valid(verbs_qp_attr->current_state))
-        return false;
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_NEXT_STATE) &&
-        !is_qp_attr_state_valid(verbs_qp_attr->next_state))
-        return false;
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_PATH_MTU) &&
-        !is_qp_attr_path_mtu_valid(verbs_qp_attr->path_mtu))
-        return false;
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_RQ_PSN))
-        verbs_qp_attr->rq_psn = is_qp_attr_queue_psn_valid(verbs_qp_attr->rq_psn);
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_SQ_PSN))
-        verbs_qp_attr->sq_psn = is_qp_attr_queue_psn_valid(verbs_qp_attr->sq_psn);
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) &&
-        !is_qp_attr_ah_add_type_valid(verbs_qp_attr->ah_attr->addr_type))
-        return false;
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) &&
-        !is_qp_attr_ah_sgid_index_valid(verbs_qp_attr->ah_attr->sgid_index))
-        return false;
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_PKEY_INDEX) &&
-        !is_qp_attr_pkey_index_valid(verbs_qp_attr->pkey_index))
-        return false;
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_PORT_NUM) &&
-        !is_qp_attr_port_num_valid(verbs_qp_attr->port_num))
-        return false;
+    int attr_mask) noexcept {
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_CURRENT_STATE) &&
+    !is_qp_attr_state_valid(verbs_qp_attr->current_state))
+    return false;
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_NEXT_STATE) &&
+    !is_qp_attr_state_valid(verbs_qp_attr->next_state))
+    return false;
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_PATH_MTU) &&
+    !is_qp_attr_path_mtu_valid(verbs_qp_attr->path_mtu))
+    return false;
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_RQ_PSN))
+    verbs_qp_attr->rq_psn = is_qp_attr_queue_psn_valid(verbs_qp_attr->rq_psn);
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_SQ_PSN))
+    verbs_qp_attr->sq_psn = is_qp_attr_queue_psn_valid(verbs_qp_attr->sq_psn);
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) &&
+    !is_qp_attr_ah_add_type_valid(verbs_qp_attr->ah_attr->addr_type))
+    return false;
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) &&
+    !is_qp_attr_ah_sgid_index_valid(verbs_qp_attr->ah_attr->sgid_index))
+    return false;
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_PKEY_INDEX) &&
+    !is_qp_attr_pkey_index_valid(verbs_qp_attr->pkey_index))
+    return false;
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_PORT_NUM) &&
+    !is_qp_attr_port_num_valid(verbs_qp_attr->port_num))
+    return false;
 
-    return true;
+  return true;
 }
 
 doca_verbs_qp_state doca_verbs_qp::get_current_state() const noexcept { return m_current_state; }
@@ -659,905 +659,905 @@ doca_error_t doca_verbs_qp::create_qp_obj(
     uint32_t uar_id, uint32_t log_rq_size, uint32_t log_sq_size_wqebb, uint32_t log_stride,
     uint64_t dbr_umem_offset, uint32_t dbr_umem_id, uint32_t wq_umem_id,
     struct doca_verbs_qp_init_attr &verbs_qp_init_attr) noexcept {
-    create_qp_in create_in{0};
-    create_qp_out create_out{0};
+  create_qp_in create_in{0};
+  create_qp_out create_out{0};
 
-    void *qpc = MLX5_ADDR_OF(create_qp_in, create_in, qpc);
+  void *qpc = MLX5_ADDR_OF(create_qp_in, create_in, qpc);
 
-    const bool use_rq = ((m_rq_size > 0) || (verbs_qp_init_attr.srq != nullptr));
+  const bool use_rq = ((m_rq_size > 0) || (verbs_qp_init_attr.srq != nullptr));
 
-    DEVX_SET(create_qp_in, create_in, opcode, MLX5_CMD_OP_CREATE_QP);
-    DEVX_SET(qpc, qpc, st, MLX5_QPC_ST_RC);
+  DEVX_SET(create_qp_in, create_in, opcode, MLX5_CMD_OP_CREATE_QP);
+  DEVX_SET(qpc, qpc, st, MLX5_QPC_ST_RC);
 
-    struct mlx5dv_pd dvpd;
-    struct mlx5dv_obj dv_obj;
-    // Query pdn
-    memset(&dv_obj, 0, sizeof(dv_obj));
-    dv_obj.pd.in = m_pd;
-    dv_obj.pd.out = &dvpd;
+  struct mlx5dv_pd dvpd;
+  struct mlx5dv_obj dv_obj;
+  // Query pdn
+  memset(&dv_obj, 0, sizeof(dv_obj));
+  dv_obj.pd.in = m_pd;
+  dv_obj.pd.out = &dvpd;
 
-    auto ret = doca_verbs_wrapper_mlx5dv_init_obj(&dv_obj, MLX5DV_OBJ_PD);
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Error in mlx5dv PD initialization");
-        return DOCA_ERROR_DRIVER;
+  auto ret = doca_verbs_wrapper_mlx5dv_init_obj(&dv_obj, MLX5DV_OBJ_PD);
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Error in mlx5dv PD initialization");
+    return DOCA_ERROR_DRIVER;
+  }
+
+  DEVX_SET(qpc, qpc, pd, dvpd.pdn);
+
+  DEVX_SET(qpc, qpc, user_index, verbs_qp_init_attr.user_index);
+  DEVX_SET(qpc, qpc, uar_page, uar_id);
+
+  if (m_sq_size_wqebb > 0) {
+    if (verbs_qp_init_attr.send_cq == nullptr) {
+      DOCA_LOG(LOG_ERR, "Failed to create QP. Send CQ is null");
+      return DOCA_ERROR_INVALID_VALUE;
+    }
+    DEVX_SET(qpc, qpc, cqn_snd, verbs_qp_init_attr.send_cq->get_cqn());
+    DEVX_SET(qpc, qpc, log_sq_size, log_sq_size_wqebb);
+  } else {
+    DEVX_SET(qpc, qpc, no_sq, 1);
+  }
+
+  if (use_rq) {
+    if (verbs_qp_init_attr.receive_cq == nullptr) {
+      DOCA_LOG(LOG_ERR, "Failed to create QP. Receive CQ is null");
+      return DOCA_ERROR_INVALID_VALUE;
     }
 
-    DEVX_SET(qpc, qpc, pd, dvpd.pdn);
+    DEVX_SET(qpc, qpc, cqn_rcv, verbs_qp_init_attr.receive_cq->get_cqn());
 
-    DEVX_SET(qpc, qpc, user_index, verbs_qp_init_attr.user_index);
-    DEVX_SET(qpc, qpc, uar_page, uar_id);
-
-    if (m_sq_size_wqebb > 0) {
-        if (verbs_qp_init_attr.send_cq == nullptr) {
-            DOCA_LOG(LOG_ERR, "Failed to create QP. Send CQ is null");
-            return DOCA_ERROR_INVALID_VALUE;
-        }
-        DEVX_SET(qpc, qpc, cqn_snd, verbs_qp_init_attr.send_cq->get_cqn());
-        DEVX_SET(qpc, qpc, log_sq_size, log_sq_size_wqebb);
-    } else {
-        DEVX_SET(qpc, qpc, no_sq, 1);
+    if (verbs_qp_init_attr.srq != nullptr) {
+      /* Case of SRQ */
+      DEVX_SET(qpc, qpc, srqn_rmpn_xrqn, verbs_qp_init_attr.srq->get_srqn());
+      DEVX_SET(qpc, qpc, rq_type, MLX5_QPC_RQ_TYPE_SRQ_RMP_XRC_SRQ_XRQ);
+      m_srq = verbs_qp_init_attr.srq;
+    } else if (m_rq_size > 0) {
+      /* Case of regular RQ */
+      DEVX_SET(qpc, qpc, log_rq_stride, log_stride);
+      DEVX_SET(qpc, qpc, log_rq_size, log_rq_size);
+      DEVX_SET(qpc, qpc, rq_type, MLX5_QPC_RQ_TYPE_REGULAR);
     }
+  } else {
+    /* Case of no RQ */
+    DEVX_SET(qpc, qpc, rq_type, MLX5_QPC_RQ_TYPE_ZERO_SIZE_RQ);
+  }
 
-    if (use_rq) {
-        if (verbs_qp_init_attr.receive_cq == nullptr) {
-            DOCA_LOG(LOG_ERR, "Failed to create QP. Receive CQ is null");
-            return DOCA_ERROR_INVALID_VALUE;
-        }
+  // DEVX_SET(qpc, qpc, cs_req, 0);            // Disable CS Request
+  // DEVX_SET(qpc, qpc, cs_res, 0);            // Disable CS Response
 
-        DEVX_SET(qpc, qpc, cqn_rcv, verbs_qp_init_attr.receive_cq->get_cqn());
+  DEVX_SET(qpc, qpc, send_dbr_mode, verbs_qp_init_attr.send_dbr_mode);
+  DEVX_SET(qpc, qpc, dbr_umem_valid, 1);
+  DEVX_SET(qpc, qpc, dbr_umem_id, dbr_umem_id);
+  DEVX_SET64(qpc, qpc, dbr_addr, dbr_umem_offset);
 
-        if (verbs_qp_init_attr.srq != nullptr) {
-            /* Case of SRQ */
-            DEVX_SET(qpc, qpc, srqn_rmpn_xrqn, verbs_qp_init_attr.srq->get_srqn());
-            DEVX_SET(qpc, qpc, rq_type, MLX5_QPC_RQ_TYPE_SRQ_RMP_XRC_SRQ_XRQ);
-            m_srq = verbs_qp_init_attr.srq;
-        } else if (m_rq_size > 0) {
-            /* Case of regular RQ */
-            DEVX_SET(qpc, qpc, log_rq_stride, log_stride);
-            DEVX_SET(qpc, qpc, log_rq_size, log_rq_size);
-            DEVX_SET(qpc, qpc, rq_type, MLX5_QPC_RQ_TYPE_REGULAR);
-        }
-    } else {
-        /* Case of no RQ */
-        DEVX_SET(qpc, qpc, rq_type, MLX5_QPC_RQ_TYPE_ZERO_SIZE_RQ);
-    }
+  DEVX_SET64(qpc, qpc, cd_master, verbs_qp_init_attr.core_direct_master);
+  DEVX_SET(create_qp_in, create_in, wq_umem_id, wq_umem_id);
+  DEVX_SET(create_qp_in, create_in, wq_umem_valid, 1);
 
-    // DEVX_SET(qpc, qpc, cs_req, 0);            // Disable CS Request
-    // DEVX_SET(qpc, qpc, cs_res, 0);            // Disable CS Response
+  /* Since wq_umem_valid == 1, FW deduces page size from umem and this field is reserved */
+  DEVX_SET(qpc, qpc, log_page_size, 0);
 
-    DEVX_SET(qpc, qpc, send_dbr_mode, verbs_qp_init_attr.send_dbr_mode);
-    DEVX_SET(qpc, qpc, dbr_umem_valid, 1);
-    DEVX_SET(qpc, qpc, dbr_umem_id, dbr_umem_id);
-    DEVX_SET64(qpc, qpc, dbr_addr, dbr_umem_offset);
+  /* Create DevX object */
+  auto status = doca_verbs_wrapper_mlx5dv_devx_obj_create(
+          m_ibv_ctx, create_in, sizeof(create_in), create_out, sizeof(create_out), &m_qp_obj);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to create QP. DevX error, syndrome=0x%x",
+        DEVX_GET(nop_out, create_out, syndrome));
+    return status;
+  }
 
-    DEVX_SET64(qpc, qpc, cd_master, verbs_qp_init_attr.core_direct_master);
-    DEVX_SET(create_qp_in, create_in, wq_umem_id, wq_umem_id);
-    DEVX_SET(create_qp_in, create_in, wq_umem_valid, 1);
+  m_qp_num = DEVX_GET(create_qp_out, create_out, qpn);
+  m_current_state = DOCA_VERBS_QP_STATE_RST;
 
-    /* Since wq_umem_valid == 1, FW deduces page size from umem and this field is reserved */
-    DEVX_SET(qpc, qpc, log_page_size, 0);
-
-    /* Create DevX object */
-    auto status = doca_verbs_wrapper_mlx5dv_devx_obj_create(
-        m_ibv_ctx, create_in, sizeof(create_in), create_out, sizeof(create_out), &m_qp_obj);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to create QP. DevX error, syndrome=0x%x",
-                 DEVX_GET(nop_out, create_out, syndrome));
-        return status;
-    }
-
-    m_qp_num = DEVX_GET(create_qp_out, create_out, qpn);
-    m_current_state = DOCA_VERBS_QP_STATE_RST;
-
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp::rst2init(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                     int attr_mask) noexcept {
-    rst2init_qp_in in{0};
-    rst2init_qp_out out{0};
+    int attr_mask) noexcept {
+  rst2init_qp_in in{0};
+  rst2init_qp_out out{0};
 
-    if (!is_rst2init_attrs_valid(attr_mask, m_qp_type)) {
-        DOCA_LOG(LOG_ERR, "rst2init attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (!is_rst2init_attrs_valid(attr_mask, m_qp_type)) {
+    DOCA_LOG(LOG_ERR, "rst2init attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    void *qpc = MLX5_ADDR_OF(rst2init_qp_in, &in, qpc);
-    DEVX_SET(rst2init_qp_in, &in, opcode, MLX5_CMD_OP_RST2INIT_QP);
-    DEVX_SET(rst2init_qp_in, &in, qpn, m_qp_num);
-    DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, verbs_qp_attr.port_num);
-    DEVX_SET(qpc, qpc, pm_state, MLX5_QPC_PM_STATE_MIGRATED);
-    // DEVX_SET(qpc, qpc, counter_set_id, 0x0);  // Not connected to a counter set
-    DEVX_SET(qpc, qpc, primary_address_path.pkey_index, verbs_qp_attr.pkey_index);
+  void *qpc = MLX5_ADDR_OF(rst2init_qp_in, &in, qpc);
+  DEVX_SET(rst2init_qp_in, &in, opcode, MLX5_CMD_OP_RST2INIT_QP);
+  DEVX_SET(rst2init_qp_in, &in, qpn, m_qp_num);
+  DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, verbs_qp_attr.port_num);
+  DEVX_SET(qpc, qpc, pm_state, MLX5_QPC_PM_STATE_MIGRATED);
+  // DEVX_SET(qpc, qpc, counter_set_id, 0x0);  // Not connected to a counter set
+  DEVX_SET(qpc, qpc, primary_address_path.pkey_index, verbs_qp_attr.pkey_index);
 
-    if (verbs_qp_attr.allow_remote_write == 1) {
-        DEVX_SET(qpc, qpc, rwe, 1);
-    }
+  if (verbs_qp_attr.allow_remote_write == 1) {
+    DEVX_SET(qpc, qpc, rwe, 1);
+  }
 
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
-        verbs_qp_attr.allow_remote_read == 1) {
-        DEVX_SET(qpc, qpc, rre, 1);
-    }
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
+    verbs_qp_attr.allow_remote_read == 1) {
+    DEVX_SET(qpc, qpc, rre, 1);
+  }
 
-    if (verbs_qp_attr.allow_remote_write == 1) {
-        DEVX_SET(qpc, qpc, rwe, 1);
-    }
+  if (verbs_qp_attr.allow_remote_write == 1) {
+    DEVX_SET(qpc, qpc, rwe, 1);
+  }
 
-    if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
-        DEVX_SET(qpc, qpc, rae, 1);
-        DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
-    }
+  if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
+    DEVX_SET(qpc, qpc, rae, 1);
+    DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
+  }
 
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP rst2init");
-        return ret;
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP rst2init");
+    return ret;
+  }
 
-    m_current_state = DOCA_VERBS_QP_STATE_INIT;
+  m_current_state = DOCA_VERBS_QP_STATE_INIT;
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Init state", this);
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Init state", this);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp::init2init(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                      int attr_mask) noexcept {
-    init2init_qp_in in{0};
-    init2init_qp_out out{0};
+    int attr_mask) noexcept {
+  init2init_qp_in in{0};
+  init2init_qp_out out{0};
 
-    if (!is_init2init_attrs_valid(attr_mask, m_qp_type)) {
-        DOCA_LOG(LOG_ERR, "init2init attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (!is_init2init_attrs_valid(attr_mask, m_qp_type)) {
+    DOCA_LOG(LOG_ERR, "init2init attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    void *qpc = MLX5_ADDR_OF(init2init_qp_in, &in, qpc);
-    DEVX_SET(init2init_qp_in, &in, opcode, MLX5_CMD_OP_INIT2INIT_QP);
-    DEVX_SET(init2init_qp_in, &in, qpn, m_qp_num);
-    DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, verbs_qp_attr.port_num);
-    DEVX_SET(qpc, qpc, primary_address_path.pkey_index, verbs_qp_attr.pkey_index);
+  void *qpc = MLX5_ADDR_OF(init2init_qp_in, &in, qpc);
+  DEVX_SET(init2init_qp_in, &in, opcode, MLX5_CMD_OP_INIT2INIT_QP);
+  DEVX_SET(init2init_qp_in, &in, qpn, m_qp_num);
+  DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, verbs_qp_attr.port_num);
+  DEVX_SET(qpc, qpc, primary_address_path.pkey_index, verbs_qp_attr.pkey_index);
 
-    if (verbs_qp_attr.allow_remote_write == 1) {
-        DEVX_SET(qpc, qpc, rwe, 1);
-    }
+  if (verbs_qp_attr.allow_remote_write == 1) {
+    DEVX_SET(qpc, qpc, rwe, 1);
+  }
 
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
-        verbs_qp_attr.allow_remote_read == 1) {
-        DEVX_SET(qpc, qpc, rre, 1);
-    }
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
+    verbs_qp_attr.allow_remote_read == 1) {
+    DEVX_SET(qpc, qpc, rre, 1);
+  }
 
-    if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
-        DEVX_SET(qpc, qpc, rae, 1);
-        DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
-    }
+  if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
+    DEVX_SET(qpc, qpc, rae, 1);
+    DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
+  }
 
-    int mlx5_opt_param_mask{0};
-    convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
-                                                                    DOCA_VERBS_QP_INIT2INIT);
-    DEVX_SET(init2init_qp_in, &in, opt_param_mask, mlx5_opt_param_mask);
+  int mlx5_opt_param_mask{0};
+  convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
+      DOCA_VERBS_QP_INIT2INIT);
+  DEVX_SET(init2init_qp_in, &in, opt_param_mask, mlx5_opt_param_mask);
 
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP init2init");
-        return ret;
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP init2init");
+    return ret;
+  }
 
-    m_current_state = DOCA_VERBS_QP_STATE_INIT;
+  m_current_state = DOCA_VERBS_QP_STATE_INIT;
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Init state", this);
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Init state", this);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp::init2rtr(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                     int attr_mask) noexcept {
-    if (!is_init2rtr_attrs_valid(attr_mask, m_qp_type)) {
-        DOCA_LOG(LOG_ERR, "init2rtr attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) && !verbs_qp_attr.ah_attr) {
-        DOCA_LOG(LOG_ERR, "AH_ATTR mask is enabled but ah_attr=nullptr");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    int attr_mask) noexcept {
+  if (!is_init2rtr_attrs_valid(attr_mask, m_qp_type)) {
+    DOCA_LOG(LOG_ERR, "init2rtr attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) && !verbs_qp_attr.ah_attr) {
+    DOCA_LOG(LOG_ERR, "AH_ATTR mask is enabled but ah_attr=nullptr");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    init2rtr_qp_in in{0};
-    init2rtr_qp_out out{0};
+  init2rtr_qp_in in{0};
+  init2rtr_qp_out out{0};
 
-    void *qpc = MLX5_ADDR_OF(init2rtr_qp_in, in, qpc);
-    DEVX_SET(init2rtr_qp_in, in, opcode, MLX5_CMD_OP_INIT2RTR_QP);
-    DEVX_SET(init2rtr_qp_in, in, qpn, m_qp_num);
-    DEVX_SET(qpc, qpc, next_rcv_psn, verbs_qp_attr.rq_psn);
-    DEVX_SET(qpc, qpc, remote_qpn, verbs_qp_attr.dest_qp_num);
-    DEVX_SET(qpc, qpc, log_msg_max, sc_verbs_log_msg_max);
+  void *qpc = MLX5_ADDR_OF(init2rtr_qp_in, in, qpc);
+  DEVX_SET(init2rtr_qp_in, in, opcode, MLX5_CMD_OP_INIT2RTR_QP);
+  DEVX_SET(init2rtr_qp_in, in, qpn, m_qp_num);
+  DEVX_SET(qpc, qpc, next_rcv_psn, verbs_qp_attr.rq_psn);
+  DEVX_SET(qpc, qpc, remote_qpn, verbs_qp_attr.dest_qp_num);
+  DEVX_SET(qpc, qpc, log_msg_max, sc_verbs_log_msg_max);
 
-    uint32_t prm_mtu{};
-    auto status = convert_doca_mtu_size_to_prm_mtu_size(verbs_qp_attr.path_mtu, prm_mtu);
-    if (status != DOCA_SUCCESS) return status;
-    DEVX_SET(qpc, qpc, mtu, prm_mtu);
+  uint32_t prm_mtu{};
+  auto status = convert_doca_mtu_size_to_prm_mtu_size(verbs_qp_attr.path_mtu, prm_mtu);
+  if (status != DOCA_SUCCESS) return status;
+  DEVX_SET(qpc, qpc, mtu, prm_mtu);
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
-        DEVX_SET(qpc, qpc, min_rnr_nak, verbs_qp_attr.min_rnr_timer);
-    if ((verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IB_GRH) ||
-        (verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IB_NO_GRH)) { /* IB */
-        DEVX_SET(qpc, qpc, primary_address_path.tclass, verbs_qp_attr.ah_attr->traffic_class);
-        DEVX_SET(qpc, qpc, primary_address_path.rlid, verbs_qp_attr.ah_attr->dlid);
-        DEVX_SET(qpc, qpc, primary_address_path.sl, verbs_qp_attr.ah_attr->sl);
-    }
-    DEVX_SET(qpc, qpc, primary_address_path.stat_rate, verbs_qp_attr.ah_attr->static_rate);
+  if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
+    DEVX_SET(qpc, qpc, min_rnr_nak, verbs_qp_attr.min_rnr_timer);
+  if ((verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IB_GRH) ||
+    (verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IB_NO_GRH)) { /* IB */
+    DEVX_SET(qpc, qpc, primary_address_path.tclass, verbs_qp_attr.ah_attr->traffic_class);
+    DEVX_SET(qpc, qpc, primary_address_path.rlid, verbs_qp_attr.ah_attr->dlid);
+    DEVX_SET(qpc, qpc, primary_address_path.sl, verbs_qp_attr.ah_attr->sl);
+  }
+  DEVX_SET(qpc, qpc, primary_address_path.stat_rate, verbs_qp_attr.ah_attr->static_rate);
 
-    if (verbs_qp_attr.ah_attr->addr_type != DOCA_VERBS_ADDR_TYPE_IB_NO_GRH) {
-        memcpy(MLX5_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
-               verbs_qp_attr.ah_attr->gid.raw, sizeof(struct doca_verbs_gid));
-        DEVX_SET(qpc, qpc, primary_address_path.hop_limit, verbs_qp_attr.ah_attr->hop_limit);
-        DEVX_SET(qpc, qpc, primary_address_path.src_addr_index, verbs_qp_attr.ah_attr->sgid_index);
-    }
+  if (verbs_qp_attr.ah_attr->addr_type != DOCA_VERBS_ADDR_TYPE_IB_NO_GRH) {
+    memcpy(MLX5_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
+      verbs_qp_attr.ah_attr->gid.raw, sizeof(struct doca_verbs_gid));
+    DEVX_SET(qpc, qpc, primary_address_path.hop_limit, verbs_qp_attr.ah_attr->hop_limit);
+    DEVX_SET(qpc, qpc, primary_address_path.src_addr_index, verbs_qp_attr.ah_attr->sgid_index);
+  }
 
-    if ((verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IPv4) ||
-        (verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IPv6)) { /* ROCE */
-        uint8_t dest_mac[PRIV_DOCA_MAC_BYTE_LENGTH];
-        status =
-            resolve_remote_mac(m_pd, PRIV_DOCA_VERBS_PORT_NUM, verbs_qp_attr.ah_attr->sgid_index,
-                               verbs_qp_attr.ah_attr->gid.raw, verbs_qp_attr.ah_attr->hop_limit,
-                               verbs_qp_attr.ah_attr->is_global, dest_mac);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get remote MAC");
-            return status;
-        }
-
-        memcpy(MLX5_ADDR_OF(qpc, qpc, primary_address_path.rmac_47_32), dest_mac,
-               sc_verbs_mac_addr_2msbytes_len);
-        memcpy(MLX5_ADDR_OF(qpc, qpc, primary_address_path.rmac_31_0),
-               dest_mac + sc_verbs_mac_addr_2msbytes_len,
-               sc_verbs_mac_addr_len - sc_verbs_mac_addr_2msbytes_len);
+  if ((verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IPv4) ||
+    (verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IPv6)) { /* ROCE */
+    uint8_t dest_mac[PRIV_DOCA_MAC_BYTE_LENGTH];
+    status =
+        resolve_remote_mac(m_pd, PRIV_DOCA_VERBS_PORT_NUM, verbs_qp_attr.ah_attr->sgid_index,
+            verbs_qp_attr.ah_attr->gid.raw, verbs_qp_attr.ah_attr->hop_limit,
+            verbs_qp_attr.ah_attr->is_global, dest_mac);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to get remote MAC");
+      return status;
     }
 
-    if (verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IB_GRH) {
-        DEVX_SET(qpc, qpc, primary_address_path.grh, 1);
+    memcpy(MLX5_ADDR_OF(qpc, qpc, primary_address_path.rmac_47_32), dest_mac,
+      sc_verbs_mac_addr_2msbytes_len);
+    memcpy(MLX5_ADDR_OF(qpc, qpc, primary_address_path.rmac_31_0),
+      dest_mac + sc_verbs_mac_addr_2msbytes_len,
+      sc_verbs_mac_addr_len - sc_verbs_mac_addr_2msbytes_len);
+  }
+
+  if (verbs_qp_attr.ah_attr->addr_type == DOCA_VERBS_ADDR_TYPE_IB_GRH) {
+    DEVX_SET(qpc, qpc, primary_address_path.grh, 1);
+  }
+
+  if (m_verbs_device_attr->m_port_type == MLX5_CAP_PORT_TYPE_ETH) {
+    uint8_t roce_version{};
+    status = query_roce_version(m_ibv_ctx, verbs_qp_attr.ah_attr->sgid_index, roce_version);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to query roce version");
+      return status;
     }
 
-    if (m_verbs_device_attr->m_port_type == MLX5_CAP_PORT_TYPE_ETH) {
-        uint8_t roce_version{};
-        status = query_roce_version(m_ibv_ctx, verbs_qp_attr.ah_attr->sgid_index, roce_version);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to query roce version");
-            return status;
-        }
+    if (roce_version >= MLX5_ROCE_ADDR_LAYOUT_ROCE_VERSION_VERSION_2_0) {
+      // generate a random udp_sport
+      srand(time(NULL));
+      uint16_t udp_sport = (uint16_t)random_in_range(m_verbs_device_attr->m_min_udp_sport,
+        m_verbs_device_attr->m_max_udp_sport);
+      DOCA_LOG(LOG_INFO, "Generated udp_sport = %d", udp_sport);
 
-        if (roce_version >= MLX5_ROCE_ADDR_LAYOUT_ROCE_VERSION_VERSION_2_0) {
-            // generate a random udp_sport
-            srand(time(NULL));
-            uint16_t udp_sport = (uint16_t)random_in_range(m_verbs_device_attr->m_min_udp_sport,
-                                                           m_verbs_device_attr->m_max_udp_sport);
-            DOCA_LOG(LOG_INFO, "Generated udp_sport = %d", udp_sport);
-
-            DEVX_SET(qpc, qpc, primary_address_path.udp_sport, udp_sport);
-            DEVX_SET(qpc, qpc, primary_address_path.dscp,
-                     verbs_qp_attr.ah_attr->traffic_class >> 2);
-        }
+      DEVX_SET(qpc, qpc, primary_address_path.udp_sport, udp_sport);
+      DEVX_SET(qpc, qpc, primary_address_path.dscp,
+          verbs_qp_attr.ah_attr->traffic_class >> 2);
     }
+  }
 
-    DEVX_SET(qpc, qpc, primary_address_path.pkey_index, verbs_qp_attr.pkey_index);
-    if (verbs_qp_attr.allow_remote_write == 1) {
-        DEVX_SET(qpc, qpc, rwe, 1);
-    }
+  DEVX_SET(qpc, qpc, primary_address_path.pkey_index, verbs_qp_attr.pkey_index);
+  if (verbs_qp_attr.allow_remote_write == 1) {
+    DEVX_SET(qpc, qpc, rwe, 1);
+  }
 
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
-        verbs_qp_attr.allow_remote_read == 1) {
-        DEVX_SET(qpc, qpc, rre, 1);
-    }
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
+    verbs_qp_attr.allow_remote_read == 1) {
+    DEVX_SET(qpc, qpc, rre, 1);
+  }
 
-    if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
-        DEVX_SET(qpc, qpc, rae, 1);
-        DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
-    }
+  if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
+    DEVX_SET(qpc, qpc, rae, 1);
+    DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
+  }
 
-    int mlx5_opt_param_mask{0};
-    convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
-                                                                    DOCA_VERBS_QP_INIT2RTR);
-    DEVX_SET(init2rtr_qp_in, in, opt_param_mask, mlx5_opt_param_mask);
+  int mlx5_opt_param_mask{0};
+  convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
+      DOCA_VERBS_QP_INIT2RTR);
+  DEVX_SET(init2rtr_qp_in, in, opt_param_mask, mlx5_opt_param_mask);
 
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP init2rtr, syndrome=0x%x",
-                 DEVX_GET(nop_out, out, syndrome));
-        return ret;
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP init2rtr, syndrome=0x%x",
+        DEVX_GET(nop_out, out, syndrome));
+    return ret;
+  }
 
-    m_current_state = DOCA_VERBS_QP_STATE_RTR;
-    m_addr_type = verbs_qp_attr.ah_attr->addr_type;
+  m_current_state = DOCA_VERBS_QP_STATE_RTR;
+  m_addr_type = verbs_qp_attr.ah_attr->addr_type;
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to RTR state", this);
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to RTR state", this);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp::rtr2rts(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                    int attr_mask) noexcept {
-    rtr2rts_qp_in in{0};
-    rtr2rts_qp_out out{0};
+    int attr_mask) noexcept {
+  rtr2rts_qp_in in{0};
+  rtr2rts_qp_out out{0};
 
-    if (!is_rtr2rts_attrs_valid(attr_mask, m_qp_type)) {
-        DOCA_LOG(LOG_ERR, "rtr2rts attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (!is_rtr2rts_attrs_valid(attr_mask, m_qp_type)) {
+    DOCA_LOG(LOG_ERR, "rtr2rts attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    void *qpc = MLX5_ADDR_OF(rtr2rts_qp_in, &in, qpc);
-    DEVX_SET(rtr2rts_qp_in, &in, opcode, MLX5_CMD_OP_RTR2RTS_QP);
-    DEVX_SET(rtr2rts_qp_in, &in, qpn, m_qp_num);
-    DEVX_SET(qpc, qpc, next_send_psn, verbs_qp_attr.sq_psn);
-    if (attr_mask & DOCA_VERBS_QP_ATTR_ACK_TIMEOUT)
-        DEVX_SET(qpc, qpc, primary_address_path.ack_timeout, verbs_qp_attr.ack_timeout);
-    if (attr_mask & DOCA_VERBS_QP_ATTR_RETRY_CNT)
-        DEVX_SET(qpc, qpc, retry_count, verbs_qp_attr.retry_cnt);
-    if (attr_mask & DOCA_VERBS_QP_ATTR_RNR_RETRY)
-        DEVX_SET(qpc, qpc, rnr_retry, verbs_qp_attr.rnr_retry);
-    if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
-        DEVX_SET(qpc, qpc, min_rnr_nak, verbs_qp_attr.min_rnr_timer);
-    if (verbs_qp_attr.allow_remote_write == 1) {
-        DEVX_SET(qpc, qpc, rwe, 1);
-    }
-    if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
-        DEVX_SET(qpc, qpc, rae, 1);
-        DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
-    }
+  void *qpc = MLX5_ADDR_OF(rtr2rts_qp_in, &in, qpc);
+  DEVX_SET(rtr2rts_qp_in, &in, opcode, MLX5_CMD_OP_RTR2RTS_QP);
+  DEVX_SET(rtr2rts_qp_in, &in, qpn, m_qp_num);
+  DEVX_SET(qpc, qpc, next_send_psn, verbs_qp_attr.sq_psn);
+  if (attr_mask & DOCA_VERBS_QP_ATTR_ACK_TIMEOUT)
+    DEVX_SET(qpc, qpc, primary_address_path.ack_timeout, verbs_qp_attr.ack_timeout);
+  if (attr_mask & DOCA_VERBS_QP_ATTR_RETRY_CNT)
+    DEVX_SET(qpc, qpc, retry_count, verbs_qp_attr.retry_cnt);
+  if (attr_mask & DOCA_VERBS_QP_ATTR_RNR_RETRY)
+    DEVX_SET(qpc, qpc, rnr_retry, verbs_qp_attr.rnr_retry);
+  if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
+    DEVX_SET(qpc, qpc, min_rnr_nak, verbs_qp_attr.min_rnr_timer);
+  if (verbs_qp_attr.allow_remote_write == 1) {
+    DEVX_SET(qpc, qpc, rwe, 1);
+  }
+  if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
+    DEVX_SET(qpc, qpc, rae, 1);
+    DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
+  }
 
-    DEVX_SET(qpc, qpc, log_ack_req_freq, 0x0);  // 8
+  DEVX_SET(qpc, qpc, log_ack_req_freq, 0x0);  // 8
 
-    int mlx5_opt_param_mask{0};
-    convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
-                                                                    DOCA_VERBS_QP_RTR2RTS);
+  int mlx5_opt_param_mask{0};
+  convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
+      DOCA_VERBS_QP_RTR2RTS);
 
-    DEVX_SET(rtr2rts_qp_in, &in, opt_param_mask, mlx5_opt_param_mask);
+  DEVX_SET(rtr2rts_qp_in, &in, opt_param_mask, mlx5_opt_param_mask);
 
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP rtr2rts");
-        return ret;
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP rtr2rts");
+    return ret;
+  }
 
-    m_current_state = DOCA_VERBS_QP_STATE_RTS;
+  m_current_state = DOCA_VERBS_QP_STATE_RTS;
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to RTS state", this);
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to RTS state", this);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp::rts2rts(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                    int attr_mask) noexcept {
-    if (!is_rts2rts_attrs_valid(attr_mask, m_qp_type)) {
-        DOCA_LOG(LOG_ERR, "rts2rts attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
+    int attr_mask) noexcept {
+  if (!is_rts2rts_attrs_valid(attr_mask, m_qp_type)) {
+    DOCA_LOG(LOG_ERR, "rts2rts attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) && !verbs_qp_attr.ah_attr) {
+    DOCA_LOG(LOG_ERR, "AH_ATTR mask is enabled but ah_attr=nullptr");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+
+  rts2rts_qp_in in{0};
+  rts2rts_qp_out out{0};
+
+  void *qpc = MLX5_ADDR_OF(rts2rts_qp_in, in, qpc);
+  DEVX_SET(rts2rts_qp_in, in, opcode, MLX5_CMD_OP_RTS2RTS_QP);
+  DEVX_SET(rts2rts_qp_in, in, qpn, m_qp_num);
+
+  if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
+    DEVX_SET(qpc, qpc, min_rnr_nak, verbs_qp_attr.min_rnr_timer);
+  if (verbs_qp_attr.allow_remote_write == 1) {
+    DEVX_SET(qpc, qpc, rwe, 1);
+  }
+
+  if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
+    verbs_qp_attr.allow_remote_read == 1) {
+    DEVX_SET(qpc, qpc, rre, 1);
+  }
+  if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
+    DEVX_SET(qpc, qpc, rae, 1);
+    DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
+  }
+
+  if (attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) {
+    DEVX_SET(qpc, qpc, primary_address_path.src_addr_index, verbs_qp_attr.ah_attr->sgid_index);
+
+    if (m_verbs_device_attr->m_is_rts2rts_qp_dscp_supported &&
+        m_verbs_device_attr->m_port_type == MLX5_CAP_PORT_TYPE_ETH) {
+      uint8_t roce_version{};
+      auto status =
+          query_roce_version(m_ibv_ctx, verbs_qp_attr.ah_attr->sgid_index, roce_version);
+      if (status != DOCA_SUCCESS) {
+        DOCA_LOG(LOG_ERR, "Failed to query roce version");
+        return status;
+      }
+
+      if (roce_version >= MLX5_ROCE_ADDR_LAYOUT_ROCE_VERSION_VERSION_2_0)
+        DEVX_SET(qpc, qpc, primary_address_path.dscp,
+            verbs_qp_attr.ah_attr->traffic_class >> 2);
     }
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) && !verbs_qp_attr.ah_attr) {
-        DOCA_LOG(LOG_ERR, "AH_ATTR mask is enabled but ah_attr=nullptr");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  }
 
-    rts2rts_qp_in in{0};
-    rts2rts_qp_out out{0};
+  int mlx5_opt_param_mask{0};
+  convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
+      DOCA_VERBS_QP_RTS2RTS);
 
-    void *qpc = MLX5_ADDR_OF(rts2rts_qp_in, in, qpc);
-    DEVX_SET(rts2rts_qp_in, in, opcode, MLX5_CMD_OP_RTS2RTS_QP);
-    DEVX_SET(rts2rts_qp_in, in, qpn, m_qp_num);
+  DEVX_SET(rts2rts_qp_in, in, opt_param_mask, mlx5_opt_param_mask);
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER)
-        DEVX_SET(qpc, qpc, min_rnr_nak, verbs_qp_attr.min_rnr_timer);
-    if (verbs_qp_attr.allow_remote_write == 1) {
-        DEVX_SET(qpc, qpc, rwe, 1);
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP rts2rts");
+    return ret;
+  }
 
-    if ((attr_mask & DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ) &&
-        verbs_qp_attr.allow_remote_read == 1) {
-        DEVX_SET(qpc, qpc, rre, 1);
-    }
-    if (verbs_qp_attr.allow_remote_atomic > DOCA_VERBS_QP_ATOMIC_MODE_NONE) {
-        DEVX_SET(qpc, qpc, rae, 1);
-        DEVX_SET(qpc, qpc, atomic_mode, verbs_qp_attr.allow_remote_atomic);
-    }
+  m_current_state = DOCA_VERBS_QP_STATE_RTS;
 
-    if (attr_mask & DOCA_VERBS_QP_ATTR_AH_ATTR) {
-        DEVX_SET(qpc, qpc, primary_address_path.src_addr_index, verbs_qp_attr.ah_attr->sgid_index);
+  DOCA_LOG(LOG_INFO, "IB Verbs QP %p: has been successfully moved to RTS state", this);
 
-        if (m_verbs_device_attr->m_is_rts2rts_qp_dscp_supported &&
-            m_verbs_device_attr->m_port_type == MLX5_CAP_PORT_TYPE_ETH) {
-            uint8_t roce_version{};
-            auto status =
-                query_roce_version(m_ibv_ctx, verbs_qp_attr.ah_attr->sgid_index, roce_version);
-            if (status != DOCA_SUCCESS) {
-                DOCA_LOG(LOG_ERR, "Failed to query roce version");
-                return status;
-            }
-
-            if (roce_version >= MLX5_ROCE_ADDR_LAYOUT_ROCE_VERSION_VERSION_2_0)
-                DEVX_SET(qpc, qpc, primary_address_path.dscp,
-                         verbs_qp_attr.ah_attr->traffic_class >> 2);
-        }
-    }
-
-    int mlx5_opt_param_mask{0};
-    convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
-                                                                    DOCA_VERBS_QP_RTS2RTS);
-
-    DEVX_SET(rts2rts_qp_in, in, opt_param_mask, mlx5_opt_param_mask);
-
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP rts2rts");
-        return ret;
-    }
-
-    m_current_state = DOCA_VERBS_QP_STATE_RTS;
-
-    DOCA_LOG(LOG_INFO, "IB Verbs QP %p: has been successfully moved to RTS state", this);
-
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
-doca_error_t doca_verbs_qp::qp2err(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                   int attr_mask) noexcept {
-    qp_2err_in in{0};
-    qp_2err_out out{0};
+doca_error_t doca_verbs_qp::qp2err(struct doca_verbs_qp_attr &/*verbs_qp_attr*/,
+    int attr_mask) noexcept {
+  qp_2err_in in{0};
+  qp_2err_out out{0};
 
-    if (!is_X2err_attrs_valid(attr_mask)) {
-        DOCA_LOG(LOG_ERR, "X2err attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (!is_X2err_attrs_valid(attr_mask)) {
+    DOCA_LOG(LOG_ERR, "X2err attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    DEVX_SET(qp_2err_in, in, opcode, MLX5_CMD_OP_QP_2ERR);
-    DEVX_SET(qp_2err_in, in, qpn, m_qp_num);
+  DEVX_SET(qp_2err_in, in, opcode, MLX5_CMD_OP_QP_2ERR);
+  DEVX_SET(qp_2err_in, in, qpn, m_qp_num);
 
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP 2err");
-        return ret;
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP 2err");
+    return ret;
+  }
 
-    m_current_state = DOCA_VERBS_QP_STATE_ERR;
+  m_current_state = DOCA_VERBS_QP_STATE_ERR;
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Error state", this);
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Error state", this);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
-doca_error_t doca_verbs_qp::qp2rst(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                   int attr_mask) noexcept {
-    qp_2rst_in in{0};
-    qp_2rst_out out{0};
+doca_error_t doca_verbs_qp::qp2rst(struct doca_verbs_qp_attr &/*verbs_qp_attr*/,
+    int attr_mask) noexcept {
+  qp_2rst_in in{0};
+  qp_2rst_out out{0};
 
-    if (!is_X2rst_attrs_valid(attr_mask)) {
-        DOCA_LOG(LOG_ERR, "X2rst attrs are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (!is_X2rst_attrs_valid(attr_mask)) {
+    DOCA_LOG(LOG_ERR, "X2rst attrs are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    DEVX_SET(qp_2rst_in, in, opcode, MLX5_CMD_OP_QP_2RST);
-    DEVX_SET(qp_2rst_in, in, qpn, m_qp_num);
+  DEVX_SET(qp_2rst_in, in, opcode, MLX5_CMD_OP_QP_2RST);
+  DEVX_SET(qp_2rst_in, in, qpn, m_qp_num);
 
-    auto ret =
-        doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to modify QP 2rst");
-        return ret;
-    }
+  auto ret =
+      doca_verbs_wrapper_mlx5dv_devx_obj_modify(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to modify QP 2rst");
+    return ret;
+  }
 
-    m_current_state = DOCA_VERBS_QP_STATE_RST;
+  m_current_state = DOCA_VERBS_QP_STATE_RST;
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Reset state", this);
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to Reset state", this);
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp::query_qp(struct doca_verbs_qp_attr &verbs_qp_attr,
-                                     struct doca_verbs_qp_init_attr &verbs_qp_init_attr) noexcept {
-    query_qp_in in{0};
-    query_qp_out out{0};
+    struct doca_verbs_qp_init_attr &verbs_qp_init_attr) noexcept {
+  query_qp_in in{0};
+  query_qp_out out{0};
 
-    DEVX_SET(query_qp_in, in, opcode, MLX5_CMD_OP_QUERY_QP);
-    DEVX_SET(query_qp_in, in, qpn, m_qp_num);
+  DEVX_SET(query_qp_in, in, opcode, MLX5_CMD_OP_QUERY_QP);
+  DEVX_SET(query_qp_in, in, qpn, m_qp_num);
 
-    auto ret = doca_verbs_wrapper_mlx5dv_devx_obj_query(m_qp_obj, in, sizeof(in), out, sizeof(out));
-    if (ret != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query QP");
-        return DOCA_ERROR_DRIVER;
-    }
+  auto ret = doca_verbs_wrapper_mlx5dv_devx_obj_query(m_qp_obj, in, sizeof(in), out, sizeof(out));
+  if (ret != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query QP");
+    return DOCA_ERROR_DRIVER;
+  }
 
-    /* Set verbs_qp_attr with the QP information */
-    const void *qpc = MLX5_ADDR_OF(query_qp_out, out, qpc);
-    auto prm_qp_state = DEVX_GET(qpc, qpc, state);
+  /* Set verbs_qp_attr with the QP information */
+  const void *qpc = MLX5_ADDR_OF(query_qp_out, out, qpc);
+  auto prm_qp_state = DEVX_GET(qpc, qpc, state);
 
-    auto status =
-        convert_prm_qp_state_to_doca_verbs_qp_state(prm_qp_state, verbs_qp_attr.current_state);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to get state, invalid qp state");
-        return DOCA_ERROR_UNEXPECTED;
-    }
+  auto status =
+      convert_prm_qp_state_to_doca_verbs_qp_state(prm_qp_state, verbs_qp_attr.current_state);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to get state, invalid qp state");
+    return DOCA_ERROR_UNEXPECTED;
+  }
 
-    verbs_qp_attr.next_state = verbs_qp_attr.current_state;
+  verbs_qp_attr.next_state = verbs_qp_attr.current_state;
 
-    auto prm_mtu_size = DEVX_GET(qpc, qpc, mtu);
-    status = convert_prm_mtu_size_to_doca_verbs_mtu_size(prm_mtu_size, verbs_qp_attr.path_mtu);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to get state, invalid MTU size");
-        return DOCA_ERROR_UNEXPECTED;
-    }
+  auto prm_mtu_size = DEVX_GET(qpc, qpc, mtu);
+  status = convert_prm_mtu_size_to_doca_verbs_mtu_size(prm_mtu_size, verbs_qp_attr.path_mtu);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to get state, invalid MTU size");
+    return DOCA_ERROR_UNEXPECTED;
+  }
 
-    verbs_qp_attr.rq_psn = DEVX_GET(qpc, qpc, next_rcv_psn);
-    verbs_qp_attr.sq_psn = DEVX_GET(qpc, qpc, next_send_psn);
-    verbs_qp_attr.dest_qp_num = DEVX_GET(qpc, qpc, remote_qpn);
-    verbs_qp_attr.pkey_index = DEVX_GET(qpc, qpc, primary_address_path.pkey_index);
-    verbs_qp_attr.port_num = DEVX_GET(qpc, qpc, primary_address_path.vhca_port_num);
-    verbs_qp_attr.ack_timeout = DEVX_GET(qpc, qpc, primary_address_path.ack_timeout);
-    verbs_qp_attr.retry_cnt = DEVX_GET(qpc, qpc, retry_count);
-    verbs_qp_attr.rnr_retry = DEVX_GET(qpc, qpc, rnr_retry);
-    verbs_qp_attr.min_rnr_timer = DEVX_GET(qpc, qpc, min_rnr_nak);
-    verbs_qp_attr.allow_remote_write = DEVX_GET(qpc, qpc, rwe);
-    verbs_qp_attr.allow_remote_read = DEVX_GET(qpc, qpc, rre);
-    // verbs_qp_attr.allow_remote_atomic = DEVX_GET(qpc, qpc, rae);
+  verbs_qp_attr.rq_psn = DEVX_GET(qpc, qpc, next_rcv_psn);
+  verbs_qp_attr.sq_psn = DEVX_GET(qpc, qpc, next_send_psn);
+  verbs_qp_attr.dest_qp_num = DEVX_GET(qpc, qpc, remote_qpn);
+  verbs_qp_attr.pkey_index = DEVX_GET(qpc, qpc, primary_address_path.pkey_index);
+  verbs_qp_attr.port_num = DEVX_GET(qpc, qpc, primary_address_path.vhca_port_num);
+  verbs_qp_attr.ack_timeout = DEVX_GET(qpc, qpc, primary_address_path.ack_timeout);
+  verbs_qp_attr.retry_cnt = DEVX_GET(qpc, qpc, retry_count);
+  verbs_qp_attr.rnr_retry = DEVX_GET(qpc, qpc, rnr_retry);
+  verbs_qp_attr.min_rnr_timer = DEVX_GET(qpc, qpc, min_rnr_nak);
+  verbs_qp_attr.allow_remote_write = DEVX_GET(qpc, qpc, rwe);
+  verbs_qp_attr.allow_remote_read = DEVX_GET(qpc, qpc, rre);
+  // verbs_qp_attr.allow_remote_atomic = DEVX_GET(qpc, qpc, rae);
 
-    if (verbs_qp_attr.ah_attr != nullptr) {
-        verbs_qp_attr.ah_attr->addr_type = m_addr_type;
-        verbs_qp_attr.ah_attr->dlid = DEVX_GET(qpc, qpc, primary_address_path.rlid);
-        verbs_qp_attr.ah_attr->sl = DEVX_GET(qpc, qpc, primary_address_path.sl);
-        verbs_qp_attr.ah_attr->sgid_index = DEVX_GET(qpc, qpc, primary_address_path.src_addr_index);
-        verbs_qp_attr.ah_attr->static_rate = DEVX_GET(qpc, qpc, primary_address_path.stat_rate);
-        verbs_qp_attr.ah_attr->hop_limit = DEVX_GET(qpc, qpc, primary_address_path.hop_limit);
-        verbs_qp_attr.ah_attr->traffic_class = DEVX_GET(qpc, qpc, primary_address_path.tclass);
+  if (verbs_qp_attr.ah_attr != nullptr) {
+    verbs_qp_attr.ah_attr->addr_type = m_addr_type;
+    verbs_qp_attr.ah_attr->dlid = DEVX_GET(qpc, qpc, primary_address_path.rlid);
+    verbs_qp_attr.ah_attr->sl = DEVX_GET(qpc, qpc, primary_address_path.sl);
+    verbs_qp_attr.ah_attr->sgid_index = DEVX_GET(qpc, qpc, primary_address_path.src_addr_index);
+    verbs_qp_attr.ah_attr->static_rate = DEVX_GET(qpc, qpc, primary_address_path.stat_rate);
+    verbs_qp_attr.ah_attr->hop_limit = DEVX_GET(qpc, qpc, primary_address_path.hop_limit);
+    verbs_qp_attr.ah_attr->traffic_class = DEVX_GET(qpc, qpc, primary_address_path.tclass);
 
-        memcpy(verbs_qp_attr.ah_attr->gid.raw,
-               MLX5_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
-               sizeof(struct doca_verbs_gid));
-    }
+    memcpy(verbs_qp_attr.ah_attr->gid.raw,
+        MLX5_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
+        sizeof(struct doca_verbs_gid));
+  }
 
-    /* Set verbs_qp_init_attr with the QP information */
-    verbs_qp_init_attr.send_cq = m_init_attr.send_cq;
-    verbs_qp_init_attr.receive_cq = m_init_attr.receive_cq;
-    verbs_qp_init_attr.sq_sig_all = m_init_attr.sq_sig_all;
-    verbs_qp_init_attr.qp_context = m_init_attr.qp_context;
-    verbs_qp_init_attr.pd = m_pd;
-    verbs_qp_init_attr.sq_wr = m_sq_size_wr;
-    verbs_qp_init_attr.rq_wr = m_rq_size;
-    verbs_qp_init_attr.receive_max_sges = m_rcv_max_sges;
-    verbs_qp_init_attr.user_index = DEVX_GET(qpc, qpc, user_index);
-    verbs_qp_init_attr.qp_type = m_qp_type;
-    verbs_qp_init_attr.send_max_sges = m_send_max_sges;
-    verbs_qp_init_attr.max_inline_data = m_init_attr.max_inline_data;
-    verbs_qp_init_attr.external_umem = m_init_attr.external_umem;
-    verbs_qp_init_attr.external_umem_offset = m_init_attr.external_umem_offset;
-    verbs_qp_init_attr.external_uar = m_init_attr.external_uar;
-    verbs_qp_init_attr.core_direct_master = m_init_attr.core_direct_master;
-    verbs_qp_init_attr.send_dbr_mode = m_init_attr.send_dbr_mode;
+  /* Set verbs_qp_init_attr with the QP information */
+  verbs_qp_init_attr.send_cq = m_init_attr.send_cq;
+  verbs_qp_init_attr.receive_cq = m_init_attr.receive_cq;
+  verbs_qp_init_attr.sq_sig_all = m_init_attr.sq_sig_all;
+  verbs_qp_init_attr.qp_context = m_init_attr.qp_context;
+  verbs_qp_init_attr.pd = m_pd;
+  verbs_qp_init_attr.sq_wr = m_sq_size_wr;
+  verbs_qp_init_attr.rq_wr = m_rq_size;
+  verbs_qp_init_attr.receive_max_sges = m_rcv_max_sges;
+  verbs_qp_init_attr.user_index = DEVX_GET(qpc, qpc, user_index);
+  verbs_qp_init_attr.qp_type = m_qp_type;
+  verbs_qp_init_attr.send_max_sges = m_send_max_sges;
+  verbs_qp_init_attr.max_inline_data = m_init_attr.max_inline_data;
+  verbs_qp_init_attr.external_umem = m_init_attr.external_umem;
+  verbs_qp_init_attr.external_umem_offset = m_init_attr.external_umem_offset;
+  verbs_qp_init_attr.external_uar = m_init_attr.external_uar;
+  verbs_qp_init_attr.core_direct_master = m_init_attr.core_direct_master;
+  verbs_qp_init_attr.send_dbr_mode = m_init_attr.send_dbr_mode;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 void doca_verbs_qp::create(struct ibv_context *ibv_ctx) {
-    auto status{DOCA_SUCCESS};
-    m_ibv_ctx = ibv_ctx;
-    m_pd = m_init_attr.pd;
+  auto status{DOCA_SUCCESS};
+  m_ibv_ctx = ibv_ctx;
+  m_pd = m_init_attr.pd;
 
-    if ((m_init_attr.external_umem != nullptr && m_init_attr.external_umem_dbr == nullptr) ||
-        (m_init_attr.external_umem == nullptr && m_init_attr.external_umem_dbr != nullptr)) {
-        DOCA_LOG(LOG_ERR, "Both UMEM should be either external or internal");
-        throw DOCA_ERROR_INVALID_VALUE;
+  if ((m_init_attr.external_umem != nullptr && m_init_attr.external_umem_dbr == nullptr) ||
+    (m_init_attr.external_umem == nullptr && m_init_attr.external_umem_dbr != nullptr)) {
+    DOCA_LOG(LOG_ERR, "Both UMEM should be either external or internal");
+    throw DOCA_ERROR_INVALID_VALUE;
+  }
+
+  /* Query device attr */
+  status = doca_verbs_query_device(ibv_ctx, &m_verbs_device_attr);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to query device attr");
+    throw DOCA_ERROR_INVALID_VALUE;
+  }
+
+  if (m_init_attr.qp_type != DOCA_VERBS_QP_TYPE_RC) {
+    DOCA_LOG(LOG_ERR, "QP type is not valid");
+    throw DOCA_ERROR_INVALID_VALUE;
+  }
+
+  if ((m_init_attr.send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT) &&
+    (m_verbs_device_attr->m_send_dbr_mode_no_dbr_ext == 0)) {
+    DOCA_LOG(LOG_ERR, "No DBR-ext support is not supported by the device");
+    throw DOCA_ERROR_NOT_SUPPORTED;
+  }
+
+  if (m_init_attr.emulate_no_dbr_ext &&
+      m_init_attr.send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT) {
+    DOCA_LOG(LOG_ERR, "emulate_no_dbr_ext and send_dbr_mode NO_DBR_EXT are not compatible");
+    throw DOCA_ERROR_INVALID_VALUE;
+  }
+
+  uint32_t log_rq_size{0};
+  uint32_t log_stride{0};
+  uint32_t log_sq_size_wqebb{0};
+
+  /* Calculate Work Queue sizes */
+  if (m_init_attr.rq_wr > 0 && m_init_attr.srq == nullptr) {
+    if (m_init_attr.rq_wr > m_verbs_device_attr->m_max_qp_wr) {
+      DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: rq_wr is too big");
+      throw DOCA_ERROR_INVALID_VALUE;
     }
-
-    /* Query device attr */
-    status = doca_verbs_query_device(ibv_ctx, &m_verbs_device_attr);
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to query device attr");
-        throw DOCA_ERROR_INVALID_VALUE;
+    if (m_init_attr.receive_max_sges == 0) {
+      DOCA_LOG(
+          LOG_ERR,
+          "Failed to create IB Verbs QP: rq_wr is greater than 0 but receive_max_sges is 0");
+      throw DOCA_ERROR_INVALID_VALUE;
     }
-
-    if (m_init_attr.qp_type != DOCA_VERBS_QP_TYPE_RC) {
-        DOCA_LOG(LOG_ERR, "QP type is not valid");
-        throw DOCA_ERROR_INVALID_VALUE;
+    m_rcv_max_sges = doca_internal_utils_next_power_of_two(m_init_attr.receive_max_sges);
+    /* Calculate receive_wqe size */
+    m_rcv_wqe_size = m_rcv_max_sges * DOCA_VERBS_DATA_SEG_SIZE_IN_BYTES;
+    if (m_rcv_wqe_size > m_verbs_device_attr->m_max_rq_desc_size) {
+      DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: rcv_max_sges is too big");
+      throw DOCA_ERROR_INVALID_VALUE;
     }
+    m_log_rcv_wqe_size = static_cast<uint8_t>(doca_internal_utils_log2(m_rcv_wqe_size));
+    log_stride = m_log_rcv_wqe_size - sc_verbs_qp_log_rq_stride_shift;
 
-    if ((m_init_attr.send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT) &&
-        (m_verbs_device_attr->m_send_dbr_mode_no_dbr_ext == 0)) {
-        DOCA_LOG(LOG_ERR, "No DBR-ext support is not supported by the device");
-        throw DOCA_ERROR_NOT_SUPPORTED;
-    }
-
-    if (m_init_attr.emulate_no_dbr_ext &&
-        m_init_attr.send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_NO_DBR_EXT) {
-        DOCA_LOG(LOG_ERR, "emulate_no_dbr_ext and send_dbr_mode NO_DBR_EXT are not compatible");
-        throw DOCA_ERROR_INVALID_VALUE;
-    }
-
-    uint32_t log_rq_size{0};
-    uint32_t log_stride{0};
-    uint32_t log_sq_size_wqebb{0};
-
-    /* Calculate Work Queue sizes */
-    if (m_init_attr.rq_wr > 0 && m_init_attr.srq == nullptr) {
-        if (m_init_attr.rq_wr > m_verbs_device_attr->m_max_qp_wr) {
-            DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: rq_wr is too big");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
-        if (m_init_attr.receive_max_sges == 0) {
-            DOCA_LOG(
-                LOG_ERR,
-                "Failed to create IB Verbs QP: rq_wr is greater than 0 but receive_max_sges is 0");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
-        m_rcv_max_sges = doca_internal_utils_next_power_of_two(m_init_attr.receive_max_sges);
-        /* Calculate receive_wqe size */
-        m_rcv_wqe_size = m_rcv_max_sges * DOCA_VERBS_DATA_SEG_SIZE_IN_BYTES;
-        if (m_rcv_wqe_size > m_verbs_device_attr->m_max_rq_desc_size) {
-            DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: rcv_max_sges is too big");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
-        m_log_rcv_wqe_size = static_cast<uint8_t>(doca_internal_utils_log2(m_rcv_wqe_size));
-        log_stride = m_log_rcv_wqe_size - sc_verbs_qp_log_rq_stride_shift;
-
-        /* Calculate RQ size in bytes */
-        auto rq_size_bytes = static_cast<uint32_t>(
+    /* Calculate RQ size in bytes */
+    auto rq_size_bytes = static_cast<uint32_t>(
             doca_internal_utils_next_power_of_two(m_init_attr.rq_wr * m_rcv_wqe_size));
-        /* Minimum size of RQ is 64 bytes */
-        rq_size_bytes = MAX(rq_size_bytes, DOCA_VERBS_WQEBB_SIZE);
-        /* Calculate RQ size in receive_wqe units */
-        m_rq_size = rq_size_bytes / m_rcv_wqe_size;
-        log_rq_size = doca_internal_utils_log2(m_rq_size);
+    /* Minimum size of RQ is 64 bytes */
+    rq_size_bytes = MAX(rq_size_bytes, DOCA_VERBS_WQEBB_SIZE);
+    /* Calculate RQ size in receive_wqe units */
+    m_rq_size = rq_size_bytes / m_rcv_wqe_size;
+    log_rq_size = doca_internal_utils_log2(m_rq_size);
+  }
+
+  if (m_init_attr.sq_wr > 0) {
+    // This check is done in rdma-core
+    if (m_init_attr.sq_wr > (0x7fffffff / m_verbs_device_attr->m_max_sq_desc_size)) {
+      DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: sq_wr is too big");
+      throw DOCA_ERROR_INVALID_VALUE;
+    }
+    if (m_init_attr.send_max_sges == 0) {
+      DOCA_LOG(
+          LOG_ERR,
+          "Failed to create IB Verbs QP: sq_wr is greater than 0 but send_max_sges is 0");
+      throw DOCA_ERROR_INVALID_VALUE;
+    }
+    m_send_max_sges = m_init_attr.send_max_sges;
+    /* Calculate Send WQE size, which is the size of one control segment, size of one rdma
+     * segment and a single data segment multiplied by the maximum number of send SGEs */
+    uint32_t send_wqe_size =
+        sizeof(struct doca_gpunetio_ib_mlx5_wqe_ctrl_seg) +
+        sizeof(struct doca_gpunetio_ib_mlx5_wqe_raddr_seg) +
+        (m_init_attr.send_max_sges * sizeof(struct doca_gpunetio_ib_mlx5_wqe_data_seg));
+    if (send_wqe_size > m_verbs_device_attr->m_max_sq_desc_size) {
+      DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: send_max_sges is too big");
+      throw DOCA_ERROR_INVALID_VALUE;
     }
 
-    if (m_init_attr.sq_wr > 0) {
-        // This check is done in rdma-core
-        if (m_init_attr.sq_wr > (0x7fffffff / m_verbs_device_attr->m_max_sq_desc_size)) {
-            DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: sq_wr is too big");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
-        if (m_init_attr.send_max_sges == 0) {
-            DOCA_LOG(
-                LOG_ERR,
-                "Failed to create IB Verbs QP: sq_wr is greater than 0 but send_max_sges is 0");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
-        m_send_max_sges = m_init_attr.send_max_sges;
-        /* Calculate Send WQE size, which is the size of one control segment, size of one rdma
-         * segment and a single data segment multiplied by the maximum number of send SGEs */
-        uint32_t send_wqe_size =
-            sizeof(struct doca_gpunetio_ib_mlx5_wqe_ctrl_seg) +
-            sizeof(struct doca_gpunetio_ib_mlx5_wqe_raddr_seg) +
-            (m_init_attr.send_max_sges * sizeof(struct doca_gpunetio_ib_mlx5_wqe_data_seg));
-        if (send_wqe_size > m_verbs_device_attr->m_max_sq_desc_size) {
-            DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: send_max_sges is too big");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
+    uint32_t send_wqe_inline_size{};
+    if (m_init_attr.max_inline_data > 0) {
+      /* Calculate inline data segment size, which is composed of:
+       * - size of mlx5_wqe_inl_data_seg (4 Bytes for byte_count and is_inline
+       * attributes)
+       * - max_inline_data size */
+      uint32_t inline_data_seg_size =
+          sizeof(struct doca_gpunetio_ib_mlx5_wqe_inl_data_seg) + m_init_attr.max_inline_data;
+      /* Align the size to OCTOWORD_SIZE (16 bytes) */
+      inline_data_seg_size =
+          doca_internal_utils_align_up_uint64(inline_data_seg_size, DOCA_VERBS_OCTOWORD_SIZE);
+      /* Calculate Send WQE with inline data size, which is the size of one control
+       * segment, size of one rdma segment and the total inline data segment size */
+      send_wqe_inline_size = sizeof(struct doca_gpunetio_ib_mlx5_wqe_ctrl_seg) +
+          sizeof(struct doca_gpunetio_ib_mlx5_wqe_raddr_seg) +
+          inline_data_seg_size;
+      if (send_wqe_inline_size > m_verbs_device_attr->m_max_sq_desc_size) {
+        DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: max_inline_data is too big");
+        throw DOCA_ERROR_INVALID_VALUE;
+      }
+    }
 
-        uint32_t send_wqe_inline_size{};
-        if (m_init_attr.max_inline_data > 0) {
-            /* Calculate inline data segment size, which is composed of:
-             * - size of mlx5_wqe_inl_data_seg (4 Bytes for byte_count and is_inline
-             * attributes)
-             * - max_inline_data size */
-            uint32_t inline_data_seg_size =
-                sizeof(struct doca_gpunetio_ib_mlx5_wqe_inl_data_seg) + m_init_attr.max_inline_data;
-            /* Align the size to OCTOWORD_SIZE (16 bytes) */
-            inline_data_seg_size =
-                doca_internal_utils_align_up_uint64(inline_data_seg_size, DOCA_VERBS_OCTOWORD_SIZE);
-            /* Calculate Send WQE with inline data size, which is the size of one control
-             * segment, size of one rdma segment and the total inline data segment size */
-            send_wqe_inline_size = sizeof(struct doca_gpunetio_ib_mlx5_wqe_ctrl_seg) +
-                                   sizeof(struct doca_gpunetio_ib_mlx5_wqe_raddr_seg) +
-                                   inline_data_seg_size;
-            if (send_wqe_inline_size > m_verbs_device_attr->m_max_sq_desc_size) {
-                DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: max_inline_data is too big");
-                throw DOCA_ERROR_INVALID_VALUE;
-            }
-        }
+    /* Set m_send_wqe_size to the maximum value between the sizes of send_wqe_size and
+     * send_wqe_inline_size
+     */
+    m_send_wqe_size = MAX(send_wqe_size, send_wqe_inline_size);
 
-        /* Set m_send_wqe_size to the maximum value between the sizes of send_wqe_size and
-         * send_wqe_inline_size
-         */
-        m_send_wqe_size = MAX(send_wqe_size, send_wqe_inline_size);
-
-        /* Align size of send_wqe_size to WQEBB size */
-        m_send_wqe_size =
-            doca_internal_utils_align_up_uint32(m_send_wqe_size, DOCA_VERBS_WQEBB_SIZE);
-        /* Calculate sq_size in bytes */
-        auto sq_size_bytes = static_cast<uint32_t>(
+    /* Align size of send_wqe_size to WQEBB size */
+    m_send_wqe_size =
+        doca_internal_utils_align_up_uint32(m_send_wqe_size, DOCA_VERBS_WQEBB_SIZE);
+    /* Calculate sq_size in bytes */
+    auto sq_size_bytes = static_cast<uint32_t>(
             doca_internal_utils_next_power_of_two(m_send_wqe_size * m_init_attr.sq_wr));
-        /* Calculate sq_size in wqebb units */
-        m_sq_size_wqebb = sq_size_bytes / DOCA_VERBS_WQEBB_SIZE;
-        if (m_sq_size_wqebb > m_verbs_device_attr->m_max_send_wqebb) {
-            DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: sq_wr is too big");
-            throw DOCA_ERROR_INVALID_VALUE;
-        }
-        log_sq_size_wqebb = doca_internal_utils_log2(m_sq_size_wqebb);
-        /* Calculate sq_size in Work Request units */
-        m_sq_size_wr = sq_size_bytes / m_send_wqe_size;
-
-        /* Due to alignments we may have more space for inline data */
-        if (m_init_attr.max_inline_data > 0) {
-            m_init_attr.max_inline_data =
-                m_send_wqe_size - (sizeof(struct doca_gpunetio_ib_mlx5_wqe_ctrl_seg) +
-                                   sizeof(struct doca_gpunetio_ib_mlx5_wqe_raddr_seg) +
-                                   sizeof(struct doca_gpunetio_ib_mlx5_wqe_inl_data_seg));
-            m_max_inline_data_length = m_init_attr.max_inline_data;
-        }
+    /* Calculate sq_size in wqebb units */
+    m_sq_size_wqebb = sq_size_bytes / DOCA_VERBS_WQEBB_SIZE;
+    if (m_sq_size_wqebb > m_verbs_device_attr->m_max_send_wqebb) {
+      DOCA_LOG(LOG_ERR, "Failed to create IB Verbs QP: sq_wr is too big");
+      throw DOCA_ERROR_INVALID_VALUE;
     }
+    log_sq_size_wqebb = doca_internal_utils_log2(m_sq_size_wqebb);
+    /* Calculate sq_size in Work Request units */
+    m_sq_size_wr = sq_size_bytes / m_send_wqe_size;
 
-    uint32_t uar_id{};
-    if (m_init_attr.external_uar == nullptr) {
-        /* Case of internal UAR */
-        auto uar_status = doca_verbs_wrapper_mlx5dv_devx_alloc_uar(
+    /* Due to alignments we may have more space for inline data */
+    if (m_init_attr.max_inline_data > 0) {
+      m_init_attr.max_inline_data =
+          m_send_wqe_size - (sizeof(struct doca_gpunetio_ib_mlx5_wqe_ctrl_seg) +
+        sizeof(struct doca_gpunetio_ib_mlx5_wqe_raddr_seg) +
+        sizeof(struct doca_gpunetio_ib_mlx5_wqe_inl_data_seg));
+      m_max_inline_data_length = m_init_attr.max_inline_data;
+    }
+  }
+
+  uint32_t uar_id{};
+  if (m_init_attr.external_uar == nullptr) {
+    /* Case of internal UAR */
+    auto uar_status = doca_verbs_wrapper_mlx5dv_devx_alloc_uar(
             m_ibv_ctx, MLX5DV_UAR_ALLOC_TYPE_BF, &m_uar_obj);
-        if (uar_status != DOCA_SUCCESS) {
-            uar_status = doca_verbs_wrapper_mlx5dv_devx_alloc_uar(
-                m_ibv_ctx, MLX5DV_UAR_ALLOC_TYPE_NC, &m_uar_obj);
-            if (uar_status != DOCA_SUCCESS) {
-                DOCA_LOG(LOG_ERR, "Failed to create UAR");
-                throw DOCA_ERROR_DRIVER;
-            }
-        }
-
-        m_uar_db_reg = reinterpret_cast<uint64_t *>(m_uar_obj->reg_addr);
-        uar_id = m_uar_obj->page_id;
-    } else {
-        /* Case of external UAR */
-        status = doca_verbs_uar_id_get(m_init_attr.external_uar, &uar_id);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get external UAR ID");
-            throw status;
-        }
-
-        void *reg_addr{};
-        if (m_init_attr.send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_DBR_VALID) {
-            status = doca_verbs_uar_reg_addr_get(m_init_attr.external_uar, &reg_addr);
-        } else {
-            status = doca_verbs_uar_dbr_less_addr_get(m_init_attr.external_uar, &reg_addr);
-        }
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get external UAR reg_addr");
-            throw status;
-        }
-        m_uar_db_reg = reinterpret_cast<uint64_t *>(reg_addr);
+    if (uar_status != DOCA_SUCCESS) {
+      uar_status = doca_verbs_wrapper_mlx5dv_devx_alloc_uar(
+              m_ibv_ctx, MLX5DV_UAR_ALLOC_TYPE_NC, &m_uar_obj);
+      if (uar_status != DOCA_SUCCESS) {
+        DOCA_LOG(LOG_ERR, "Failed to create UAR");
+        throw DOCA_ERROR_DRIVER;
+      }
     }
 
-    uint32_t dbr_umem_id{0};
-    uint64_t dbr_umem_offset{0};
-    uint32_t wq_umem_id{0};
+    m_uar_db_reg = reinterpret_cast<uint64_t *>(m_uar_obj->reg_addr);
+    uar_id = m_uar_obj->page_id;
+  } else {
+    /* Case of external UAR */
+    status = doca_verbs_uar_id_get(m_init_attr.external_uar, &uar_id);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to get external UAR ID");
+      throw status;
+    }
 
-    if (m_init_attr.external_umem == nullptr) {
-        auto db_umem_offset =
-            (m_rq_size * m_rcv_wqe_size) + (m_sq_size_wqebb * DOCA_VERBS_WQEBB_SIZE);
-        /* Align the Work Queue size to cacheline size for better performance */
-        db_umem_offset =
-            doca_internal_utils_align_up_uint32(db_umem_offset, DOCA_VERBS_CACHELINE_SIZE);
+    void *reg_addr{};
+    if (m_init_attr.send_dbr_mode == DOCA_VERBS_QP_SEND_DBR_MODE_DBR_VALID) {
+      status = doca_verbs_uar_reg_addr_get(m_init_attr.external_uar, &reg_addr);
+    } else {
+      status = doca_verbs_uar_dbr_less_addr_get(m_init_attr.external_uar, &reg_addr);
+    }
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to get external UAR reg_addr");
+      throw status;
+    }
+    m_uar_db_reg = reinterpret_cast<uint64_t *>(reg_addr);
+  }
 
-        /* Case of internal umem */
-        auto total_umem_size = doca_internal_utils_align_up_uint32(
+  uint32_t dbr_umem_id{0};
+  uint64_t dbr_umem_offset{0};
+  uint32_t wq_umem_id{0};
+
+  if (m_init_attr.external_umem == nullptr) {
+    auto db_umem_offset =
+        (m_rq_size * m_rcv_wqe_size) + (m_sq_size_wqebb * DOCA_VERBS_WQEBB_SIZE);
+    /* Align the Work Queue size to cacheline size for better performance */
+    db_umem_offset =
+        doca_internal_utils_align_up_uint32(db_umem_offset, DOCA_VERBS_CACHELINE_SIZE);
+
+    /* Case of internal umem */
+    auto total_umem_size = doca_internal_utils_align_up_uint32(
             db_umem_offset + sc_verbs_qp_doorbell_size, DOCA_VERBS_PAGE_SIZE);
 
-        m_umem_buf = (uint8_t *)memalign(DOCA_VERBS_PAGE_SIZE, total_umem_size);
+    m_umem_buf = (uint8_t *)memalign(DOCA_VERBS_PAGE_SIZE, total_umem_size);
 
-        memset(m_umem_buf, 0, total_umem_size);
+    memset(m_umem_buf, 0, total_umem_size);
 
-        m_wq_buf = m_umem_buf;
-        m_rq_buf = m_wq_buf;
-        m_sq_buf = m_wq_buf + ((uintptr_t)m_rq_size << m_log_rcv_wqe_size);
+    m_wq_buf = m_umem_buf;
+    m_rq_buf = m_wq_buf;
+    m_sq_buf = m_wq_buf + ((uintptr_t)m_rq_size << m_log_rcv_wqe_size);
 
-        auto umem_status = doca_verbs_wrapper_mlx5dv_devx_umem_reg(m_ibv_ctx, m_wq_buf,
-                                                                   total_umem_size, 0, &m_umem_obj);
-        if (umem_status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to create QP UMEM");
-            throw DOCA_ERROR_DRIVER;
-        }
-
-        wq_umem_id = m_umem_obj->umem_id;
-        dbr_umem_offset = db_umem_offset;
-        dbr_umem_id = wq_umem_id;
-
-        m_db_buffer = reinterpret_cast<uint32_t *>(m_wq_buf + db_umem_offset);
-    } else {
-        uint8_t *tmp_db_buffer;
-
-        /* Case of external umem for wq and dbr */
-        status = doca_verbs_umem_get_address(m_init_attr.external_umem,
-                                             reinterpret_cast<void **>(&m_wq_buf));
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get external umem address");
-            throw status;
-        }
-
-        m_wq_buf += m_init_attr.external_umem_offset;
-        m_rq_buf = m_wq_buf;
-        m_sq_buf = m_wq_buf + ((uintptr_t)m_rq_size << m_log_rcv_wqe_size);
-
-        status = doca_verbs_umem_get_id(m_init_attr.external_umem, &wq_umem_id);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get external umem id");
-            throw status;
-        }
-
-        /* Case of external umem */
-        status = doca_verbs_umem_get_address(m_init_attr.external_umem_dbr,
-                                             reinterpret_cast<void **>(&tmp_db_buffer));
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get external umem address");
-            throw status;
-        }
-
-        status = doca_verbs_umem_get_id(m_init_attr.external_umem_dbr, &dbr_umem_id);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to get external umem id");
-            throw status;
-        }
-
-        dbr_umem_offset = m_init_attr.external_umem_dbr_offset;
-        m_db_buffer = reinterpret_cast<uint32_t *>(tmp_db_buffer + dbr_umem_offset);
+    auto umem_status = doca_verbs_wrapper_mlx5dv_devx_umem_reg(m_ibv_ctx, m_wq_buf,
+            total_umem_size, 0, &m_umem_obj);
+    if (umem_status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to create QP UMEM");
+      throw DOCA_ERROR_DRIVER;
     }
 
-    /* Create QP object */
-    status = create_qp_obj(uar_id, log_rq_size, log_sq_size_wqebb, log_stride, dbr_umem_offset,
-                           dbr_umem_id, wq_umem_id, m_init_attr);
+    wq_umem_id = m_umem_obj->umem_id;
+    dbr_umem_offset = db_umem_offset;
+    dbr_umem_id = wq_umem_id;
+
+    m_db_buffer = reinterpret_cast<uint32_t *>(m_wq_buf + db_umem_offset);
+  } else {
+    uint8_t *tmp_db_buffer;
+
+    /* Case of external umem for wq and dbr */
+    status = doca_verbs_umem_get_address(m_init_attr.external_umem,
+            reinterpret_cast<void **>(&m_wq_buf));
     if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_ERR, "Failed to create QP object");
-        throw DOCA_ERROR_DRIVER;
+      DOCA_LOG(LOG_ERR, "Failed to get external umem address");
+      throw status;
     }
 
-    DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully created", this);
+    m_wq_buf += m_init_attr.external_umem_offset;
+    m_rq_buf = m_wq_buf;
+    m_sq_buf = m_wq_buf + ((uintptr_t)m_rq_size << m_log_rcv_wqe_size);
+
+    status = doca_verbs_umem_get_id(m_init_attr.external_umem, &wq_umem_id);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to get external umem id");
+      throw status;
+    }
+
+    /* Case of external umem */
+    status = doca_verbs_umem_get_address(m_init_attr.external_umem_dbr,
+            reinterpret_cast<void **>(&tmp_db_buffer));
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to get external umem address");
+      throw status;
+    }
+
+    status = doca_verbs_umem_get_id(m_init_attr.external_umem_dbr, &dbr_umem_id);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to get external umem id");
+      throw status;
+    }
+
+    dbr_umem_offset = m_init_attr.external_umem_dbr_offset;
+    m_db_buffer = reinterpret_cast<uint32_t *>(tmp_db_buffer + dbr_umem_offset);
+  }
+
+  /* Create QP object */
+  status = create_qp_obj(uar_id, log_rq_size, log_sq_size_wqebb, log_stride, dbr_umem_offset,
+          dbr_umem_id, wq_umem_id, m_init_attr);
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_ERR, "Failed to create QP object");
+    throw DOCA_ERROR_DRIVER;
+  }
+
+  DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully created", this);
 }
 
 doca_error_t doca_verbs_qp::destroy() noexcept {
-    doca_error_t ret = DOCA_SUCCESS;
+  doca_error_t ret = DOCA_SUCCESS;
 
-    if (m_verbs_device_attr) {
-        auto status = doca_verbs_device_attr_free(m_verbs_device_attr);
-        if (status != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to free device attr");
-            return DOCA_ERROR_INVALID_VALUE;
-        }
-        m_verbs_device_attr = nullptr;
+  if (m_verbs_device_attr) {
+    auto status = doca_verbs_device_attr_free(m_verbs_device_attr);
+    if (status != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to free device attr");
+      return DOCA_ERROR_INVALID_VALUE;
     }
+    m_verbs_device_attr = nullptr;
+  }
 
-    if (m_qp_obj) {
-        ret = doca_verbs_wrapper_mlx5dv_devx_obj_destroy(m_qp_obj);
-        if (ret != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to destroy QP object");
-            return DOCA_ERROR_DRIVER;
-        }
-        m_qp_obj = nullptr;
+  if (m_qp_obj) {
+    ret = doca_verbs_wrapper_mlx5dv_devx_obj_destroy(m_qp_obj);
+    if (ret != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to destroy QP object");
+      return DOCA_ERROR_DRIVER;
     }
+    m_qp_obj = nullptr;
+  }
 
-    if (m_uar_obj) {
-        doca_verbs_wrapper_mlx5dv_devx_free_uar(m_uar_obj);
-        m_uar_obj = nullptr;
+  if (m_uar_obj) {
+    doca_verbs_wrapper_mlx5dv_devx_free_uar(m_uar_obj);
+    m_uar_obj = nullptr;
+  }
+
+  if (m_umem_obj) {
+    ret = doca_verbs_wrapper_mlx5dv_devx_umem_dereg(m_umem_obj);
+    if (ret != DOCA_SUCCESS) {
+      DOCA_LOG(LOG_ERR, "Failed to destroy UMEM object");
+      return DOCA_ERROR_DRIVER;
     }
+    m_umem_obj = nullptr;
+  }
 
-    if (m_umem_obj) {
-        ret = doca_verbs_wrapper_mlx5dv_devx_umem_dereg(m_umem_obj);
-        if (ret != DOCA_SUCCESS) {
-            DOCA_LOG(LOG_ERR, "Failed to destroy UMEM object");
-            return DOCA_ERROR_DRIVER;
-        }
-        m_umem_obj = nullptr;
-    }
+  if (m_umem_buf) {
+    free(m_umem_buf);
+    m_umem_buf = nullptr;
+  }
 
-    if (m_umem_buf) {
-        free(m_umem_buf);
-        m_umem_buf = nullptr;
-    }
-
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_verbs_qp::doca_verbs_qp(struct ibv_context *ibv_ctx,
-                             struct doca_verbs_qp_init_attr &verbs_qp_init_attr)
-    : m_ibv_ctx(ibv_ctx), m_init_attr(verbs_qp_init_attr) {
-    try {
-        create(ibv_ctx);
-    } catch (...) {
-        (void)destroy();
-        DOCA_LOG(LOG_ERR, "Failed to create QP");
-        throw;
-    }
+    struct doca_verbs_qp_init_attr &verbs_qp_init_attr)
+  : m_ibv_ctx(ibv_ctx), m_init_attr(verbs_qp_init_attr) {
+  try {
+    create(ibv_ctx);
+  } catch (...) {
+    (void)destroy();
+    DOCA_LOG(LOG_ERR, "Failed to create QP");
+    throw;
+  }
 }
 
 doca_verbs_qp::~doca_verbs_qp() { static_cast<void>(destroy()); }
@@ -1569,7 +1569,7 @@ void *doca_verbs_qp::get_dbr_addr() const noexcept { return (void *)m_db_buffer;
 void *doca_verbs_qp::get_uar_addr() const noexcept { return (void *)m_uar_db_reg; }
 
 enum doca_verbs_uar_allocation_type doca_verbs_qp::get_uar_mtype() const noexcept {
-    return m_init_attr.external_uar->get_uar_mtype();
+  return m_init_attr.external_uar->get_uar_mtype();
 }
 
 void *doca_verbs_qp::get_sq_buf() const noexcept { return m_sq_buf; }
@@ -1583,11 +1583,11 @@ uint32_t doca_verbs_qp::get_rq_size() const noexcept { return m_rq_size; }
 uint32_t doca_verbs_qp::get_rcv_wqe_size() const noexcept { return m_rcv_wqe_size; }
 
 enum doca_verbs_qp_send_dbr_mode doca_verbs_qp::get_send_dbr_mode() const noexcept {
-    return static_cast<enum doca_verbs_qp_send_dbr_mode>(m_init_attr.send_dbr_mode);
+  return static_cast<enum doca_verbs_qp_send_dbr_mode>(m_init_attr.send_dbr_mode);
 }
 
 bool doca_verbs_qp::get_emulate_no_dbr_ext() const noexcept {
-    return m_init_attr.emulate_no_dbr_ext;
+  return m_init_attr.emulate_no_dbr_ext;
 }
 
 /**********************************************************************************************************************
@@ -1595,1234 +1595,1234 @@ bool doca_verbs_qp::get_emulate_no_dbr_ext() const noexcept {
  *********************************************************************************************************************/
 
 doca_error_t doca_verbs_qp_init_attr_create(struct doca_verbs_qp_init_attr **verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create qp_init_attr: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create qp_init_attr: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    *verbs_qp_init_attr =
-        (struct doca_verbs_qp_init_attr *)calloc(1, sizeof(struct doca_verbs_qp_init_attr));
-    if (*verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create qp_init_attr: failed to allocate memory");
-        return DOCA_ERROR_NO_MEMORY;
-    }
+  *verbs_qp_init_attr =
+      (struct doca_verbs_qp_init_attr *)calloc(1, sizeof(struct doca_verbs_qp_init_attr));
+  if (*verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create qp_init_attr: failed to allocate memory");
+    return DOCA_ERROR_NO_MEMORY;
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_destroy(struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to destroy qp_init_attr: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to destroy qp_init_attr: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    free(verbs_qp_init_attr);
-    verbs_qp_init_attr = nullptr;
+  free(verbs_qp_init_attr);
+  verbs_qp_init_attr = nullptr;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_pd(struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                            struct ibv_pd *pd) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set pd: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (pd == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set pd: parameter pd is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct ibv_pd *pd) {
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set pd: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (pd == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set pd: parameter pd is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->pd = pd;
+  verbs_qp_init_attr->pd = pd;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 struct ibv_pd *doca_verbs_qp_init_attr_get_pd(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get pd: parameter verbs_qp_init_attr is NULL");
-        return nullptr;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get pd: parameter verbs_qp_init_attr is NULL");
+    return nullptr;
+  }
 
-    return verbs_qp_init_attr->pd;
+  return verbs_qp_init_attr->pd;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_send_cq(struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                                 struct doca_verbs_cq *send_cq) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set send_cq: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (send_cq == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set send_cq: parameter send_cq is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_cq *send_cq) {
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set send_cq: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (send_cq == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set send_cq: parameter send_cq is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->send_cq = send_cq;
+  verbs_qp_init_attr->send_cq = send_cq;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 struct doca_verbs_cq *doca_verbs_qp_init_attr_get_send_cq(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get send_cq: parameter verbs_qp_init_attr is NULL");
-        return nullptr;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get send_cq: parameter verbs_qp_init_attr is NULL");
+    return nullptr;
+  }
 
-    return verbs_qp_init_attr->send_cq;
+  return verbs_qp_init_attr->send_cq;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_receive_cq(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, struct doca_verbs_cq *receive_cq) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set receive_cq: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (receive_cq == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set receive_cq: parameter receive_cq is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set receive_cq: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (receive_cq == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set receive_cq: parameter receive_cq is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->receive_cq = receive_cq;
+  verbs_qp_init_attr->receive_cq = receive_cq;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 struct doca_verbs_cq *doca_verbs_qp_init_attr_get_receive_cq(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get receive_cq: parameter verbs_qp_init_attr is NULL");
-        return nullptr;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get receive_cq: parameter verbs_qp_init_attr is NULL");
+    return nullptr;
+  }
 
-    return verbs_qp_init_attr->receive_cq;
+  return verbs_qp_init_attr->receive_cq;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_sq_sig_all(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, int sq_sig_all) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set sq_sig_all: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set sq_sig_all: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->sq_sig_all = sq_sig_all;
+  verbs_qp_init_attr->sq_sig_all = sq_sig_all;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 int doca_verbs_qp_init_attr_get_sq_sig_all(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get sq_sig_all: parameter verbs_qp_init_attr is NULL");
-        return -1;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get sq_sig_all: parameter verbs_qp_init_attr is NULL");
+    return -1;
+  }
 
-    return verbs_qp_init_attr->sq_sig_all;
+  return verbs_qp_init_attr->sq_sig_all;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_sq_wr(struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                               uint32_t sq_wr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set sq_wr: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t sq_wr) {
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set sq_wr: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->sq_wr = sq_wr;
+  verbs_qp_init_attr->sq_wr = sq_wr;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_sq_wr(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get sq_wr: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get sq_wr: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->sq_wr;
+  return verbs_qp_init_attr->sq_wr;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_rq_wr(struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                               uint32_t rq_wr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set receive_cq: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t rq_wr) {
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set receive_cq: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->rq_wr = rq_wr;
+  verbs_qp_init_attr->rq_wr = rq_wr;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_rq_wr(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get rq_wr: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get rq_wr: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->rq_wr;
+  return verbs_qp_init_attr->rq_wr;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_send_max_sges(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, uint32_t send_max_sges) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set send_max_sges: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set send_max_sges: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->send_max_sges = send_max_sges;
+  verbs_qp_init_attr->send_max_sges = send_max_sges;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_send_max_sges(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get send_max_sges: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get send_max_sges: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->send_max_sges;
+  return verbs_qp_init_attr->send_max_sges;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_receive_max_sges(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, uint32_t receive_max_sges) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set receive_max_sges: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set receive_max_sges: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->receive_max_sges = receive_max_sges;
+  verbs_qp_init_attr->receive_max_sges = receive_max_sges;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_receive_max_sges(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get receive_max_sges: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get receive_max_sges: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->receive_max_sges;
+  return verbs_qp_init_attr->receive_max_sges;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_max_inline_data(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, uint32_t max_inline_data) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set max_inline_data: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set max_inline_data: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->max_inline_data = max_inline_data;
+  verbs_qp_init_attr->max_inline_data = max_inline_data;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_max_inline_data(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get max_inline_data: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get max_inline_data: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->max_inline_data;
+  return verbs_qp_init_attr->max_inline_data;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_user_index(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, uint32_t user_index) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set user_index: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set user_index: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if ((user_index & USER_INDEX_MSB_8BITS_MASK) != 0) {
-        DOCA_LOG(LOG_ERR, "Failed to set user_index: input parameter user_index=%u exceeds 24 bits",
-                 user_index);
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if ((user_index & USER_INDEX_MSB_8BITS_MASK) != 0) {
+    DOCA_LOG(LOG_ERR, "Failed to set user_index: input parameter user_index=%u exceeds 24 bits",
+        user_index);
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->user_index = user_index;
+  verbs_qp_init_attr->user_index = user_index;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_user_index(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get user_index: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get user_index: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->user_index;
+  return verbs_qp_init_attr->user_index;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_qp_type(struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                                 uint32_t qp_type) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set qp_type: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t qp_type) {
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set qp_type: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->qp_type = qp_type;
+  verbs_qp_init_attr->qp_type = qp_type;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_init_attr_get_qp_type(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get qp_type: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get qp_type: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->qp_type;
+  return verbs_qp_init_attr->qp_type;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_external_umem(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, struct doca_verbs_umem *external_umem,
     uint64_t external_umem_offset) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (external_umem == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter external_umem is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (external_umem == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter external_umem is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->external_umem = external_umem;
-    verbs_qp_init_attr->external_umem_offset = external_umem_offset;
+  verbs_qp_init_attr->external_umem = external_umem;
+  verbs_qp_init_attr->external_umem_offset = external_umem_offset;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_external_dbr_umem(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, struct doca_verbs_umem *external_umem,
     uint64_t external_umem_offset) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (external_umem == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter external_umem is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (external_umem == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set external_umem: parameter external_umem is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->external_umem_dbr = external_umem;
-    verbs_qp_init_attr->external_umem_dbr_offset = external_umem_offset;
+  verbs_qp_init_attr->external_umem_dbr = external_umem;
+  verbs_qp_init_attr->external_umem_dbr_offset = external_umem_offset;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_get_external_umem(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
     struct doca_verbs_umem **external_umem, uint64_t *external_umem_offset) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get external_umem: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (external_umem == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get external_umem: parameter external_umem is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (external_umem_offset == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get external_umem: parameter external_umem_offset is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get external_umem: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (external_umem == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get external_umem: parameter external_umem is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (external_umem_offset == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get external_umem: parameter external_umem_offset is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    *external_umem = verbs_qp_init_attr->external_umem;
-    *external_umem_offset = verbs_qp_init_attr->external_umem_offset;
+  *external_umem = verbs_qp_init_attr->external_umem;
+  *external_umem_offset = verbs_qp_init_attr->external_umem_offset;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_external_uar(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, struct doca_verbs_uar *external_uar) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set external_uar: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (external_uar == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set external_uar: parameter external_uar is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set external_uar: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (external_uar == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set external_uar: parameter external_uar is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->external_uar = external_uar;
+  verbs_qp_init_attr->external_uar = external_uar;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_get_external_uar(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
     struct doca_verbs_uar **external_uar) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get external_uar: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (external_uar == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get external_uar: parameter external_uar is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get external_uar: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (external_uar == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get external_uar: parameter external_uar is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    *external_uar = verbs_qp_init_attr->external_uar;
+  *external_uar = verbs_qp_init_attr->external_uar;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_qp_context(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, void *qp_context) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set qp_context: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (qp_context == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set qp_context: parameter qp_context is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set qp_context: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (qp_context == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set qp_context: parameter qp_context is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->qp_context = qp_context;
+  verbs_qp_init_attr->qp_context = qp_context;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 void *doca_verbs_qp_init_attr_get_qp_context(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get qp_context: parameter verbs_qp_init_attr is NULL");
-        return nullptr;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get qp_context: parameter verbs_qp_init_attr is NULL");
+    return nullptr;
+  }
 
-    return verbs_qp_init_attr->qp_context;
+  return verbs_qp_init_attr->qp_context;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_core_direct_master(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, uint8_t core_direct_master) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set core_direct_master: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set core_direct_master: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    if (core_direct_master != 0x0 && core_direct_master != 0x1) {
-        DOCA_LOG(LOG_ERR, "Failed to set core_direct_master: invalid input value %d",
-                 core_direct_master);
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (core_direct_master != 0x0 && core_direct_master != 0x1) {
+    DOCA_LOG(LOG_ERR, "Failed to set core_direct_master: invalid input value %d",
+        core_direct_master);
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->core_direct_master = core_direct_master;
+  verbs_qp_init_attr->core_direct_master = core_direct_master;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint8_t doca_verbs_qp_init_attr_get_core_direct_master(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get core_direct_master: parameter verbs_qp_init_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get core_direct_master: parameter verbs_qp_init_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_init_attr->core_direct_master;
+  return verbs_qp_init_attr->core_direct_master;
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_send_dbr_mode(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
     enum doca_verbs_qp_send_dbr_mode send_dbr_mode) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set send_dbr_mode: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set send_dbr_mode: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->send_dbr_mode = static_cast<uint8_t>(send_dbr_mode);
-    return DOCA_SUCCESS;
+  verbs_qp_init_attr->send_dbr_mode = static_cast<uint8_t>(send_dbr_mode);
+  return DOCA_SUCCESS;
 }
 
 enum doca_verbs_qp_send_dbr_mode doca_verbs_qp_init_attr_get_send_dbr_mode(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get send_dbr_mode: parameter verbs_qp_init_attr is NULL");
-        return DOCA_VERBS_QP_SEND_DBR_MODE_DBR_VALID;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get send_dbr_mode: parameter verbs_qp_init_attr is NULL");
+    return DOCA_VERBS_QP_SEND_DBR_MODE_DBR_VALID;
+  }
 
-    return static_cast<enum doca_verbs_qp_send_dbr_mode>(verbs_qp_init_attr->send_dbr_mode);
+  return static_cast<enum doca_verbs_qp_send_dbr_mode>(verbs_qp_init_attr->send_dbr_mode);
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_emulate_no_dbr_ext(
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr, bool emulate_no_dbr_ext) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set emulate_no_dbr_ext: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set emulate_no_dbr_ext: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->emulate_no_dbr_ext = emulate_no_dbr_ext;
+  verbs_qp_init_attr->emulate_no_dbr_ext = emulate_no_dbr_ext;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 bool doca_verbs_qp_init_attr_get_emulate_no_dbr_ext(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get emulate_no_dbr_ext: parameter verbs_qp_init_attr is NULL");
-        return false;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get emulate_no_dbr_ext: parameter verbs_qp_init_attr is NULL");
+    return false;
+  }
 
-    return verbs_qp_init_attr->emulate_no_dbr_ext;
+  return verbs_qp_init_attr->emulate_no_dbr_ext;
 }
 
 doca_error_t doca_verbs_qp_attr_create(struct doca_verbs_qp_attr **verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create qp_attr: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create qp_attr: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    *verbs_qp_attr = (struct doca_verbs_qp_attr *)calloc(1, sizeof(struct doca_verbs_qp_attr));
-    if (*verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create qp_attr: failed to allocate memory");
-        return DOCA_ERROR_NO_MEMORY;
-    }
+  *verbs_qp_attr = (struct doca_verbs_qp_attr *)calloc(1, sizeof(struct doca_verbs_qp_attr));
+  if (*verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create qp_attr: failed to allocate memory");
+    return DOCA_ERROR_NO_MEMORY;
+  }
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_attr_destroy(struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to destroy qp_attr: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to destroy qp_attr: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    free(verbs_qp_attr);
-    verbs_qp_attr = nullptr;
+  free(verbs_qp_attr);
+  verbs_qp_attr = nullptr;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_attr_set_next_state(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                               enum doca_verbs_qp_state next_state) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set next_state: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    enum doca_verbs_qp_state next_state) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set next_state: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->next_state = next_state;
+  verbs_qp_attr->next_state = next_state;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 enum doca_verbs_qp_state doca_verbs_qp_attr_get_next_state(
     const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get next_state: parameter verbs_qp_attr is NULL");
-        return static_cast<enum doca_verbs_qp_state>(0);
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get next_state: parameter verbs_qp_attr is NULL");
+    return static_cast<enum doca_verbs_qp_state>(0);
+  }
 
-    return verbs_qp_attr->next_state;
+  return verbs_qp_attr->next_state;
 }
 
 doca_error_t doca_verbs_qp_attr_set_current_state(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                                  enum doca_verbs_qp_state current_state) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set current_state: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    enum doca_verbs_qp_state current_state) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set current_state: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->current_state = current_state;
+  verbs_qp_attr->current_state = current_state;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 enum doca_verbs_qp_state doca_verbs_qp_attr_get_current_state(
     const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get current_state: parameter verbs_qp_attr is NULL");
-        return static_cast<enum doca_verbs_qp_state>(0);
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get current_state: parameter verbs_qp_attr is NULL");
+    return static_cast<enum doca_verbs_qp_state>(0);
+  }
 
-    return verbs_qp_attr->current_state;
+  return verbs_qp_attr->current_state;
 }
 
 doca_error_t doca_verbs_qp_attr_set_path_mtu(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                             enum doca_verbs_mtu_size path_mtu) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set path_mtu: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    enum doca_verbs_mtu_size path_mtu) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set path_mtu: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->path_mtu = path_mtu;
+  verbs_qp_attr->path_mtu = path_mtu;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 enum doca_verbs_mtu_size doca_verbs_qp_attr_get_path_mtu(
     const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get path_mtu: parameter verbs_qp_attr is NULL");
-        return static_cast<enum doca_verbs_mtu_size>(0);
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get path_mtu: parameter verbs_qp_attr is NULL");
+    return static_cast<enum doca_verbs_mtu_size>(0);
+  }
 
-    return verbs_qp_attr->path_mtu;
+  return verbs_qp_attr->path_mtu;
 }
 
 doca_error_t doca_verbs_qp_attr_set_rq_psn(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                           uint32_t rq_psn) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set rq_psn: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t rq_psn) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set rq_psn: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->rq_psn = rq_psn;
+  verbs_qp_attr->rq_psn = rq_psn;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_attr_get_rq_psn(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get rq_psn: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get rq_psn: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->rq_psn;
+  return verbs_qp_attr->rq_psn;
 }
 
 doca_error_t doca_verbs_qp_attr_set_sq_psn(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                           uint32_t sq_psn) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set sq_psn: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t sq_psn) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set sq_psn: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->sq_psn = sq_psn;
+  verbs_qp_attr->sq_psn = sq_psn;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_attr_get_sq_psn(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get sq_psn: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get sq_psn: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->sq_psn;
+  return verbs_qp_attr->sq_psn;
 }
 
 doca_error_t doca_verbs_qp_attr_set_dest_qp_num(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                                uint32_t dest_qp_num) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set dest_qp_num: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint32_t dest_qp_num) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set dest_qp_num: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->dest_qp_num = dest_qp_num;
+  verbs_qp_attr->dest_qp_num = dest_qp_num;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_qp_attr_get_dest_qp_num(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get dest_qp_num: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get dest_qp_num: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->dest_qp_num;
+  return verbs_qp_attr->dest_qp_num;
 }
 
 doca_error_t doca_verbs_qp_attr_set_allow_remote_write(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                                       int allow_remote_write) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set allow_remote_write: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    int allow_remote_write) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set allow_remote_write: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->allow_remote_write = allow_remote_write;
+  verbs_qp_attr->allow_remote_write = allow_remote_write;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 int doca_verbs_qp_attr_get_allow_remote_write(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get allow_remote_write: parameter verbs_qp_attr is NULL");
-        return -1;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get allow_remote_write: parameter verbs_qp_attr is NULL");
+    return -1;
+  }
 
-    return verbs_qp_attr->allow_remote_write;
+  return verbs_qp_attr->allow_remote_write;
 }
 
 doca_error_t doca_verbs_qp_attr_set_allow_remote_read(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                                      int allow_remote_read) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set allow_remote_read: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    int allow_remote_read) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set allow_remote_read: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->allow_remote_read = allow_remote_read;
+  verbs_qp_attr->allow_remote_read = allow_remote_read;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 int doca_verbs_qp_attr_get_allow_remote_read(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get allow_remote_read: parameter verbs_qp_attr is NULL");
-        return -1;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get allow_remote_read: parameter verbs_qp_attr is NULL");
+    return -1;
+  }
 
-    return verbs_qp_attr->allow_remote_read;
+  return verbs_qp_attr->allow_remote_read;
 }
 
 doca_error_t doca_verbs_qp_attr_set_allow_remote_atomic(
     struct doca_verbs_qp_attr *verbs_qp_attr, enum doca_verbs_qp_atomic_type atomic_type) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set allow_remote_atomic: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set allow_remote_atomic: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->allow_remote_atomic = atomic_type;
+  verbs_qp_attr->allow_remote_atomic = atomic_type;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 enum doca_verbs_qp_atomic_type doca_verbs_qp_attr_get_allow_remote_atomic(
     const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get allow_remote_atomic: parameter verbs_qp_attr is NULL");
-        return DOCA_VERBS_QP_ATOMIC_MODE_NONE;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get allow_remote_atomic: parameter verbs_qp_attr is NULL");
+    return DOCA_VERBS_QP_ATOMIC_MODE_NONE;
+  }
 
-    return verbs_qp_attr->allow_remote_atomic;
+  return verbs_qp_attr->allow_remote_atomic;
 }
 
 doca_error_t doca_verbs_qp_attr_set_ah_attr(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                            doca_verbs_ah_attr *ah_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set ah_attr: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (ah_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set ah_attr: parameter ah_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    doca_verbs_ah_attr *ah_attr) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set ah_attr: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (ah_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set ah_attr: parameter ah_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->ah_attr = ah_attr;
+  verbs_qp_attr->ah_attr = ah_attr;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 struct doca_verbs_ah_attr *doca_verbs_qp_attr_get_ah_attr(
     const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get ah_attr: parameter verbs_qp_attr is NULL");
-        return nullptr;
-    }
-    if (verbs_qp_attr->ah_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get ah_attr: ah_attr object was not set previously");
-        return nullptr;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get ah_attr: parameter verbs_qp_attr is NULL");
+    return nullptr;
+  }
+  if (verbs_qp_attr->ah_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get ah_attr: ah_attr object was not set previously");
+    return nullptr;
+  }
 
-    return verbs_qp_attr->ah_attr;
+  return verbs_qp_attr->ah_attr;
 }
 
 doca_error_t doca_verbs_qp_attr_set_pkey_index(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                               uint16_t pkey_index) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set pkey_index: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint16_t pkey_index) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set pkey_index: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->pkey_index = pkey_index;
+  verbs_qp_attr->pkey_index = pkey_index;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint16_t doca_verbs_qp_attr_get_pkey_index(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get pkey_index: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get pkey_index: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->pkey_index;
+  return verbs_qp_attr->pkey_index;
 }
 
 doca_error_t doca_verbs_qp_attr_set_port_num(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                             uint16_t port_num) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set port_num: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint16_t port_num) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set port_num: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->port_num = port_num;
+  verbs_qp_attr->port_num = port_num;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint16_t doca_verbs_qp_attr_get_port_num(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get port_num: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get port_num: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->port_num;
+  return verbs_qp_attr->port_num;
 }
 
 doca_error_t doca_verbs_qp_attr_set_ack_timeout(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                                uint16_t ack_timeout) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set ack_timeout: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint16_t ack_timeout) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set ack_timeout: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->ack_timeout = ack_timeout;
+  verbs_qp_attr->ack_timeout = ack_timeout;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint16_t doca_verbs_qp_attr_get_ack_timeout(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get ack_timeout: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get ack_timeout: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->ack_timeout;
+  return verbs_qp_attr->ack_timeout;
 }
 
 doca_error_t doca_verbs_qp_attr_set_retry_cnt(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                              uint16_t retry_cnt) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set retry_cnt: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint16_t retry_cnt) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set retry_cnt: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->retry_cnt = retry_cnt;
+  verbs_qp_attr->retry_cnt = retry_cnt;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint16_t doca_verbs_qp_attr_get_retry_cnt(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get retry_cnt: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get retry_cnt: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->retry_cnt;
+  return verbs_qp_attr->retry_cnt;
 }
 
 doca_error_t doca_verbs_qp_attr_set_rnr_retry(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                              uint16_t rnr_retry) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set rnr_retry: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint16_t rnr_retry) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set rnr_retry: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->rnr_retry = rnr_retry;
+  verbs_qp_attr->rnr_retry = rnr_retry;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint16_t doca_verbs_qp_attr_get_rnr_retry(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get rnr_retry: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get rnr_retry: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->rnr_retry;
+  return verbs_qp_attr->rnr_retry;
 }
 
 doca_error_t doca_verbs_qp_attr_set_min_rnr_timer(struct doca_verbs_qp_attr *verbs_qp_attr,
-                                                  uint16_t min_rnr_timer) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set min_rnr_timer: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint16_t min_rnr_timer) {
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set min_rnr_timer: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_attr->min_rnr_timer = min_rnr_timer;
+  verbs_qp_attr->min_rnr_timer = min_rnr_timer;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint16_t doca_verbs_qp_attr_get_min_rnr_timer(const struct doca_verbs_qp_attr *verbs_qp_attr) {
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get min_rnr_timer: parameter verbs_qp_attr is NULL");
-        return 0;
-    }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get min_rnr_timer: parameter verbs_qp_attr is NULL");
+    return 0;
+  }
 
-    return verbs_qp_attr->min_rnr_timer;
+  return verbs_qp_attr->min_rnr_timer;
 }
 
 doca_error_t doca_verbs_ah_attr_create(struct ibv_context *context,
-                                       struct doca_verbs_ah_attr **verbs_ah) {
-    if (context == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create verbs_ah: parameter context is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create verbs_ah: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_ah_attr **verbs_ah) {
+  if (context == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create verbs_ah: parameter context is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create verbs_ah: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    *verbs_ah = (struct doca_verbs_ah_attr *)calloc(1, sizeof(struct doca_verbs_ah_attr));
-    if (*verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create verbs_ah: failed to allocate memory");
-        return DOCA_ERROR_NO_MEMORY;
-    }
+  *verbs_ah = (struct doca_verbs_ah_attr *)calloc(1, sizeof(struct doca_verbs_ah_attr));
+  if (*verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create verbs_ah: failed to allocate memory");
+    return DOCA_ERROR_NO_MEMORY;
+  }
 
-    (*verbs_ah)->is_global = 1;
+  (*verbs_ah)->is_global = 1;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_ah_attr_destroy(struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to destroy verbs_ah: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to destroy verbs_ah: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    free(verbs_ah);
-    verbs_ah = nullptr;
+  free(verbs_ah);
+  verbs_ah = nullptr;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_ah_attr_set_gid(struct doca_verbs_ah_attr *verbs_ah,
-                                        struct doca_verbs_gid gid) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set gid: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_gid gid) {
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set gid: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->gid = gid;
+  verbs_ah->gid = gid;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 struct doca_verbs_gid doca_verbs_ah_get_gid(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get gid: parameter verbs_ah is NULL");
-        struct doca_verbs_gid zero_gid {};
-        memset(&zero_gid, 0, sizeof(zero_gid));
-        return zero_gid;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get gid: parameter verbs_ah is NULL");
+    struct doca_verbs_gid zero_gid {};
+    memset(&zero_gid, 0, sizeof(zero_gid));
+    return zero_gid;
+  }
 
-    return verbs_ah->gid;
+  return verbs_ah->gid;
 }
 
 doca_error_t doca_verbs_ah_attr_set_addr_type(struct doca_verbs_ah_attr *verbs_ah,
-                                              enum doca_verbs_addr_type addr_type) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set addr_type: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    enum doca_verbs_addr_type addr_type) {
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set addr_type: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->addr_type = addr_type;
+  verbs_ah->addr_type = addr_type;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 enum doca_verbs_addr_type doca_verbs_ah_get_addr_type(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get addr_type: parameter verbs_ah is NULL");
-        return static_cast<enum doca_verbs_addr_type>(0);
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get addr_type: parameter verbs_ah is NULL");
+    return static_cast<enum doca_verbs_addr_type>(0);
+  }
 
-    return verbs_ah->addr_type;
+  return verbs_ah->addr_type;
 }
 
 doca_error_t doca_verbs_ah_attr_set_dlid(struct doca_verbs_ah_attr *verbs_ah, uint32_t dlid) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set dlid: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set dlid: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->dlid = dlid;
+  verbs_ah->dlid = dlid;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint32_t doca_verbs_ah_get_dlid(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get dlid: parameter verbs_ah is NULL");
-        return 0;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get dlid: parameter verbs_ah is NULL");
+    return 0;
+  }
 
-    return verbs_ah->dlid;
+  return verbs_ah->dlid;
 }
 
 doca_error_t doca_verbs_ah_attr_set_sl(struct doca_verbs_ah_attr *verbs_ah, uint8_t sl) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set sl: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set sl: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->sl = sl;
+  verbs_ah->sl = sl;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint8_t doca_verbs_ah_get_sl(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get sl: parameter verbs_ah is NULL");
-        return 0;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get sl: parameter verbs_ah is NULL");
+    return 0;
+  }
 
-    return verbs_ah->sl;
+  return verbs_ah->sl;
 }
 
 doca_error_t doca_verbs_ah_attr_set_sgid_index(struct doca_verbs_ah_attr *verbs_ah,
-                                               uint8_t sgid_index) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set sgid_index: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint8_t sgid_index) {
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set sgid_index: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->sgid_index = sgid_index;
+  verbs_ah->sgid_index = sgid_index;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint8_t doca_verbs_ah_get_sgid_index(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get sgid_index: parameter verbs_ah is NULL");
-        return 0;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get sgid_index: parameter verbs_ah is NULL");
+    return 0;
+  }
 
-    return verbs_ah->sgid_index;
+  return verbs_ah->sgid_index;
 }
 
 doca_error_t doca_verbs_ah_attr_set_static_rate(struct doca_verbs_ah_attr *verbs_ah,
-                                                uint8_t static_rate) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set static_rate: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint8_t static_rate) {
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set static_rate: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->static_rate = static_rate;
+  verbs_ah->static_rate = static_rate;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint8_t doca_verbs_ah_get_static_rate(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get static_rate: parameter verbs_ah is NULL");
-        return 0;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get static_rate: parameter verbs_ah is NULL");
+    return 0;
+  }
 
-    return verbs_ah->static_rate;
+  return verbs_ah->static_rate;
 }
 
 doca_error_t doca_verbs_ah_attr_set_hop_limit(struct doca_verbs_ah_attr *verbs_ah,
-                                              uint8_t hop_limit) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set hop_limit: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint8_t hop_limit) {
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set hop_limit: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->hop_limit = hop_limit;
+  verbs_ah->hop_limit = hop_limit;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint8_t doca_verbs_ah_get_hop_limit(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get hop_limit: parameter verbs_ah is NULL");
-        return 0;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get hop_limit: parameter verbs_ah is NULL");
+    return 0;
+  }
 
-    return verbs_ah->hop_limit;
+  return verbs_ah->hop_limit;
 }
 
 doca_error_t doca_verbs_ah_attr_set_traffic_class(struct doca_verbs_ah_attr *verbs_ah,
-                                                  uint8_t traffic_class) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set traffic_class: parameter verbs_ah is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    uint8_t traffic_class) {
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set traffic_class: parameter verbs_ah is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_ah->traffic_class = traffic_class;
+  verbs_ah->traffic_class = traffic_class;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 uint8_t doca_verbs_ah_get_traffic_class(const struct doca_verbs_ah_attr *verbs_ah) {
-    if (verbs_ah == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get traffic_class: parameter verbs_ah is NULL");
-        return 0;
-    }
+  if (verbs_ah == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get traffic_class: parameter verbs_ah is NULL");
+    return 0;
+  }
 
-    return verbs_ah->traffic_class;
+  return verbs_ah->traffic_class;
 }
 
 doca_error_t doca_verbs_qp_create(struct ibv_context *context,
-                                  struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                  struct doca_verbs_qp **verbs_qp) {
-    if (context == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create verbs_qp: parameter context is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create verbs_qp: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (verbs_qp == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to create verbs_qp: parameter verbs_qp is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
+    struct doca_verbs_qp **verbs_qp) {
+  if (context == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create verbs_qp: parameter context is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create verbs_qp: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (verbs_qp == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to create verbs_qp: parameter verbs_qp is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    try {
-        *verbs_qp = new doca_verbs_qp(context, *verbs_qp_init_attr);
-        DOCA_LOG(LOG_INFO, "IB Verbs Context %p: verbs_qp=%p was created", context, *verbs_qp);
-        return DOCA_SUCCESS;
-    } catch (doca_error_t err) {
-        return err;
-    }
-
+  try {
+    *verbs_qp = new doca_verbs_qp(context, *verbs_qp_init_attr);
+    DOCA_LOG(LOG_INFO, "IB Verbs Context %p: verbs_qp=%p was created", context, *verbs_qp);
     return DOCA_SUCCESS;
+  } catch (doca_error_t err) {
+    return err;
+  }
+
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_destroy(struct doca_verbs_qp *verbs_qp) {
-    if (verbs_qp == nullptr) {
-        DOCA_LOG(LOG_INFO, "Failed to destroy verbs_qp: parameter verbs_qp is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+  if (verbs_qp == nullptr) {
+    DOCA_LOG(LOG_INFO, "Failed to destroy verbs_qp: parameter verbs_qp is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    auto status = verbs_qp->destroy();
-    if (status != DOCA_SUCCESS) {
-        DOCA_LOG(LOG_INFO, "Failed to destroy verbs_qp.");
-        return status;
-    }
+  auto status = verbs_qp->destroy();
+  if (status != DOCA_SUCCESS) {
+    DOCA_LOG(LOG_INFO, "Failed to destroy verbs_qp.");
+    return status;
+  }
 
-    delete (verbs_qp);
-    return DOCA_SUCCESS;
+  delete (verbs_qp);
+  return DOCA_SUCCESS;
 }
 
 doca_error_t doca_verbs_qp_modify(struct doca_verbs_qp *verbs_qp,
-                                  struct doca_verbs_qp_attr *verbs_qp_attr, int attr_mask) {
-    if (verbs_qp == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: parameter verbs_qp is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (!verbs_qp->is_qp_attr_valid(verbs_qp_attr, attr_mask)) {
-        DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: some QP attributes values are invalid");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_qp_attr *verbs_qp_attr, int attr_mask) {
+  if (verbs_qp == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: parameter verbs_qp is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (!verbs_qp->is_qp_attr_valid(verbs_qp_attr, attr_mask)) {
+    DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: some QP attributes values are invalid");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    doca_verbs_qp_state current_state;
-    doca_verbs_qp_state next_state;
-    if (!(attr_mask & DOCA_VERBS_QP_ATTR_CURRENT_STATE))
-        current_state = verbs_qp->get_current_state();
-    else
-        current_state = verbs_qp_attr->current_state;
-    if (!(attr_mask & DOCA_VERBS_QP_ATTR_NEXT_STATE))
-        next_state = current_state;
-    else
-        next_state = verbs_qp_attr->next_state;
+  doca_verbs_qp_state current_state;
+  doca_verbs_qp_state next_state;
+  if (!(attr_mask & DOCA_VERBS_QP_ATTR_CURRENT_STATE))
+    current_state = verbs_qp->get_current_state();
+  else
+    current_state = verbs_qp_attr->current_state;
+  if (!(attr_mask & DOCA_VERBS_QP_ATTR_NEXT_STATE))
+    next_state = current_state;
+  else
+    next_state = verbs_qp_attr->next_state;
 
-    switch (next_state) {
-        case DOCA_VERBS_QP_STATE_RST:
-            return verbs_qp->qp2rst(*verbs_qp_attr, attr_mask);
-        case DOCA_VERBS_QP_STATE_INIT:
-            if (current_state == DOCA_VERBS_QP_STATE_RST)
-                return verbs_qp->rst2init(*verbs_qp_attr, attr_mask);
-            else if (current_state == DOCA_VERBS_QP_STATE_INIT)
-                return verbs_qp->init2init(*verbs_qp_attr, attr_mask);
-            else
-                goto invalid_input;
-        case DOCA_VERBS_QP_STATE_RTR:
-            if (current_state == DOCA_VERBS_QP_STATE_INIT)
-                return verbs_qp->init2rtr(*verbs_qp_attr, attr_mask);
-            else
-                goto invalid_input;
-        case DOCA_VERBS_QP_STATE_RTS:
-            if (current_state == DOCA_VERBS_QP_STATE_RTR)
-                return verbs_qp->rtr2rts(*verbs_qp_attr, attr_mask);
-            else if (current_state == DOCA_VERBS_QP_STATE_RTS)
-                return verbs_qp->rts2rts(*verbs_qp_attr, attr_mask);
-            else
-                goto invalid_input;
-        case DOCA_VERBS_QP_STATE_ERR:
-            return verbs_qp->qp2err(*verbs_qp_attr, attr_mask);
-        default:
-            DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: invalid next_state");
-            return DOCA_ERROR_INVALID_VALUE;
-    }
+  switch (next_state) {
+    case DOCA_VERBS_QP_STATE_RST:
+      return verbs_qp->qp2rst(*verbs_qp_attr, attr_mask);
+    case DOCA_VERBS_QP_STATE_INIT:
+      if (current_state == DOCA_VERBS_QP_STATE_RST)
+        return verbs_qp->rst2init(*verbs_qp_attr, attr_mask);
+      else if (current_state == DOCA_VERBS_QP_STATE_INIT)
+        return verbs_qp->init2init(*verbs_qp_attr, attr_mask);
+      else
+        goto invalid_input;
+    case DOCA_VERBS_QP_STATE_RTR:
+      if (current_state == DOCA_VERBS_QP_STATE_INIT)
+        return verbs_qp->init2rtr(*verbs_qp_attr, attr_mask);
+      else
+        goto invalid_input;
+    case DOCA_VERBS_QP_STATE_RTS:
+      if (current_state == DOCA_VERBS_QP_STATE_RTR)
+        return verbs_qp->rtr2rts(*verbs_qp_attr, attr_mask);
+      else if (current_state == DOCA_VERBS_QP_STATE_RTS)
+        return verbs_qp->rts2rts(*verbs_qp_attr, attr_mask);
+      else
+        goto invalid_input;
+    case DOCA_VERBS_QP_STATE_ERR:
+      return verbs_qp->qp2err(*verbs_qp_attr, attr_mask);
+    default:
+      DOCA_LOG(LOG_ERR, "Failed to modify verbs_qp: invalid next_state");
+      return DOCA_ERROR_INVALID_VALUE;
+  }
 
 invalid_input:
-    DOCA_LOG(LOG_ERR,
-             "Failed to modify verbs_qp: invalid combination of current_state and next_state");
-    return DOCA_ERROR_INVALID_VALUE;
+  DOCA_LOG(LOG_ERR,
+      "Failed to modify verbs_qp: invalid combination of current_state and next_state");
+  return DOCA_ERROR_INVALID_VALUE;
 }
 
 doca_error_t doca_verbs_qp_query(struct doca_verbs_qp *verbs_qp,
-                                 struct doca_verbs_qp_attr *verbs_qp_attr,
-                                 struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to query verbs_qp: parameter verbs_qp is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (verbs_qp_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to query verbs_qp: parameter verbs_qp_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to query verbs_qp: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_qp_attr *verbs_qp_attr,
+    struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
+  if (verbs_qp == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to query verbs_qp: parameter verbs_qp is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (verbs_qp_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to query verbs_qp: parameter verbs_qp_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to query verbs_qp: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    return verbs_qp->query_qp(*verbs_qp_attr, *verbs_qp_init_attr);
+  return verbs_qp->query_qp(*verbs_qp_attr, *verbs_qp_init_attr);
 }
 
 uint32_t doca_verbs_qp_get_qpn(const struct doca_verbs_qp *verbs_qp) { return verbs_qp->get_qpn(); }
 
 void *doca_verbs_qp_get_dbr_addr(const struct doca_verbs_qp *verbs_qp) {
-    return verbs_qp->get_dbr_addr();
+  return verbs_qp->get_dbr_addr();
 }
 
 void *doca_verbs_qp_get_uar_addr(const struct doca_verbs_qp *verbs_qp) {
-    return verbs_qp->get_uar_addr();
+  return verbs_qp->get_uar_addr();
 }
 
 void doca_verbs_qp_get_wq(const struct doca_verbs_qp *verbs_qp, void **sq_buf,
-                          uint32_t *sq_num_entries, void **rq_buf, uint32_t *rq_num_entries,
-                          uint32_t *rwqe_size_bytes) {
-    *sq_buf = verbs_qp->get_sq_buf();
-    *rq_buf = verbs_qp->get_rq_buf();
-    *sq_num_entries = verbs_qp->get_sq_size_wqebb();
-    *rq_num_entries = verbs_qp->get_rq_size();
-    *rwqe_size_bytes = verbs_qp->get_rcv_wqe_size();
+    uint32_t *sq_num_entries, void **rq_buf, uint32_t *rq_num_entries,
+    uint32_t *rwqe_size_bytes) {
+  *sq_buf = verbs_qp->get_sq_buf();
+  *rq_buf = verbs_qp->get_rq_buf();
+  *sq_num_entries = verbs_qp->get_sq_size_wqebb();
+  *rq_num_entries = verbs_qp->get_rq_size();
+  *rwqe_size_bytes = verbs_qp->get_rcv_wqe_size();
 }
 
 doca_error_t doca_verbs_qp_init_attr_set_srq(struct doca_verbs_qp_init_attr *verbs_qp_init_attr,
-                                             struct doca_verbs_srq *srq) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set srq: parameter verbs_qp_init_attr is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
-    if (srq == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to set srq: parameter srq is NULL");
-        return DOCA_ERROR_INVALID_VALUE;
-    }
+    struct doca_verbs_srq *srq) {
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set srq: parameter verbs_qp_init_attr is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
+  if (srq == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to set srq: parameter srq is NULL");
+    return DOCA_ERROR_INVALID_VALUE;
+  }
 
-    verbs_qp_init_attr->srq = srq;
+  verbs_qp_init_attr->srq = srq;
 
-    return DOCA_SUCCESS;
+  return DOCA_SUCCESS;
 }
 
 struct doca_verbs_srq *doca_verbs_qp_init_attr_get_srq(
     const struct doca_verbs_qp_init_attr *verbs_qp_init_attr) {
-    if (verbs_qp_init_attr == nullptr) {
-        DOCA_LOG(LOG_ERR, "Failed to get srq: parameter verbs_qp_init_attr is NULL");
-        return nullptr;
-    }
+  if (verbs_qp_init_attr == nullptr) {
+    DOCA_LOG(LOG_ERR, "Failed to get srq: parameter verbs_qp_init_attr is NULL");
+    return nullptr;
+  }
 
-    return verbs_qp_init_attr->srq;
+  return verbs_qp_init_attr->srq;
 }
 
 enum doca_verbs_qp_send_dbr_mode doca_verbs_qp_get_send_dbr_mode(
     const struct doca_verbs_qp *verbs_qp) {
-    return verbs_qp->get_send_dbr_mode();
+  return verbs_qp->get_send_dbr_mode();
 }
 
 bool doca_verbs_qp_get_emulate_no_dbr_ext(const struct doca_verbs_qp *verbs_qp) {
-    return verbs_qp->get_emulate_no_dbr_ext();
+  return verbs_qp->get_emulate_no_dbr_ext();
 }

--- a/src/transport/net_ib/gin.cc
+++ b/src/transport/net_ib/gin.cc
@@ -17,8 +17,8 @@ const int NCCL_GIN_IB_ALLTOALL_TAG = 0xa1;
 static ncclResult_t ncclGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
   *gdrSupport = true;
   bool peerMemSupport =
-     gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
-     ncclIbGdrSupport() == ncclSuccess;
+      gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
+      ncclIbGdrSupport() == ncclSuccess;
   if (peerMemSupport) return ncclSuccess;
 
   if (ncclIbDmaBufSupport(0) == ncclSuccess) return ncclSuccess;
@@ -31,8 +31,8 @@ static ncclResult_t ncclGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
 // Check the current GPU supports GDR for GIN. This is run during connect().
 static ncclResult_t ncclGinIbGdrGpuSupport(bool gdaki) {
   bool peerMemSupport =
-     gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
-     ncclIbGdrSupport() == ncclSuccess;
+      gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
+      ncclIbGdrSupport() == ncclSuccess;
   if (peerMemSupport) return ncclSuccess;
 
   int cudaDev;
@@ -72,7 +72,7 @@ extern ncclGin_t ncclGinIbProxy;
 
 // Initlialize GDAKI or PROXY backend. ginType can force a particular backend.
 // If provided, overwrite ginIb with the backend (generic ginIb case).
-ncclResult_t ncclGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction, int ginType, ncclGin_t* ginIb) {
+ncclResult_t ncclGinIbInitType(void** ctx, uint64_t /*commId*/, ncclDebugLogger_t logFunction, int ginType, ncclGin_t* ginIb) {
   NCCLCHECK(ncclIbInitDevices(logFunction, nullptr));
   if (ncclNIbDevs == 0) return ncclInternalError; // Caught in plugin init code, not propagated to user.
 
@@ -134,13 +134,13 @@ static ncclResult_t ncclGinIbAllGather(struct ncclGinIbCollComm *cComm, void *sr
   int done;
 
   NCCLCHECKGOTO(ncclNetIb.regMr(cComm->recvComm, recvBuf,
-                                cComm->nranks * len, NCCL_PTR_HOST,
-                                &rMhandle),
-                status, out);
+    cComm->nranks * len, NCCL_PTR_HOST,
+    &rMhandle),
+    status, out);
   NCCLCHECKGOTO(ncclNetIb.regMr(cComm->sendComm, recvBuf,
-                                cComm->nranks * len, NCCL_PTR_HOST,
-                                &sMhandle),
-                status, out);
+    cComm->nranks * len, NCCL_PTR_HOST,
+    &sMhandle),
+    status, out);
 
   speer = cComm->rank;
   memcpy((void *)((uintptr_t)recvBuf + speer * len), srcBuf, len);
@@ -151,23 +151,23 @@ static ncclResult_t ncclGinIbAllGather(struct ncclGinIbCollComm *cComm, void *sr
       tag = NCCL_GIN_IB_ALLGATHER_TAG;
       if (srequest == NULL)
         NCCLCHECKGOTO(ncclNetIb.isend(cComm->sendComm,
-                                      (void *)((uintptr_t)recvBuf + speer * len),
-                                      len, tag, sMhandle, NULL, &srequest),
-                      status, out);
+          (void *)((uintptr_t)recvBuf + speer * len),
+          len, tag, sMhandle, NULL, &srequest),
+          status, out);
       if (rrequest == NULL)
         NCCLCHECKGOTO(ncclNetIb.irecv(cComm->recvComm, 1, &rbuf, &len,
-                                      &tag, &rMhandle, NULL, &rrequest),
-                      status, out);
+          &tag, &rMhandle, NULL, &rrequest),
+          status, out);
     }
     while (srequest || rrequest) {
       if (rrequest)
         NCCLCHECKGOTO(ncclNetIb.test(rrequest, &done, NULL),
-                      status, out);
+          status, out);
       if (done)
         rrequest = NULL;
       if (srequest)
         NCCLCHECKGOTO(ncclNetIb.test(srequest, &done, NULL),
-                      status, out);
+          status, out);
       if (done)
         srequest = NULL;
     }
@@ -212,7 +212,7 @@ ncclResult_t ncclGinIbP2PBarrier(struct ncclGinIbCollComm *cComm) {
 }
 
 ncclResult_t ncclGinIbConnect(void *ctx, void *handles[], int nranks, int rank, int nConnections,
-                              int queueDepth, void *listenComm, void **collComm) {
+    int queueDepth, void *listenComm, void **collComm) {
   struct ncclIbListenComm *lComm = (struct ncclIbListenComm *)listenComm;
   struct ncclGinIbCollComm *cCommArray = nullptr;
   int next;
@@ -231,8 +231,7 @@ ncclResult_t ncclGinIbConnect(void *ctx, void *handles[], int nranks, int rank, 
     cComm->nConnections = nConnections;
 
     next = (cComm->rank + 1) % nranks;
-    do
-    {
+    do {
       if (cComm->sendComm == NULL) {
         NCCLCHECK(ncclNetIb.connect(ctx, lComm->dev, handles[next], &cComm->sendComm, NULL));
       }
@@ -256,7 +255,7 @@ ncclResult_t ncclGinIbConnect(void *ctx, void *handles[], int nranks, int rank, 
         if (cComm->fullRecvComm[acceptPeer] == NULL)
           NCCLCHECK(ncclNetIb.accept(lComm, &cComm->fullRecvComm[acceptPeer], NULL));
       } while ((cComm->fullSendComm[connectPeer] == NULL) ||
-               (cComm->fullRecvComm[acceptPeer] == NULL));
+        (cComm->fullRecvComm[acceptPeer] == NULL));
       NCCLCHECK(ncclGinIbP2PBarrier(cComm));
     }
   }
@@ -334,12 +333,12 @@ ncclResult_t ncclGinIbGdakiListen(void* ctx, int dev, void* opaqueHandle, void**
 }
 
 ncclResult_t ncclGinIbGdakiConnect(void *ctx, void *handles[], int nranks, int rank, int nContexts,
-                                   int queueDepth, void *listenComm, void **collComm) {
+    int queueDepth, void *listenComm, void **collComm) {
   // Check the current GPU supports GDR
   NCCLCHECK(ncclGinIbGdrGpuSupport(/*gdaki*/ true));
 
   NCCLCHECK(
-    ncclGinIbConnect(ctx, handles, nranks, rank, nContexts, queueDepth, listenComm, collComm));
+      ncclGinIbConnect(ctx, handles, nranks, rank, nContexts, queueDepth, listenComm, collComm));
 
   struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)*collComm;
   cComm->getProperties = (ncclResult_t(*)(int dev, void *props))ncclGinIbGdakiGetProperties;
@@ -368,8 +367,7 @@ ncclResult_t ncclGinIbGdakiDestroyContext(void* ginCtx) {
   return ncclGinGdakiDestroyContext(ginCtx);
 }
 
-ncclResult_t ncclGinIbGdakiProgress(void *collComm)
-{
+ncclResult_t ncclGinIbGdakiProgress(void *collComm) {
   return ncclGinGdakiProgress(collComm);
 }
 
@@ -417,7 +415,7 @@ ncclResult_t ncclGinIbProxyGetProperties(int dev, ncclNetProperties_t* props) {
 }
 
 ncclResult_t ncclGinIbProxyConnect(void *ctx, void *handles[], int nranks, int rank, int nContexts,
-                                   int queueDepth, void *listenComm, void **collComm) {
+    int queueDepth, void *listenComm, void **collComm) {
   if (queueDepth != 0) {
     WARN("GIN_IB_PROXY does not support specifying qp depth");
     return ncclInvalidUsage;
@@ -428,7 +426,7 @@ ncclResult_t ncclGinIbProxyConnect(void *ctx, void *handles[], int nranks, int r
 
   // Connect.
   NCCLCHECK(
-    ncclGinIbConnect(ctx, handles, nranks, rank, nContexts, queueDepth, listenComm, collComm));
+      ncclGinIbConnect(ctx, handles, nranks, rank, nContexts, queueDepth, listenComm, collComm));
 
   return ncclSuccess;
 }
@@ -473,8 +471,8 @@ ncclResult_t ncclGinIbProxyCloseColl(void* collComm) {
 }
 
 ncclResult_t ncclGinIbProxyIPut(void *collComm, uint64_t srcOff, void *srcMhandle, size_t size,
-                                uint64_t dstOff, void *dstMhandle, uint32_t rank, int connectionId,
-                                void **request) {
+    uint64_t dstOff, void *dstMhandle, uint32_t rank, int connectionId,
+    void **request) {
   struct ncclGinIbCollComm* cComm = &((struct ncclGinIbCollComm*)collComm)[connectionId];
 
   struct ncclIbGinProxyMrHandle *srcMrHandle = (struct ncclIbGinProxyMrHandle *)srcMhandle;
@@ -525,9 +523,9 @@ ncclResult_t ncclGinIbProxyIPut(void *collComm, uint64_t srcOff, void *srcMhandl
 }
 
 ncclResult_t ncclGinIbProxyIPutSignal(void *collComm, uint64_t srcOff, void *srcMhandle,
-                                      size_t size, uint64_t dstOff, void *dstMhandle, uint32_t rank,
-                                      uint64_t signalOff, void *signalMhandle, uint64_t signalValue,
-                                      uint32_t signalOp, int connectionId, void **request) {
+    size_t size, uint64_t dstOff, void *dstMhandle, uint32_t rank,
+    uint64_t signalOff, void *signalMhandle, uint64_t signalValue,
+    uint32_t signalOp, int connectionId, void **request) {
   if (signalOp != NCCL_NET_SIGNAL_OP_INC && signalOp != NCCL_NET_SIGNAL_OP_ADD) {
     WARN("ncclGinIbProxyIPutSignal: Unsupported signalOp %u", signalOp);
     return ncclInvalidArgument;
@@ -637,8 +635,8 @@ ncclResult_t ncclGinIbProxyTest(void *collComm, void *request, int *done) {
       char line[SOCKET_NAME_MAXLEN+1];
       char *hcaName = req->devBases[i]->pd->context->device->name;
       WARN("NET/IB/GIN: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
-          ncclSocketToString(&addr, line), wc[i].status, wc[i].opcode, wc[i].byte_len, wc[i].vendor_err, ncclIbReqTypeStr[req->type],
-          localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+        ncclSocketToString(&addr, line), wc[i].status, wc[i].opcode, wc[i].byte_len, wc[i].vendor_err, ncclIbReqTypeStr[req->type],
+        localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
       return ncclRemoteError;
     }
 

--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -116,7 +116,7 @@ static int ncclIbRelaxedOrderingCapable(void) {
   return r == ncclInternalError ? 0 : 1;
 }
 
-static bool ncclMlx5dvDmaBufCapable(ibv_context *context){
+static bool ncclMlx5dvDmaBufCapable(ibv_context *context) {
   ncclResult_t res;
   int dev_fail = 0;
 
@@ -143,8 +143,8 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
   if (props->ndevs == 0) {
-      WARN("NET/IB : Can't make virtual NIC with 0 devices");
-      return ncclInvalidUsage;
+    WARN("NET/IB : Can't make virtual NIC with 0 devices");
+    return ncclInvalidUsage;
   }
 
   if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
@@ -165,7 +165,7 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     // Each successive time, copy the name '+' new name
     if (mDev->vProps.ndevs > 1) {
       snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s", dev->devName);
-    // First time, copy the plain name
+      // First time, copy the plain name
     } else {
       strncpy(mDev->devName, dev->devName, MAXNAMESIZE);
     }
@@ -181,7 +181,7 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     ncclIbDev* dev = ncclIbDevs + props->devs[i];
     if (dev->link != dev0->link) {
       WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-        props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
+          props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
       return ncclInvalidUsage;
     }
   }
@@ -214,7 +214,7 @@ ncclResult_t ncclIbFinalizeDevices(void) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+ncclResult_t ncclIbInitDevices(ncclDebugLogger_t /*logFunction*/, ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
   if (netRefCount++) return ret;
   ncclProfilerFunction = profFunction;
@@ -272,88 +272,88 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
           continue;
         }
         for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
-            struct ibv_port_attr portAttr;
-            if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
-              WARN("NET/IB : Unable to query port_num %d", port_num);
-              continue;
-            }
-            if (portAttr.state != IBV_PORT_ACTIVE) continue;
-            if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+          struct ibv_port_attr portAttr;
+          if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
+            WARN("NET/IB : Unable to query port_num %d", port_num);
+            continue;
+          }
+          if (portAttr.state != IBV_PORT_ACTIVE) continue;
+          if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
 
-            // check against user specified HCAs/ports
-            if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
-              continue;
-            }
+          // check against user specified HCAs/ports
+          if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+            continue;
+          }
 
-            // check for mlx5 data direct support only once for a each device
-            if (devCount == -1) {
-              devCount = 1;
-              devOffset = 0;
-              if (ncclParamIbDataDirect() > 0 && ibProvider == IB_PROVIDER_MLX5 && ncclMlx5dvDmaBufCapable(context)) {
-                int pathLen = strlen(dataDirectDevicePath);
-                ncclResult_t res = wrap_mlx5dv_get_data_direct_sysfs_path(context, dataDirectDevicePath + pathLen, sizeof(dataDirectDevicePath) - pathLen);
-                if (res == ncclSuccess) {
-                  // data direct devices are exposed twice: with the C2C + PCIe link and with the data direct link
-                  devCount = 2;
-                  // by default only expose the data direct NIC (devOffset = 1), unless set to 2 by the user
-                  devOffset = (ncclParamIbDataDirect() == 2) ? 0 : 1;
-                  INFO(NCCL_INIT | NCCL_NET, "NET/IB: Data Direct DMA Interface is detected for device %s", devices[d]->name);
-                } else if (res == ncclInvalidArgument) {
-                  TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
-                } else {
-                  WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
-                  return res;
-                }
-              }
-            }
-            for (int dev = devOffset; dev < devCount; ++dev) {
-              ncclIbDevs[ncclNIbDevs].device = d;
-              ncclIbDevs[ncclNIbDevs].ibProvider = ibProvider;
-              ncclIbDevs[ncclNIbDevs].guid = devAttr.sys_image_guid;
-              ncclIbDevs[ncclNIbDevs].portAttr = portAttr;
-              ncclIbDevs[ncclNIbDevs].portNum = port_num;
-              ncclIbDevs[ncclNIbDevs].link = portAttr.link_layer;
-              if (portAttr.active_speed_ex) {
-                // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
-                ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed_ex) * ncclIbWidth(portAttr.active_width);
+          // check for mlx5 data direct support only once for a each device
+          if (devCount == -1) {
+            devCount = 1;
+            devOffset = 0;
+            if (ncclParamIbDataDirect() > 0 && ibProvider == IB_PROVIDER_MLX5 && ncclMlx5dvDmaBufCapable(context)) {
+              int pathLen = strlen(dataDirectDevicePath);
+              ncclResult_t res = wrap_mlx5dv_get_data_direct_sysfs_path(context, dataDirectDevicePath + pathLen, sizeof(dataDirectDevicePath) - pathLen);
+              if (res == ncclSuccess) {
+                // data direct devices are exposed twice: with the C2C + PCIe link and with the data direct link
+                devCount = 2;
+                // by default only expose the data direct NIC (devOffset = 1), unless set to 2 by the user
+                devOffset = (ncclParamIbDataDirect() == 2) ? 0 : 1;
+                INFO(NCCL_INIT | NCCL_NET, "NET/IB: Data Direct DMA Interface is detected for device %s", devices[d]->name);
+              } else if (res == ncclInvalidArgument) {
+                TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
               } else {
-                ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed) * ncclIbWidth(portAttr.active_width);
+                WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
+                return res;
               }
-              ncclIbDevs[ncclNIbDevs].context = context;
-              ncclIbDevs[ncclNIbDevs].pdRefs = 0;
-              ncclIbDevs[ncclNIbDevs].pd = NULL;
-              // for dev==1 (data direct device), pciPath is given by mlx5
-              strncpy(ncclIbDevs[ncclNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
-              NCCLCHECKGOTO(ncclIbGetPciPath(ncclIbDevs[ncclNIbDevs].devName, (dev == 1) ? NULL : &ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].fullPciPath), ret, fail);
-              if (dev == 1) {
-                snprintf(ncclIbDevs[ncclNIbDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
-                NCCLCHECK(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX));
-                strncpy(ncclIbDevs[ncclNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
-                ncclIbDevs[ncclNIbDevs].capsProvider.mlx5.dataDirect = 1;
-              }
-
-              ncclIbDevs[ncclNIbDevs].maxQp = devAttr.max_qp;
-              ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
-              ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
-              ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
-              NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
-
-              // Enable ADAPTIVE_ROUTING by default on IB networks
-              // But allow it to be overloaded by an env parameter
-              ncclIbDevs[ncclNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
-              if (ncclParamIbAdaptiveRouting() != -2) ncclIbDevs[ncclNIbDevs].ar = ncclParamIbAdaptiveRouting();
-
-              INFO(NCCL_NET, "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d", d, devices[d]->name, devices[d]->dev_name,
-                   ncclIbDevs[ncclNIbDevs].portNum, NCCL_IB_LLSTR(portAttr.link_layer), ibProviderName[ncclIbDevs[ncclNIbDevs].ibProvider], ncclIbDevs[ncclNIbDevs].speed, context,
-                   ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].ar);
-
-              ncclIbAsyncThread = std::thread(ncclIbAsyncThreadMain, ncclIbDevs + ncclNIbDevs);
-              ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", ncclNIbDevs);
-              ncclIbAsyncThread.detach();
-
-              ncclNIbDevs++;
-              nPorts++;
             }
+          }
+          for (int dev = devOffset; dev < devCount; ++dev) {
+            ncclIbDevs[ncclNIbDevs].device = d;
+            ncclIbDevs[ncclNIbDevs].ibProvider = ibProvider;
+            ncclIbDevs[ncclNIbDevs].guid = devAttr.sys_image_guid;
+            ncclIbDevs[ncclNIbDevs].portAttr = portAttr;
+            ncclIbDevs[ncclNIbDevs].portNum = port_num;
+            ncclIbDevs[ncclNIbDevs].link = portAttr.link_layer;
+            if (portAttr.active_speed_ex) {
+              // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
+              ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed_ex) * ncclIbWidth(portAttr.active_width);
+            } else {
+              ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed) * ncclIbWidth(portAttr.active_width);
+            }
+            ncclIbDevs[ncclNIbDevs].context = context;
+            ncclIbDevs[ncclNIbDevs].pdRefs = 0;
+            ncclIbDevs[ncclNIbDevs].pd = NULL;
+            // for dev==1 (data direct device), pciPath is given by mlx5
+            strncpy(ncclIbDevs[ncclNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
+            NCCLCHECKGOTO(ncclIbGetPciPath(ncclIbDevs[ncclNIbDevs].devName, (dev == 1) ? NULL : &ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].fullPciPath), ret, fail);
+            if (dev == 1) {
+              snprintf(ncclIbDevs[ncclNIbDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
+              NCCLCHECK(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX));
+              strncpy(ncclIbDevs[ncclNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
+              ncclIbDevs[ncclNIbDevs].capsProvider.mlx5.dataDirect = 1;
+            }
+
+            ncclIbDevs[ncclNIbDevs].maxQp = devAttr.max_qp;
+            ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
+            ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
+            ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
+            NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
+
+            // Enable ADAPTIVE_ROUTING by default on IB networks
+            // But allow it to be overloaded by an env parameter
+            ncclIbDevs[ncclNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
+            if (ncclParamIbAdaptiveRouting() != -2) ncclIbDevs[ncclNIbDevs].ar = ncclParamIbAdaptiveRouting();
+
+            INFO(NCCL_NET, "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d", d, devices[d]->name, devices[d]->dev_name,
+                ncclIbDevs[ncclNIbDevs].portNum, NCCL_IB_LLSTR(portAttr.link_layer), ibProviderName[ncclIbDevs[ncclNIbDevs].ibProvider], ncclIbDevs[ncclNIbDevs].speed, context,
+                ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].ar);
+
+            ncclIbAsyncThread = std::thread(ncclIbAsyncThreadMain, ncclIbDevs + ncclNIbDevs);
+            ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", ncclNIbDevs);
+            ncclIbAsyncThread.detach();
+
+            ncclNIbDevs++;
+            nPorts++;
+          }
         }
         if (nPorts == 0 && ncclSuccess != wrap_ibv_close_device(context)) { ret = ncclInternalError; goto fail; }
       }
@@ -376,7 +376,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // Add this plain physical device to the list of virtual devices (after sorting)
       int vDev;
-      ncclNetVDeviceProps_t vProps = {0};
+      ncclNetVDeviceProps_t vProps = {};
       vProps.ndevs = 1;
       vProps.devs[0] = d;
       NCCLCHECK(ncclIbMakeVDeviceInternal(&vDev, &vProps));
@@ -390,7 +390,7 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+ncclResult_t ncclIbInit(void** ctx, uint64_t /*commId*/, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
   ncclNetCommConfig_t* netCommConfig = nullptr;
   NCCLCHECK(ncclIbInitDevices(logFunction, profFunction));

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -60,26 +60,26 @@ static ncclResult_t ncclIbPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   switch (wr->opcode) {
     case IBV_WR_RDMA_WRITE:
       sprintf(wrStr, "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64 ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
-        wr,
-        wr->wr_id,
-        opcodeStr,
-        wr->num_sge,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
-        wr->wr.rdma.remote_addr,
-        wr->wr.rdma.rkey);
+          wr,
+          wr->wr_id,
+          opcodeStr,
+          wr->num_sge,
+          (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
+          (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
+          wr->wr.rdma.remote_addr,
+          wr->wr.rdma.rkey);
       break;
     case IBV_WR_RDMA_WRITE_WITH_IMM:
       sprintf(wrStr, "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64 ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
-        wr,
-        wr->wr_id,
-        opcodeStr,
-        wr->num_sge,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
-        wr->wr.rdma.remote_addr,
-        wr->wr.rdma.rkey,
-        wr->imm_data);
+          wr,
+          wr->wr_id,
+          opcodeStr,
+          wr->num_sge,
+          (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
+          (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
+          wr->wr.rdma.remote_addr,
+          wr->wr.rdma.rkey,
+          wr->imm_data);
       break;
     default:
       WARN("NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
@@ -156,7 +156,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   lastWr->next = NULL;
   lastWr->send_flags = IBV_SEND_SIGNALED;
 
-  uint32_t sendOffsets[NCCL_NET_IB_MAX_RECVS] = {0};
+  uint32_t sendOffsets[NCCL_NET_IB_MAX_RECVS] = {};
   int qpIndex = -1;
   ncclIbQp* qp = NULL;
   for (int i = 0; i < nqps; i++) {
@@ -256,7 +256,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
+ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* /*phandle*/, void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm->base.ready == 0) {
     WARN("NET/IB: ncclIbIsend() called when comm->base.ready == 0");
@@ -285,12 +285,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
 
     if (size > slots[r].size) size = slots[r].size;
     // Sanity checks
-    if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
+    if (slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
       char line[SOCKET_NAME_MAXLEN + 1];
       union ncclSocketAddress addr;
       ncclSocketGetAddr(&comm->base.sock, &addr);
       WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
-        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
+          r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
       return ncclInternalError;
     }
 
@@ -409,7 +409,7 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
+ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** /*phandles*/, void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm->base.ready == 0) {
     WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
@@ -611,11 +611,11 @@ static inline ncclResult_t ncclIbRequestComplete(struct ncclIbRequest* r, int* d
     TRACE(NCCL_NET, "NET/IB: %s: Send request completed (req=%p, comm=%p, id=%ld)", __func__, r, r->base, r->id);
     if (sizes) {
       sizes[0] = r->send.size;
-  #ifdef NCCL_ENABLE_NET_PROFILING
+#ifdef NCCL_ENABLE_NET_PROFILING
       for (int j = 0; j < r->pInfo[0].nEventHandles; j++) {
         NCCLCHECK(ncclProfilerFunction(&r->pInfo[0].qpEventHandles[j], ncclProfilerNetEventStop, NULL, 0, NULL));
       }
-  #endif
+#endif
     }
     int slot = r->id % NET_IB_MAX_REQUESTS;
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)r->base;
@@ -649,9 +649,9 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   ncclSocketToString(&addr, sockStr);
   char *hcaName = devBase->pd->context->device->name;
   WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s",
-      sockStr, ibvWcStatusStr(wc->status), wc->status,
-      ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
-      localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+    sockStr, ibvWcStatusStr(wc->status), wc->status,
+    ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
+    localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
   return ncclSuccess;
 }
 
@@ -666,11 +666,11 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
     return ncclInternalError;
   }
 
-  #ifdef ENABLE_TRACE
+#ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN+1];
   TRACE(NCCL_NET, "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, devIndex=%d",
-    ncclSocketToString(&addr, line), wc->status, wc->opcode,wc->byte_len, wc->wr_id, req, req->type, req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
-  #endif
+      ncclSocketToString(&addr, line), wc->status, wc->opcode,wc->byte_len, wc->wr_id, req, req->type, req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
+#endif
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {

--- a/src/transport/net_ib/p2p.h
+++ b/src/transport/net_ib/p2p.h
@@ -27,7 +27,7 @@ static inline ncclResult_t ncclIbRecvCommGetQpForCts(struct ncclIbRecvComm* recv
 }
 
 static inline ncclResult_t ncclIbRequestRetrieveAsIndex(ncclIbRequest* reqs, uint32_t reqIndex, ncclIbRequest** req) {
-  if (reqIndex < 0 || reqIndex >= NET_IB_MAX_REQUESTS) {
+  if (reqIndex >= NET_IB_MAX_REQUESTS) {
     WARN("NET/IB: %s: Invalid request index %d. Not in the range [%d, %d). Cannot retrieve request.", __func__, reqIndex, 0, NET_IB_MAX_REQUESTS);
     return ncclInternalError;
   }

--- a/src/transport/net_ib/p2p_resiliency.cc
+++ b/src/transport/net_ib/p2p_resiliency.cc
@@ -155,7 +155,7 @@ static ncclResult_t ncclIbResiliencySendRequestFree(struct ncclIbResiliencySend*
   // freed.
   failedSendRequest->state = ncclIbResiliencyRequestStatePending;
   failedSendRequest->request = NULL;
-  failedSendRequest->errorInfo = {0};
+  failedSendRequest->errorInfo = {};
   failedSendRequest->failedAttempts = 0;
 
   sendResCtx->base.outstandingRequests--;
@@ -170,43 +170,43 @@ static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request)
   }
   int slot = request->id % NET_IB_MAX_REQUESTS;
   if (request->type == NCCL_NET_IB_REQ_SEND) {
-      struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)request->base->resiliency;
-      struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)request->base;
-      struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
-      for (int r = 0; r < request->nreqs; r++) {
-        // Clear all event counters and later on increment only the required
-        // ones based on the probing results on which QP a retransmission is
-        // required.
-        memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
+    struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)request->base->resiliency;
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)request->base;
+    struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
+    for (int r = 0; r < request->nreqs; r++) {
+      // Clear all event counters and later on increment only the required
+      // ones based on the probing results on which QP a retransmission is
+      // required.
+      memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
 
-        // Populate events
-        int nqps = ncclIbCommBaseGetNqpsPerRequest(sendReqs[r]->base);
-        int qpIndex = -1;
-        ncclIbQp* qp = NULL;
-        for (int i = 0; i < nqps; i++) {
-          // TODO: This code does not handle the case where a send request fails twice!
-          // If that device that is used for retransmission fails during retransmission,
-          // the logic here will retrieve the QP that was used for the first send attempt
-          // and not the QP that was used for the second send attempt! Causing
-          // probably data corruption or a hang.
-          NCCLCHECK(ncclIbCommBaseGetQpForRequest(sendReqs[r]->base, sendReqs[r]->id, i, &qp, &qpIndex));
+      // Populate events
+      int nqps = ncclIbCommBaseGetNqpsPerRequest(sendReqs[r]->base);
+      int qpIndex = -1;
+      ncclIbQp* qp = NULL;
+      for (int i = 0; i < nqps; i++) {
+        // TODO: This code does not handle the case where a send request fails twice!
+        // If that device that is used for retransmission fails during retransmission,
+        // the logic here will retrieve the QP that was used for the first send attempt
+        // and not the QP that was used for the second send attempt! Causing
+        // probably data corruption or a hang.
+        NCCLCHECK(ncclIbCommBaseGetQpForRequest(sendReqs[r]->base, sendReqs[r]->id, i, &qp, &qpIndex));
 
-          // Selective Retransmission:
-          // If the probing result shows that the data was delivered successfully on this QP,
-          // we don't need to retransmit it.
-          if (sendResCtx->probingResults[slot][qpIndex] == true) {
-            INFO(NCCL_NET, "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, comm=%p, id=%ld, slot=%d) as it was already delivered.", __func__, qpIndex, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
-            continue;
-          }
-
-          INFO(NCCL_NET, "NET/IB: %s: Retransmitting reqIndex=%d on qp_num=%u (req=%p, comm=%p, id=%ld, slot=%d) as it was not delivered.", __func__, r, qp->qp->qp_num, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
-          // Reset the sentData for this QP since we are going to retransmit it.
-          sendReqs[r]->send.sentData[qpIndex] = false;
-          ncclIbAddEvent(sendReqs[r], qp->devIndex);
+        // Selective Retransmission:
+        // If the probing result shows that the data was delivered successfully on this QP,
+        // we don't need to retransmit it.
+        if (sendResCtx->probingResults[slot][qpIndex] == true) {
+          INFO(NCCL_NET, "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, comm=%p, id=%ld, slot=%d) as it was already delivered.", __func__, qpIndex, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
+          continue;
         }
+
+        INFO(NCCL_NET, "NET/IB: %s: Retransmitting reqIndex=%d on qp_num=%u (req=%p, comm=%p, id=%ld, slot=%d) as it was not delivered.", __func__, r, qp->qp->qp_num, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
+        // Reset the sentData for this QP since we are going to retransmit it.
+        sendReqs[r]->send.sentData[qpIndex] = false;
+        ncclIbAddEvent(sendReqs[r], qp->devIndex);
       }
-      INFO(NCCL_NET, "NET/IB: %s: Reposting send request (request=%p, comm=%p, id=%ld, slot=%ld, nreqs=%d)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS, request->nreqs);
-      NCCLCHECK(ncclIbMultiSend((struct ncclIbSendComm*)request->base, slot));
+    }
+    INFO(NCCL_NET, "NET/IB: %s: Reposting send request (request=%p, comm=%p, id=%ld, slot=%ld, nreqs=%d)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS, request->nreqs);
+    NCCLCHECK(ncclIbMultiSend((struct ncclIbSendComm*)request->base, slot));
   } else if (request->type == NCCL_NET_IB_REQ_RECV) {
     INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
     NCCLCHECK(ncclIbPostFifo((struct ncclIbRecvComm*)request->base, request, slot));
@@ -219,7 +219,7 @@ static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request)
 
 static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
   INFO(NCCL_NET,"NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
-  bool inRecvRange = (wc->wr_id >= 0 && wc->wr_id <= NET_IB_MAX_REQUESTS);
+  bool inRecvRange = (wc->wr_id <= NET_IB_MAX_REQUESTS);
   bool inFlushRange = (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
     WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__, wc->wr_id, resCtx->baseComm);
@@ -400,8 +400,8 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   struct ncclIbQp* probingQp = &resCtx->probingQps[devIndex];
 
-  struct ibv_send_wr probeWr = {0};
-  struct ibv_sge sge = {0};
+  struct ibv_send_wr probeWr = {};
+  struct ibv_sge sge = {};
 
   int slot = failedSendRequest->request->id % NET_IB_MAX_REQUESTS;
 
@@ -592,7 +592,7 @@ ncclResult_t ncclIbResiliencyDataCqSizeGet(struct ncclIbResiliency* resCtx, uint
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbResiliencyDataRqSizeGet(struct ncclIbResiliency* resCtx, uint devIndex, uint32_t* rqSize) {
+ncclResult_t ncclIbResiliencyDataRqSizeGet(struct ncclIbResiliency* resCtx, uint /*devIndex*/, uint32_t* rqSize) {
   assert(rqSize != NULL);
   // This API should only be called on the receiver side.
   assert(resCtx->baseComm->isSend == 0);
@@ -648,7 +648,7 @@ ncclResult_t ncclIbResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
 ncclResult_t ncclIbResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, struct ncclIbResiliencyInfo* localResiliencyInfo) {
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
   void* qpContext = (void*)&sendComm->base.stats;
-  struct ncclIbQpCreateAttr qpCreateAttrs = {0};
+  struct ncclIbQpCreateAttr qpCreateAttrs = {};
   qpCreateAttrs.type = IBV_QPT_RC;
   // Probing QPs on the sender side do not require any remote permissions.
   qpCreateAttrs.accessFlags = IBV_ACCESS_LOCAL_WRITE;
@@ -698,7 +698,7 @@ ncclResult_t ncclIbResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, str
 ncclResult_t ncclIbResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbResiliencyInfo* localResiliencyInfo) {
   ncclIbRecvComm* recvComm = (ncclIbRecvComm*)resCtx->baseComm;
   void* qpContext = (void*)&recvComm->base.stats;
-  struct ncclIbQpCreateAttr qpCreateAttrs = {0};
+  struct ncclIbQpCreateAttr qpCreateAttrs = {};
   qpCreateAttrs.type = IBV_QPT_RC;
   // On the receiver side, probing QPs do not need to send/receive any messages.
   // They are only used as targets of RDMA Read operations.

--- a/src/transport/net_ib/reg.cc
+++ b/src/transport/net_ib/reg.cc
@@ -7,7 +7,7 @@
 
 #include "common.h"
 
-ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, ibv_mr** mhandle) {
+ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, size_t size, int /*type*/, uint64_t offset, int fd, uint64_t mrFlags, ibv_mr** mhandle) {
   static thread_local uintptr_t pageSize = 0;
   if (pageSize == 0) pageSize = sysconf(_SC_PAGESIZE);
   struct ncclIbMrCache* cache = &ncclIbDevs[base->ibDevN].mrCache;
@@ -36,8 +36,7 @@ ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, 
         if (relaxedOrdering) {
           // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING support
           NCCLCHECK(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void*)addr, pages*pageSize, addr, flags));
-        }
-        else {
+        } else {
           NCCLCHECK(wrap_ibv_reg_mr(&mr, base->pd, (void*)addr, pages*pageSize, flags));
         }
       }
@@ -51,7 +50,7 @@ ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, 
       *mhandle = mr;
       return ncclSuccess;
     } else if ((addr >= cache->slots[slot].addr) &&
-        ((addr-cache->slots[slot].addr)/pageSize+pages) <= cache->slots[slot].pages) {
+      ((addr-cache->slots[slot].addr)/pageSize+pages) <= cache->slots[slot].pages) {
       cache->slots[slot].refs += 1;
       *mhandle = cache->slots[slot].mr;
       return ncclSuccess;

--- a/src/transport/net_socket.cc
+++ b/src/transport/net_socket.cc
@@ -49,7 +49,7 @@ static ncclProfilerCallback_t ncclProfilerFunction;
 // context support is added to the plugin the ref counter can be removed.
 static int netRefCount;
 
-ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+ncclResult_t ncclNetSocketInit(void** /*ctx*/, uint64_t /*commId*/, ncclNetCommConfig_t* /*config*/, ncclDebugLogger_t /*logFunction*/, ncclProfilerCallback_t profFunction) {
   if (netRefCount++) return ncclSuccess;
   ncclProfilerFunction = profFunction;
   if (ncclNetIfs == -1) {
@@ -62,7 +62,7 @@ ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t*
         WARN("NET/Socket : no interface found");
         return ncclInternalError;
       } else {
-        #define MAX_LINE_LEN (2047)
+#define MAX_LINE_LEN (2047)
         char line[MAX_LINE_LEN+1];
         char addrline[SOCKET_NAME_MAXLEN+1];
         line[0] = '\0';
@@ -72,7 +72,7 @@ ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t*
           memcpy(&ncclNetSocketDevs[i].addr, addrs+i, sizeof(union ncclSocketAddress));
           NCCLCHECK(ncclNetSocketGetPciPath(ncclNetSocketDevs[i].devName, &ncclNetSocketDevs[i].pciPath));
           snprintf(line+strlen(line), MAX_LINE_LEN-strlen(line), " [%d]%s:%s", i, names+i*MAX_IF_NAME_SIZE,
-              ncclSocketToString(&addrs[i], addrline));
+            ncclSocketToString(&addrs[i], addrline));
         }
         line[MAX_LINE_LEN] = '\0';
         INFO(NCCL_INIT|NCCL_NET,"NET/Socket : Using%s", line);
@@ -239,7 +239,7 @@ void* persistentSocketThread(void *args_) {
   struct ncclNetSocketTaskQueue* myQueue = &resource->threadTaskQueue;
   int nSocksPerThread = comm->nSocks / comm->nThreads;
 #ifdef NCCL_ENABLE_NET_PROFILING
-  void* eHandle[MAX_REQUESTS*MAX_SOCKETS] = { 0 };
+  void* eHandle[MAX_REQUESTS*MAX_SOCKETS] = {};
 #endif
   while (1) {
     int idle = 1;
@@ -346,7 +346,7 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclNetSocketListen(void* ctx, int dev, void* opaqueHandle, void** listenComm) {
+ncclResult_t ncclNetSocketListen(void* /*ctx*/, int dev, void* opaqueHandle, void** listenComm) {
   if (dev < 0 || dev >= ncclNetIfs) { // data transfer socket is based on specified dev
     WARN("NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
     return ncclInternalError;
@@ -375,7 +375,7 @@ fail:
 }
 
 #define SOCKET_CTRL_SIZE (sizeof(int))
-ncclResult_t ncclNetSocketConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/) {
+ncclResult_t ncclNetSocketConnect(void* /*ctx*/, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/) {
   if (dev < 0 || dev >= ncclNetIfs) { // data transfer socket is based on specified dev
     return ncclInternalError;
   }
@@ -497,6 +497,9 @@ ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, voi
 }
 
 ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclProfilerInfo* pInfo, int op, void* data, int size, struct ncclNetSocketTask** req) {
+#ifndef NCCL_ENABLE_NET_PROFILING
+  (void)pInfo;
+#endif
   int tid = comm->nextSock % comm->nThreads;
   struct ncclNetSocketThreadResources* res = comm->threadResources+tid;
   struct ncclNetSocketTaskQueue* queue = &res->threadTaskQueue;
@@ -568,7 +571,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         NCCLCHECK(ncclSocketGetAddr(r->ctrlSock, &addr));
         WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket network is in a healthy state, "
              "there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between ranks",
-             ncclSocketToString(&addr, line), senderSize, r->size);
+            ncclSocketToString(&addr, line), senderSize, r->size);
         return ncclInvalidUsage;
       }
       // copy to the data buffer if we have received some inline data already
@@ -644,23 +647,25 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetSocketRegMr(void* comm, void* data, size_t size, int type, void** mhandle) {
+ncclResult_t ncclNetSocketRegMr(void* /*comm*/, void* /*data*/, size_t /*size*/, int type, void** /*mhandle*/) {
   return (type != NCCL_PTR_HOST) ? ncclInternalError : ncclSuccess;
 }
-ncclResult_t ncclNetSocketDeregMr(void* comm, void* mhandle) { return ncclSuccess; }
+ncclResult_t ncclNetSocketDeregMr(void* /*comm*/, void* /*mhandle*/) { return ncclSuccess; }
 
-ncclResult_t ncclNetSocketIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
+ncclResult_t ncclNetSocketIsend(void* sendComm, void* data, size_t size, int /*tag*/, void* /*mhandle*/, void* phandle, void** request) {
   struct ncclNetSocketComm* comm = (struct ncclNetSocketComm*)sendComm;
   NCCLCHECK(ncclNetSocketGetRequest(comm, NCCL_SOCKET_SEND, data, (int) size, (struct ncclNetSocketRequest**)request));
 #ifdef NCCL_ENABLE_NET_PROFILING
   // NCCL core profiler callback
   struct ncclNetSocketRequest* req = *(struct ncclNetSocketRequest **)request;
   req->pInfo.pHandle = phandle;
+#else
+  (void)phandle;
 #endif
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetSocketIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
+ncclResult_t ncclNetSocketIrecv(void* recvComm, int n, void** data, size_t* sizes, int* /*tags*/, void** /*mhandles*/, void** phandles, void** request) {
   struct ncclNetSocketComm* comm = (struct ncclNetSocketComm*)recvComm;
   if (n != 1) return ncclInternalError;
   NCCLCHECK(ncclNetSocketGetRequest(comm, NCCL_SOCKET_RECV, data[0], (int)sizes[0], (struct ncclNetSocketRequest**)request));
@@ -668,11 +673,13 @@ ncclResult_t ncclNetSocketIrecv(void* recvComm, int n, void** data, size_t* size
   // NCCL core profiler callback
   struct ncclNetSocketRequest* req = *(struct ncclNetSocketRequest **)request;
   if (phandles) req->pInfo.pHandle = phandles[0];
+#else
+  (void)phandles;
 #endif
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetSocketIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
+ncclResult_t ncclNetSocketIflush(void* /*recvComm*/, int /*n*/, void** /*data*/, int* /*sizes*/, void** /*mhandles*/, void** /*request*/) {
   // We don't support CUDA pointers, so we don't need a flush operation
   return ncclInternalError;
 }
@@ -716,7 +723,7 @@ ncclResult_t ncclNetSocketClose(void* opaqueComm) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetSocketFinalize(void* ctx) {
+ncclResult_t ncclNetSocketFinalize(void* /*ctx*/) {
   netRefCount--;
   return ncclSuccess;
 }

--- a/src/transport/nvls.cc
+++ b/src/transport/nvls.cc
@@ -29,28 +29,28 @@ struct localRegData {
   int handleTypes;
 };
 
-ncclResult_t nvlsCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+ncclResult_t nvlsCanConnect(int* ret, struct ncclComm* /*comm*/, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* /*info1*/, struct ncclPeerInfo* /*info2*/) {
   // This transport cannot be used for p2p
   *ret = 0;
   return ncclSuccess;
 }
 
-ncclResult_t nvlsSendFree(struct ncclComm* comm, struct ncclConnector* send) {
+ncclResult_t nvlsSendFree(struct ncclComm* /*comm*/, struct ncclConnector* /*send*/) {
   return ncclSuccess;
 }
 
-ncclResult_t nvlsRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
+ncclResult_t nvlsRecvFree(struct ncclComm* /*comm*/, struct ncclConnector* /*recv*/) {
   return ncclSuccess;
 }
 
 struct ncclTransport nvlsTransport = {
   "NVLS",
   nvlsCanConnect,
-  { NULL, NULL, nvlsSendFree, NULL, NULL, NULL, NULL, NULL },
-  { NULL, NULL, nvlsRecvFree, NULL, NULL, NULL, NULL, NULL }
+  { NULL, NULL, nvlsSendFree, NULL, NULL, NULL, NULL, NULL, NULL, NULL },
+  { NULL, NULL, nvlsRecvFree, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
 
-ncclResult_t ncclNvlsGroupCreate(struct ncclComm *comm, CUmulticastObjectProp *prop, int rank, unsigned int nranks, CUmemGenericAllocationHandle *mcHandle, char *shareableHandle) {
+ncclResult_t ncclNvlsGroupCreate(struct ncclComm */*comm*/, CUmulticastObjectProp *prop, int rank, unsigned int nranks, CUmemGenericAllocationHandle *mcHandle, char *shareableHandle) {
   CUmemAllocationHandleType type = ncclCuMemHandleType;
   size_t size = prop->size;
 
@@ -62,8 +62,7 @@ ncclResult_t ncclNvlsGroupCreate(struct ncclComm *comm, CUmulticastObjectProp *p
   if (type == CU_MEM_HANDLE_TYPE_FABRIC) {
     // Get a handle to pass to other ranks
     CUCHECK(cuMemExportToShareableHandle(shareableHandle, *mcHandle, ncclCuMemHandleType, 0));
-  }
-  else {
+  } else {
     memcpy(shareableHandle, mcHandle, sizeof(CUmemGenericAllocationHandle));
   }
 
@@ -122,7 +121,7 @@ ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHa
   return ncclSuccess;
 }
 
-ncclResult_t nvlsGroupUnmapMem(struct ncclComm *comm, size_t ucsize, void* ucptr, CUmemGenericAllocationHandle* ucHandle, size_t mcsize, void* mcptr, CUmemGenericAllocationHandle* mcHandle) {
+ncclResult_t nvlsGroupUnmapMem(struct ncclComm */*comm*/, size_t ucsize, void* ucptr, CUmemGenericAllocationHandle* ucHandle, size_t mcsize, void* mcptr, CUmemGenericAllocationHandle* mcHandle) {
   INFO(NCCL_NVLS, "NVLS Unmap mem UC handle 0x%llx(%p) ucsize %zu MC handle 0x%llx(%p) mcsize %zd", *ucHandle, ucptr, ucsize, *mcHandle, mcptr, mcsize);
 
   // Release the UC memory and mapping
@@ -200,7 +199,7 @@ ncclResult_t ncclNvlsInit(struct ncclComm* comm) {
     comm->nvlsChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, channels));
   }
   INFO(NCCL_INIT, "NVLS multicast support is %savailable on dev %d (NVLS_NCHANNELS %d)",
-       comm->nvlsSupport ? "" : "not ", dev, comm->nvlsChannels);
+    comm->nvlsSupport ? "" : "not ", dev, comm->nvlsChannels);
   return ncclSuccess;
 }
 
@@ -335,7 +334,7 @@ ncclResult_t ncclNvlsBufferSetup(struct ncclComm* comm) {
   nvlsTotalSize = nvlsPerRankSize * nHeads;
 
   INFO(NCCL_INIT | NCCL_NVLS, "NVLS comm %p headRank %d nHeads %d nvlsRanks %d buffSize %zu nvlsPerRankSize %zu nvlsTotalSize %zu",
-       comm, headRank, nHeads, comm->localRanks, buffSize, nvlsPerRankSize, nvlsTotalSize);
+      comm, headRank, nHeads, comm->localRanks, buffSize, nvlsPerRankSize, nvlsTotalSize);
 
   NCCLCHECKGOTO(nvlsAllocateMem(comm, &resources->accessDesc, nvlsTotalSize, &resources->ucBuffHandle, &resources->mcBuffHandle, (void**)&resources->ucBuff, (void**)&resources->mcBuff, &resources->buffUCSize, &resources->buffMCSize), res, fail);
 
@@ -689,7 +688,7 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
   }
   if (sendbuff) {
     CUCHECKGOTO(cuPointerGetAttribute((void*)&regData[comm->localRank * 2].handleTypes,
-                                      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)sendbuff), ret, fail);
+      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)sendbuff), ret, fail);
   }
 
   if (recvRegRecord) {
@@ -698,7 +697,7 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
   }
   if (recvbuff) {
     CUCHECKGOTO(cuPointerGetAttribute((void*)&regData[comm->localRank * 2 + 1].handleTypes,
-                                      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)recvbuff), ret, fail);
+      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)recvbuff), ret, fail);
   }
 
   NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regData + comm->localRank * 2, regData, sizeof(struct localRegData) * 2), ret, fail);
@@ -718,7 +717,7 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
     }
 
     if ((sendbuff && (regData[i * 2].handleTypes & ncclCuMemHandleType) == 0) ||
-        (recvbuff && (regData[i * 2 + 1].handleTypes & ncclCuMemHandleType) == 0)) {
+      (recvbuff && (regData[i * 2 + 1].handleTypes & ncclCuMemHandleType) == 0)) {
       goto fail;
     }
   }
@@ -827,7 +826,7 @@ struct ncclNvlsCleanupCallback {
   struct ncclComm *comm;
 };
 
-static ncclResult_t cleanupNvls(struct ncclComm* comm, struct ncclCommCallback* cb) {
+static ncclResult_t cleanupNvls(struct ncclComm* /*comm*/, struct ncclCommCallback* cb) {
   struct ncclNvlsCleanupCallback* obj = (struct ncclNvlsCleanupCallback*)cb;
   NCCLCHECK(ncclCommGraphDeregister(obj->comm, obj->reg));
   free(obj);
@@ -838,7 +837,7 @@ ncclResult_t ncclNvlsGraphRegisterBuffer(
     struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize,
     int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv,
     struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueEltsAdded
-  ) {
+) {
   struct ncclNvlsCleanupCallback* sendRecord = NULL;
   struct ncclNvlsCleanupCallback* recvRecord = NULL;
   void *baseSend = NULL;
@@ -966,7 +965,7 @@ ncclResult_t ncclNvlsGraphRegisterBuffer(
     struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize,
     int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv,
     struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueEltsAdded
-  ) {
+) {
   *outRegBufUsed = false;
   return ncclSuccess;
 }

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -107,7 +107,7 @@ static int busIdToCudaDev(int64_t busId) {
   for (int i = 0; i < ndev; i++) {
     char devBusIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
     if (!CUDASUCCESS(cudaDeviceGetPCIBusId(
-            devBusIdStr, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE, i)))
+      devBusIdStr, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE, i)))
       return -1;
     int64_t devBusId;
     NCCLCHECK(busIdToInt64(devBusIdStr, &devBusId));
@@ -126,7 +126,7 @@ static void initCeOperation();
 extern int64_t ncclParamMNNVLEnable();
 
 /* Determine if two peers can communicate through p2p */
-ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
   initCeOperation();
 
   // Check topology / p2p level.
@@ -170,7 +170,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
   int p2p;
   if (!CUDASUCCESS(cudaDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2))) {
     INFO(NCCL_INIT|NCCL_P2P,"peer query failed between dev %d(=%lx) and dev %d(=%lx)",
-         cudaDev1, info1->busId, cudaDev2, info2->busId);
+      cudaDev1, info1->busId, cudaDev2, info2->busId);
     *ret = 0;
     return ncclSuccess;
   }
@@ -198,7 +198,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
 
   if (p2p == 0) {
     INFO(NCCL_INIT|NCCL_P2P,"Could not enable P2P between dev %d(=%lx) and dev %d(=%lx)",
-         cudaDev1, info1->busId, cudaDev2, info2->busId);
+      cudaDev1, info1->busId, cudaDev2, info2->busId);
     *ret = 0;
     return ncclSuccess;
   }
@@ -253,7 +253,7 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
   return ncclSuccess;
 }
 
-ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc *ipcDesc) {
+ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc */*ipcDesc*/) {
   return ncclSuccess;
 }
 
@@ -304,7 +304,7 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
 
     // Track imported buffer
     NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, (void*)dptr, size, handle, type, memType,
-                                         peer, comm->peerInfo[peer].cudaDev, ownerPtr));
+      peer, comm->peerInfo[peer].cudaDev, ownerPtr));
 #else
     return ncclInternalError;
 #endif
@@ -335,7 +335,7 @@ static ncclResult_t p2pGetInfo(struct ncclComm* comm, struct ncclPeerInfo* info1
   return ncclSuccess;
 }
 
-static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* proxyConn, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclP2pBuff* p2pBuff, void** devMem, void** ipcPtr) {
+static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* /*proxyConn*/, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclP2pBuff* p2pBuff, void** devMem, void** ipcPtr) {
   if (P2P_SAME_PID(myInfo, peerInfo)) {
     if (peerInfo->cudaDev != myInfo->cudaDev) {
       // Same PID different GPUs, enable P2P access
@@ -345,7 +345,7 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
         cudaGetLastError();
       } else if (err != cudaSuccess) {
         WARN("failed to peer with device %d(=%lx): %d %s",
-            peerInfo->cudaDev, peerInfo->busId, err, cudaGetErrorString(err));
+          peerInfo->cudaDev, peerInfo->busId, err, cudaGetErrorString(err));
         return ncclInternalError;
       }
       if (ncclCuMemEnable()) {
@@ -357,8 +357,8 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
 
         // Track as imported peer memory for dynamic memory management
         NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, *devMem, p2pBuff->size,
-                                             p2pBuff->ipcDesc.memHandle, ncclCuMemHandleType, ncclMemOffload,
-                                             peerInfo->rank, peerInfo->cudaDev, p2pBuff->directPtr));
+          p2pBuff->ipcDesc.memHandle, ncclCuMemHandleType, ncclMemOffload,
+          peerInfo->rank, peerInfo->cudaDev, p2pBuff->directPtr));
       } else {
         *devMem = p2pBuff->directPtr;
         *ipcPtr = NULL;
@@ -411,12 +411,12 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
         resources->type = P2P_CUMEM;
         const char *MNNVL = comm->MNNVL ? "MNNVL" : "CUMEM";
         INFO(NCCL_INIT|NCCL_P2P,"Channel %02d/%01d : %d[%d] -> %d[%d] via P2P/%s%s%s",
-             channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, MNNVL, useReadStr, useMemcpy ? "/CE" : "");;
+            channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, MNNVL, useReadStr, useMemcpy ? "/CE" : "");;
       } else {
         // Legacy CUDA IPC
         resources->type = P2P_IPC;
         INFO(NCCL_INIT|NCCL_P2P,"Channel %02d/%01d : %d[%d] -> %d[%d] via P2P/IPC%s%s",
-             channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, useReadStr, useMemcpy ? "/CE" : "");
+            channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, useReadStr, useMemcpy ? "/CE" : "");
       }
     }
     send->conn.flags |= info->read ? NCCL_P2P_READ : NCCL_P2P_WRITE;
@@ -425,7 +425,7 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
     info->rank = intermediateRank;
     INFO(NCCL_INIT|NCCL_P2P, "Channel %02d/%01d : %d[%d] -> %d[%d] via P2P/indirect/%d[%d]%s",
         channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, intermediateRank,
-	  comm->peerInfo[intermediateRank].nvmlDev, useReadStr);
+        comm->peerInfo[intermediateRank].nvmlDev, useReadStr);
   }
 
   memset(&req, '\0', sizeof(req));
@@ -449,7 +449,7 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
 
 /* Create and return connect structures for this peer to connect to me */
 ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo,
-    struct ncclConnect* connectInfo, struct ncclConnector * recv, int channelId, int connIndex) {
+    struct ncclConnect* connectInfo, struct ncclConnector * recv, int /*channelId*/, int connIndex) {
   struct p2pResources* resources;
   struct ncclP2pRequest req;
   NCCLCHECK(ncclCalloc(&resources, 1));
@@ -477,7 +477,7 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
         // cuMem API support
         resources->type = P2P_CUMEM;
         TRACE(NCCL_INIT|NCCL_P2P,"Ring %02d : %d[%d] <- %d[%d] via P2P/CUMEM",
-              channelId, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev);
+            channelId, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev);
       } else {
         // Legacy CUDA IPC
         resources->type = P2P_IPC;
@@ -504,7 +504,7 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
 }
 
 /* Connect/Send to this peer */
-static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int /*nranks*/, int rank, struct ncclConnector* send) {
   struct p2pResources* resources = (struct p2pResources*)send->transportResources;
   struct ncclRecvMem* remDevMem = NULL;
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;
@@ -544,7 +544,7 @@ static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* co
 }
 
 /* Connect/Recv from this peer */
-ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
+ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int /*nranks*/, int rank, struct ncclConnector* recv) {
   struct p2pResources* resources = (struct p2pResources*)recv->transportResources;
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;
 
@@ -602,8 +602,7 @@ ncclResult_t p2pSendFree(struct ncclComm* comm, struct ncclConnector* send) {
           NCCLCHECK(ncclCudaFree(resources->recvMemIpc, comm->memManager));
         }
       }
-    }
-    else {
+    } else {
       if (resources->sendMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->sendMemIpc));
       if (resources->recvMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->recvMemIpc));
     }
@@ -632,8 +631,7 @@ ncclResult_t p2pRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
           NCCLCHECK(ncclCudaFree(resources->recvMemIpc, comm->memManager));
         }
       }
-    }
-    else {
+    } else {
       if (resources->sendMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->sendMemIpc));
       if (resources->recvMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->recvMemIpc));
       if (useMemcpy) {
@@ -706,7 +704,7 @@ static ncclResult_t p2pRecvProxySetup(struct ncclProxyConnection* connection, st
   return ncclSuccess;
 }
 
-static ncclResult_t p2pSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t p2pSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* /*proxyState*/, void* reqBuff, int reqSize, void* /*respBuff*/, int /*respSize*/, int* /*done*/) {
   struct p2pShmProxyInfo* proxyInfo = (struct p2pShmProxyInfo*)connection->transportResources;
 
   if (reqSize != sizeof(void*)) return ncclInternalError;
@@ -815,9 +813,9 @@ static ncclResult_t p2pSendProxyProgress(struct ncclProxyState* proxyState, stru
       struct ncclProxySubArgs* sub = args->subs+s;
       struct p2pShmProxyInfo* resources = (struct p2pShmProxyInfo*) (sub->connection->transportResources);
       if (p != NCCL_PROTO_SIMPLE) { // Only Simple uses cudaMemcpy
-          resources->step = sub->base + sub->nsteps;
-          args->done++;
-          continue;
+        resources->step = sub->base + sub->nsteps;
+        args->done++;
+        continue;
       }
       if (sub->transmitted < sub->done + NCCL_STEPS && sub->transmitted < sub->nsteps) {
         int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
@@ -920,7 +918,7 @@ ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t user
   }
   for (int segment = 0; segment < *numSegments; segment++) {
     struct p2pIpcExpInfo* ipcInfo = *ipcInfos + segment;
-     if (!proxyConn->sameProcess) {
+    if (!proxyConn->sameProcess) {
       if (ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
         ipcInfo->impFd = impFds[segment];
         close(expFds[segment]);
@@ -1152,7 +1150,7 @@ struct ncclIpcCleanupCallback {
   struct ncclReg *reg;
 };
 
-static ncclResult_t cleanupIpc(struct ncclComm* comm, struct ncclCommCallback* cb) {
+static ncclResult_t cleanupIpc(struct ncclComm* /*comm*/, struct ncclCommCallback* cb) {
   struct ncclIpcCleanupCallback* obj = (struct ncclIpcCleanupCallback*)cb;
   NCCLCHECK(ncclCommGraphDeregister(obj->comm, obj->reg));
   free(obj);
@@ -1286,15 +1284,15 @@ exit:
   return ret;
 fail:
   if (!ipcExpInfo->legacyIpcCap) {
-      size_t offset = 0;
-      for (int segment = 0; segment < numSegments; segment++) {
-        if (mapped[segment]) {
-          CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)regAddr + offset, ipcExpInfo[segment].size));
-        }
-        if (imported[segment]) {
-          CUCHECKIGNORE(cuMemRelease(segmentHandles[segment]));
-        }
+    size_t offset = 0;
+    for (int segment = 0; segment < numSegments; segment++) {
+      if (mapped[segment]) {
+        CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)regAddr + offset, ipcExpInfo[segment].size));
       }
+      if (imported[segment]) {
+        CUCHECKIGNORE(cuMemRelease(segmentHandles[segment]));
+      }
+    }
     if (regAddr) CUCHECKIGNORE(cuMemAddressFree((CUdeviceptr)regAddr, totalSize));
   }
   regAddr = NULL;

--- a/src/transport/profiler.cc
+++ b/src/transport/profiler.cc
@@ -9,7 +9,7 @@
 #include "profiler.h"
 #include "device.h"
 
-static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* /*proxyState*/, void* /*reqBuff*/, int /*reqSize*/, void* /*respBuff*/, int /*respSize*/, int* /*done*/) {
   connection->proxyAppendPtr = &connection->proxyAppend;
   connection->shared = 0;
   return ncclSuccess;
@@ -19,7 +19,7 @@ static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection,
 // - base       : is set to the current value of workCounter[channelId]
 // - posted     : is set to sub->nsteps to indicate that the profiler has started the event
 // - transmitted: is set to sub->nsteps to indicate that the profiler has stopped the event
-static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
+static ncclResult_t profilerProxyProgress(struct ncclProxyState* /*proxyState*/, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
     for (int s = 0; s < args->nsubs; s++) {
       struct ncclProxySubArgs* sub = args->subs + s;

--- a/src/transport/shm.cc
+++ b/src/transport/shm.cc
@@ -74,7 +74,7 @@ static int shmLocality = 0;
 static void initCeOperation();
 
 /* Determine two peers can communicate with SHM */
-static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
   *ret = 0;
   initCeOperation();
 
@@ -100,7 +100,7 @@ static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTo
 #define MAX_SHM_NAME_LEN 1024
 
 /* Create and return connect structures for this peer to connect to me */
-static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
+static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int /*connIndex*/) {
   struct shmSendResources* resources;
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   size_t shmSize = sizeof(struct ncclSendMem);
@@ -131,7 +131,7 @@ static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
   return ncclSuccess;
 }
 
-static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
+static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* /*graph*/, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int /*channelId*/, int /*connIndex*/) {
   struct shmRecvResources* resources;
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   size_t shmSize = sizeof(struct ncclRecvMem);
@@ -162,7 +162,7 @@ static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
 }
 
 /* Connect to this peer */
-static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int /*nranks*/, int /*rank*/, struct ncclConnector* send) {
   // Setup device pointers
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   struct shmSendResources* resources = (struct shmSendResources*)send->transportResources;
@@ -183,7 +183,10 @@ static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* co
     send->conn.connFifo = resources->devRemHostMem->connFifo;
   }
   if (useMemcpySend) {
-    struct shmProxyInfo proxyInfo = { NULL, NULL, send->conn.buffs[NCCL_PROTO_SIMPLE], resources->hostMem, resources->remHostMem };
+    struct shmProxyInfo proxyInfo = {};
+    proxyInfo.shmFifo = send->conn.buffs[NCCL_PROTO_SIMPLE];
+    proxyInfo.sendMem = resources->hostMem;
+    proxyInfo.recvMem = resources->remHostMem;
     NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &proxyInfo, sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
     send->conn.buffs[NCCL_PROTO_SIMPLE] = proxyInfo.devFifo;
     send->conn.tail = &proxyInfo.ceRecvMem->tail;
@@ -196,7 +199,7 @@ static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* co
   return ncclSuccess;
 }
 
-static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
+static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int /*nranks*/, int /*rank*/, struct ncclConnector* recv) {
   // Setup device pointers
   struct shmRecvResources* resources = (struct shmRecvResources*)recv->transportResources;
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
@@ -214,7 +217,10 @@ static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* co
   recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
 
   if (useMemcpyRecv) {
-    struct shmProxyInfo proxyInfo = { NULL, NULL, recv->conn.buffs[NCCL_PROTO_SIMPLE], resources->remHostMem, resources->hostMem };
+    struct shmProxyInfo proxyInfo = {};
+    proxyInfo.shmFifo = recv->conn.buffs[NCCL_PROTO_SIMPLE];
+    proxyInfo.sendMem = resources->remHostMem;
+    proxyInfo.recvMem = resources->hostMem;
     NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgConnect, &proxyInfo, sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
     recv->conn.buffs[NCCL_PROTO_SIMPLE] = proxyInfo.devFifo;
     recv->conn.tail = &proxyInfo.ceRecvMem->tail;
@@ -226,7 +232,7 @@ static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* co
   return ncclSuccess;
 }
 
-static ncclResult_t shmSendFree(struct ncclComm* comm, struct ncclConnector* send) {
+static ncclResult_t shmSendFree(struct ncclComm* /*comm*/, struct ncclConnector* send) {
   struct shmRecvResources* resources = (struct shmRecvResources*)send->transportResources;
   if (resources) {
     NCCLCHECK(ncclShmIpcClose(&resources->remDesc));
@@ -236,7 +242,7 @@ static ncclResult_t shmSendFree(struct ncclComm* comm, struct ncclConnector* sen
   return ncclSuccess;
 }
 
-static ncclResult_t shmRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
+static ncclResult_t shmRecvFree(struct ncclComm* /*comm*/, struct ncclConnector* recv) {
   struct shmRecvResources* resources = (struct shmRecvResources*)recv->transportResources;
   if (resources) {
     NCCLCHECK(ncclShmIpcClose(&resources->remDesc));
@@ -361,9 +367,9 @@ static ncclResult_t shmSendProxyProgress(struct ncclProxyState* proxyState, stru
       struct ncclProxySubArgs* sub = args->subs+s;
       struct shmProxyInfo* resources = (struct shmProxyInfo*) (sub->connection->transportResources);
       if (p != NCCL_PROTO_SIMPLE) { // Only Simple uses cudaMemcpy
-          resources->step = sub->base + sub->nsteps;
-          args->done++;
-          continue;
+        resources->step = sub->base + sub->nsteps;
+        args->done++;
+        continue;
       }
       if (sub->transmitted < sub->done + NCCL_STEPS && sub->transmitted < sub->nsteps) {
         int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
@@ -420,9 +426,9 @@ static ncclResult_t shmRecvProxyProgress(struct ncclProxyState* proxyState, stru
       struct ncclProxySubArgs* sub = args->subs+s;
       struct shmProxyInfo* resources = (struct shmProxyInfo*) (sub->connection->transportResources);
       if (p != NCCL_PROTO_SIMPLE) { // Only Simple uses cudaMemcpy
-          resources->step = sub->base + sub->nsteps;
-          args->done++;
-          continue;
+        resources->step = sub->base + sub->nsteps;
+        args->done++;
+        continue;
       }
       if (sub->transmitted < sub->done + NCCL_STEPS && sub->transmitted < sub->nsteps) {
         int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
@@ -458,7 +464,7 @@ static ncclResult_t shmRecvProxyProgress(struct ncclProxyState* proxyState, stru
   return ncclSuccess;
 }
 
-static ncclResult_t shmSendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t shmSendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* /*proxyState*/, void* reqBuff, int reqSize, void* respBuff, int respSize, int* /*done*/) {
   ncclResult_t result = ncclSuccess;
   struct shmRequest* req = (struct shmRequest*)reqBuff;
   /* check message size */
@@ -479,7 +485,7 @@ fail:
   goto exit;
 }
 
-static ncclResult_t shmRecvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t shmRecvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* /*proxyState*/, void* reqBuff, int reqSize, void* respBuff, int respSize, int* /*done*/) {
   ncclResult_t result = ncclSuccess;
   struct shmRequest* req = (struct shmRequest*)reqBuff;
   /* check message size */
@@ -666,6 +672,6 @@ ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t *desc) {
 struct ncclTransport shmTransport = {
   "SHM",
   shmCanConnect,
-  { shmSendSetup, shmSendConnect, shmSendFree, NULL, shmSendProxySetup, NULL, shmSendProxyFree, NULL },
-  { shmRecvSetup, shmRecvConnect, shmRecvFree, NULL, shmRecvProxySetup, NULL, shmRecvProxyFree, NULL }
+  { shmSendSetup, shmSendConnect, shmSendFree, NULL, shmSendProxySetup, NULL, shmSendProxyFree, NULL, NULL, NULL },
+  { shmRecvSetup, shmRecvConnect, shmRecvFree, NULL, shmRecvProxySetup, NULL, shmRecvProxyFree, NULL, NULL, NULL }
 };


### PR DESCRIPTION
## Summary
- Enable `-Wextra`, `-Wshadow=local`, `-Wnon-virtual-dtor`, `-Woverloaded-virtual`, `-Wimplicit-fallthrough` in the base CXXFLAGS for both Makefile and CMake build systems
- Enable `-Werror` by default (`WERROR=1`) so no new warnings can be introduced going forward
- Fix all existing warnings across 79 source files to achieve a zero-warning build

## Warning categories fixed
| Warning | Count | Fix |
|---|---|---|
| `-Wmissing-field-initializers` | ~343 | `= {0}` → `= {}`; complete partial aggregate inits |
| `-Wunused-parameter` | ~180 | Comment out names (`type /*name*/`); `(void)param` for conditionally-used params |
| `-Wshadow=local` | ~34 | Rename inner variables; prefix macro-internal vars with `_` |
| `-Wunused-function` | ~10 | Add `inline` to static header functions |
| `-Wtype-limits` | 5 | Remove always-false `unsigned < 0` comparisons |
| `-Wempty-body` | 4 | Add braces around conditionally-empty `TRACE()` macro bodies |
| `-Wimplicit-fallthrough` | 2 | Add `__attribute__((fallthrough))` |
| Third-party NVTX | ~192 | `#pragma GCC system_header` on vendored header |

## Design decisions
- **`-Wshadow=local`** instead of full `-Wshadow`**: Full `-Wshadow` produces ~1700 warnings from constructor parameters shadowing members (idiomatic C++). `-Wshadow=local` catches the genuinely dangerous local-shadows-local cases only.
- **`WERROR=0` escape hatch**: Developers can still build with `make WERROR=0` during prototyping if needed.
- **Vendored NVTX headers**: Suppressed via `#pragma GCC system_header` since modifying third-party code is impractical.

## Test plan
- [x] Full clean build with CUDA 12.9 on RTX 5090 — zero C++ warnings, library links successfully
- [x] `astyle` formatter run on all modified files
- [x] Tuner plugin unit tests: 15/15 passed
- [x] All 10 example programs in `docs/examples/` build cleanly under strict flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)