### PR TITLE
Fix atomic alignment

### DIFF
--- a/src/include/nccl_device/gin/proxy/gin_proxy_device_host_common.h
+++ b/src/include/nccl_device/gin/proxy/gin_proxy_device_host_common.h
@@ -118,7 +118,7 @@ typedef enum {
   ncclGinProxyGfdQwords = 8,
 } ncclGinProxyGfdQwordIdx_t;
 
-typedef struct __attribute__((packed)) {
+typedef struct {
   ncclGinProxyQword_t qword[ncclGinProxyGfdQwords];
 } ncclGinProxyGfd_t;
 static_assert(sizeof(ncclGinProxyGfd_t) == 64,


### PR DESCRIPTION
## Description

<!-- Clearly describe what the PR does and why -->

Below is the smallest reproducible code. the `__attribute__((packed))` on `ncclGinProxyGfd_t` makes the alignment of ncclGinProxyGfd_t equals to 1. The packed struct here is not needed for two reasons.
1. We will do atomic operations on the address later. packed breaks the alignment requirement of atomics
2. `ncclGinProxyQword_t` is already packed and size of it is 8 bytes. So size of `ncclGinProxyGfd_t` is 64 bytes. and `packed` is redundant here.

```c++
#include <atomic>

typedef union {
  uint64_t raw;
  struct {
    uint64_t v : 1;
    uint64_t resv : 63;
  } __attribute__((packed)) flag;
} ncclGinProxyQword_t;


static_assert(sizeof(ncclGinProxyQword_t) == sizeof(uint64_t),
              "sizeof(ncclGinProxyQword_t) != sizeof(uint64_t)");

typedef struct __attribute__((packed)) {
  ncclGinProxyQword_t qword[8];
} ncclGinProxyGfd_t;

static_assert(alignof(ncclGinProxyGfd_t) == 1,
              "Incorrect packed implementation");

void f( ncclGinProxyGfd_t *q) {
  ncclGinProxyQword_t qword;
  __atomic_load(&q[0].qword[0].raw, &qword.raw, __ATOMIC_RELAXED);
}
```

gcc does not give any warning. But clang does.
```
test_atomic.cc:24:3: warning: misaligned atomic operation may incur significant performance penalty; the expected alignment (8 bytes) exceeds the actual alignment (1 bytes) [-Watomic-alignment]
   24 |   __atomic_load(&q[0].qword[0].raw, &qword.raw, __ATOMIC_RELAXED);
      |   ^
1 warning generated.

```

## Related Issues

<!-- Reference any related issues or PRs -->
If we are going to support clang, this packed must be removed, otherwise `libatomic` needs to be linked.
https://github.com/NVIDIA/nccl/issues/1744
## Changes & Impact

<!-- Note any breaking changes or API modifications -->
This PR does not affect GCC. For clang, the generated code does not need link to `libatomic`

## Performance Impact
No difference for GCC. Significant performance improvement on clang since libatomic call is eliminated 
<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

