### PR TITLE
[nccl-ep] Remove redundant `cudaStreamSynchronize` in `ncclEpCreateHandle`

### DIFF
--- a/contrib/nccl_ep/nccl_ep.cc
+++ b/contrib/nccl_ep/nccl_ep.cc
@@ -1758,9 +1758,6 @@ ncclResult_t ncclEpCreateHandle(
             ep_group->comm,
             stream));
 
-        // Sync before preprocessing (ncclAllGather is async)
-        CUDA_CHECK(cudaStreamSynchronize(stream));
-
              // ===== Step 3: Run metadata_preprocessing =====
              // Computes exact buffer positions via parallel prefix-sum:
              //   - sparse_to_dense_map: token→rank→buffer_position mapping


### PR DESCRIPTION
## Description

The `ncclAllGather` and `call_metadata_preprocessing` are on the same CUDA stream, so intra-stream ordering already guarantees the allgather completes before the preprocessing kernel launches. Additionally, it seems nowhere else would use the allgather result `global_routing_map`.

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

Removed the `cudaStreamSynchronize`

## Performance Impact

Should save an unnecessary GPU-CPU sync. 

