### PR TITLE
[nccl-ep] Remove dead code of ht struct

### DIFF
--- a/contrib/nccl_ep/nccl_ep.cc
+++ b/contrib/nccl_ep/nccl_ep.cc
@@ -1367,35 +1367,6 @@ struct ncclEpHandle {
 
     union {
         struct {
-            // Both intranode and internode
-            int* recv_counter;
-            int* recv_counter_device;
-            int* internal_recv_expert_counter_host = nullptr;
-            int received_token_count = -1;
-            ncclNDTensor_t rank_token_counts;
-            ncclNDTensor_t expert_token_counts;
-            ncclNDTensor_t token_rank_mask;
-            ncclNDTensor_t global_channel_prefix;
-            ncclNDTensor_t nvl_send_head;
-            ncclNDTensor_t recv_global_channel_prefix;
-
-            // Internode only
-            int* rdma_recv_counter;
-            int* rdma_recv_counter_device;
-            int rdma_received_token_count = -1;
-            std::optional<ncclNDTensor_t> rdma_rank_token_counts;
-            ncclNDTensor_t rdma_channel_prefix;
-            ncclNDTensor_t recv_rdma_rank_prefix;
-            ncclNDTensor_t recv_global_rank_prefix;
-            ncclNDTensor_t rdma_send_head;
-            ncclNDTensor_t recv_source_metadata;
-            ncclNDTensor_t recv_rdma_channel_prefix;
-
-            // Intranode only
-            ncclNDTensor_t inter_rank_token_offsets;
-            ncclNDTensor_t recv_token_source_map;
-        } ht;
-        struct {
             // packed tensors for LL
             ncclNDTensor_t expert_recv_source_indices;
             ncclNDTensor_t expert_dispatch_layout;
@@ -1539,10 +1510,8 @@ struct ncclEpHandle {
           cached_mode(false),
           num_scales(0),
           hidden_int4(0) {
-        // Zero the entire union (ht, ll, hybridep share memory)
-         // Use max size to ensure all members are zeroed
-         constexpr size_t union_size = std::max({sizeof(ht), sizeof(ll), sizeof(hybridep)});
-         memset(static_cast<void*>(&ht), 0, union_size);
+        constexpr size_t union_size = std::max(sizeof(ll), sizeof(hybridep));
+        memset(static_cast<void*>(&ll), 0, union_size);
     }
 
     ~ncclEpHandle() {


### PR DESCRIPTION
## Description

the `ht` struct is completely dead code -- zero references anywhere in the codebase. Only hybridep and ll are used for the HT and LL paths respectively

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

Removed `ht` struct

## Performance Impact

No impact expected

