### PR TITLE
Fix dev_runtime memory leaks

### DIFF
--- a/src/dev_runtime.cc
+++ b/src/dev_runtime.cc
@@ -94,6 +94,9 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
   lsaSize = gcd(lsaSize, nodeSize);
   devr->lsaSize = lsaSize;
   devr->lsaSelf = comm->rank % lsaSize;
+  if (devr->lsaRankList != nullptr) {
+    free(devr->lsaRankList);
+  }
   devr->lsaRankList = (int*)malloc(devr->lsaSize*sizeof(int));
   for (int i=0; i < devr->lsaSize; i++) {
     devr->lsaRankList[i] = comm->rank + (i - devr->lsaSelf);
@@ -132,7 +135,15 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   struct ncclDevrState* devr = &comm->devrState;
   cudaStream_t stream;
   ncclResult_t ret = ncclSuccess;
-  if (devr->bigSize == 0) return ncclSuccess;
+  if (!comm->symmetricSupport || devr->bigSize == 0) {
+    if (devr->lsaRankList != nullptr) {
+      free(devr->lsaRankList);
+    }
+    if (devr->winSorted != nullptr) {
+      free(devr->winSorted);
+    }
+    return ncclSuccess;
+  }
 
   while (!ncclIntruQueueEmpty(&devr->regTaskQueue)) {
     struct ncclDevrRegTask* task = ncclIntruQueueDequeue(&devr->regTaskQueue);

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -537,6 +537,7 @@ struct ncclComm {
   ncclNet_t* ncclNet;
   void* netContext;
   void* ginContext;
+  void* rmaGinContext;
   int netPluginIndex;
   int ginPluginIndex;
   int ncclNetVer;

--- a/src/init.cc
+++ b/src/init.cc
@@ -264,8 +264,8 @@ static ncclResult_t commFree(ncclComm_t comm) {
 
   if (comm->symmetricSupport) {
     NCCLCHECK(ncclSymkFinalize(comm));
-    NCCLCHECK(ncclDevrFinalize(comm));
   }
+  NCCLCHECK(ncclDevrFinalize(comm));
   NCCLCHECK(ncclRasCommFini(comm));
 
   /* in commReclaim, we have guaranteed only last rank which calls ncclCommDestroy() will
@@ -2187,6 +2187,8 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   }
 
   NCCLCHECKGOTO(ncclCalloc(&comm, 1), res, fail);
+  comm->devrState.lsaRankList = nullptr;
+  comm->devrState.winSorted = nullptr;
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlag, 1), res, fail);
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);

--- a/src/plugin/gin.cc
+++ b/src/plugin/gin.cc
@@ -109,7 +109,7 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
 
   // Initialize RMA plugin
   if (pluginLib->ncclRmaPluginState == ncclGinPluginStateInitReady && pluginLib->ncclRma) {
-    if (pluginLib->ncclRma->init(&comm->ginContext, comm->commHash, ncclDebugLog) != ncclSuccess ||
+    if (pluginLib->ncclRma->init(&comm->rmaGinContext, comm->commHash, ncclDebugLog) != ncclSuccess ||
         pluginLib->ncclRma->devices(&ndev) != ncclSuccess || ndev <= 0) {
       pluginLib->ncclRmaPluginState = ncclGinPluginStateDisabled;
     } else {
@@ -213,6 +213,7 @@ static void initPluginLibsOnceFunc() {
 }
 
 static ncclResult_t ncclGinPluginFinalize(struct ncclComm* comm, int pluginIndex) {
+  if (ginPluginLibs[pluginIndex].ncclRma && ginPluginLibs[pluginIndex].ncclRmaPluginState == ncclGinPluginStateEnabled) NCCLCHECK(ginPluginLibs[pluginIndex].ncclRma->finalize(comm->rmaGinContext));
   if (ginPluginLibs[pluginIndex].ncclGin && ginPluginLibs[pluginIndex].ncclGinPluginState == ncclGinPluginStateEnabled) NCCLCHECK(ginPluginLibs[pluginIndex].ncclGin->finalize(comm->ginContext));
   ginPluginLibs[pluginIndex].ncclGinPluginRefCount--;
   if (pluginIndex < (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS)) {
@@ -252,6 +253,7 @@ ncclResult_t ncclGinInit(struct ncclComm* comm) {
 
 ncclResult_t ncclGinInitFromParent(struct ncclComm* comm, struct ncclComm* parent) {
   comm->ginContext = parent->ginContext;
+  comm->rmaGinContext = parent->rmaGinContext;
   comm->ginPluginIndex = parent->ginPluginIndex;
   return ncclSuccess;
 }

--- a/src/rma/rma_proxy.cc
+++ b/src/rma/rma_proxy.cc
@@ -479,7 +479,7 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   }
   if (rmaProxyState->connected) return ncclSuccess;
 
-  NCCLCHECK(rmaProxyState->ncclGin->init(&rmaProxyState->ginInstance, comm->commHash, ncclDebugLog));
+  rmaProxyState->ginInstance = comm->rmaGinContext;
 
   int ndev = 0;
   NCCLCHECK(rmaProxyState->ncclGin->devices(&ndev));


### PR DESCRIPTION
## Description

Fix CPU memory leak in dev_runtime finalize method.

Without this change we observe heap checker failures on the following code launched on H100 machine:

```
constexpr int kNumLocalDevices = 2;
ncclComm_t communicators[kNumLocalDevices];
ncclCommInitAll(communicators, kNumLocalDevices,
                /*devlist=*/nullptr);

for (int i = 0; i < kNumLocalDevices; ++i) {
  ncclCommDestroy(communicators[i]);
}
``` 

Heap checker shows the following stack trace where unreleased memory is allocated:

```
ncclDevrInitOnce()
ncclTeamLsa
initTransportsRank()
ncclCommInitRankFunc()
ncclAsyncJobMain()
```

Considering that lsaRankList is allocated before bigSize is initialized, I assume it should also be deallocated even in bigSize is zero.

## Related Issues

No issues opened IIUC

## Changes & Impact

No impact

## Performance Impact

No impact

