### PR TITLE
Fix physical NICs leaking into topology when vNICs are cached across communicators

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -1418,6 +1418,21 @@ ncclResult_t ncclTopoProcessNet(ncclXml* xml, const char* dumpXmlFile, struct nc
       NCCLCHECK(net->devices(&nDevs));
       nVirtualNics = nDevs - nPhysicalNics;
       NCCLCHECK(net->setVirtDevCount(net->netPluginIndex, nVirtualNics));
+    } else if (nVirtualNics > 0) {
+      // vNICs already created by a previous communicator. Mark merged physical
+      // NICs as keep=0 since ncclTopoMakeVNics (which normally does this) was
+      // skipped.
+      for (int v = nPhysicalNics; v < nPhysicalNics + nVirtualNics; v++) {
+        ncclNetProperties_t props;
+        NCCLCHECK(net->getProperties(v, &props));
+        for (int d = 0; d < props.vProps.ndevs; d++) {
+          ncclNetProperties_t physProps;
+          NCCLCHECK(net->getProperties(props.vProps.devs[d], &physProps));
+          struct ncclXmlNode* netNode = NULL;
+          NCCLCHECK(xmlFindTagKv(xml, "net", &netNode, "name", physProps.name));
+          if (netNode) NCCLCHECK(xmlSetAttrInt(netNode, "keep", 0));
+        }
+      }
     }
     // populate the virtual devices if any
     if (nVirtualNics > 0) {


### PR DESCRIPTION
## Summary

When multiple NCCL communicators are created in the same process, the first communicator creates virtual NICs (vNICs) via `ncclTopoMakeVNics` and caches the vNIC count via `setVirtDevCount`. Subsequent communicators skip vNIC creation (`topo.cc:1413`, `nVirtualNics != NCCL_UNDEF_DEV_COUNT`) but fail to mark the merged physical NICs as `keep=0`.

This causes the second communicator's topology to contain **both** physical and virtual NICs, giving the ring search extra NIC paths. When two sub-communicators (e.g., DP groups in a TP+DP setup) are created after a TP communicator, they can end up with different ring topologies due to the extra NICs, leading to different reduction orders in `reduce_scatter` and **bitwise non-deterministic results**.

## Root Cause

In `ncclTopoProcessNet` (`src/graph/topo.cc`):

1. `ncclTopoPopulateNics` always sets physical NICs to `keep=1` (line 1410)
2. `ncclTopoMakeVNics` creates vNICs **and** marks physical NICs `keep=0` (line 1037) — but only runs on the first communicator
3. Subsequent communicators skip step 2, leaving physical NICs with `keep=1`
4. `ncclTopoTrimXml` keeps everything with `keep=1`, so physical NICs leak into the topology

## Fix

When vNICs are already cached (`nVirtualNics > 0` but not `NCCL_UNDEF_DEV_COUNT`), query each vNIC's constituent physical devices via `getProperties` and mark them `keep=0`. This matches the behavior of `ncclTopoMakeVnic` (line 1037) without re-creating the vNICs.

## Reproduction

On GB300 with tp=2, dp=64 (128 GPUs across 2 nodes):

1. Initialize TP communicator first (e.g., `all_reduce` on TP group)
2. Initialize DP communicator (e.g., `reduce_scatter` on DP group)
3. The two DP groups (even vs odd GPUs) get different ring topologies on channels 10-15 and 26-31
4. `reduce_scatter` produces bitwise different results for TP-paired ranks with identical inputs

The issue does not reproduce when the DP communicator is initialized first, confirming the cross-communicator vNIC caching as the root cause.

## Verification

Confirmed via NCCL debug logs (`NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=GRAPH`):
- **With bug**: DP comm sees 6 NICs per GPU pair (physical 0,1,4,5 + virtual 8,10)
- **After fix**: DP comm sees only 2 vNICs per GPU pair (virtual only) — matching the behavior when DP is initialized first