### PR TITLE
Correct crossing multi-sockets bandwith of AMD Zen5/Turin CPUs

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -76,7 +76,7 @@ static ncclResult_t ncclTopoGetInterCpuBw(struct ncclTopoNode* cpu, float* bw) {
       BDW_QPI_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
-    *bw = AMD_BW;
+    *bw = cpu->cpu.model == NCCL_TOPO_CPU_MODEL_AMD_TURIN ? TURIN_XGMI_BW : AMD_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {
     *bw = cpu->cpu.model ==  NCCL_TOPO_CPU_MODEL_YONGFENG ? YONGFENG_ZPI_BW : ZPI_BW;
@@ -629,6 +629,12 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
       if (familyId == 7 && modelId == 0x5B) cpu->cpu.model = NCCL_TOPO_CPU_MODEL_YONGFENG;
+    } else if (cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
+      int familyId, modelId;
+      NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
+      NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
+      if (familyId == 0xBF && modelId == 0x2)
+        cpu->cpu.model = NCCL_TOPO_CPU_MODEL_AMD_TURIN;
     }
   }
   for (int s=0; s<xmlCpu->nSubs; s++) {

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -23,6 +23,7 @@
 #define SM100_NVLINK_BW 40.1
 #define PCI_BW 12.0           // PCI Gen3 x16
 #define AMD_BW 16.0
+#define TURIN_XGMI_BW 192.0
 #define BDW_QPI_BW 6.0
 #define SKL_QPI_BW 10.0
 #define SRP_QPI_BW 22.0

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -85,6 +85,7 @@ ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncc
 #define NCCL_TOPO_CPU_MODEL_INTEL_SRP 3
 #define NCCL_TOPO_CPU_MODEL_INTEL_ERP 4
 #define NCCL_TOPO_CPU_MODEL_YONGFENG 1
+#define NCCL_TOPO_CPU_MODEL_AMD_TURIN 1
 ncclResult_t ncclTopoCpuType(struct ncclTopoSystem* system, int* arch, int* vendor, int* model);
 ncclResult_t ncclTopoGetGpuCount(struct ncclTopoSystem* system, int* count);
 ncclResult_t ncclTopoGetNetCount(struct ncclTopoSystem* system, int* count);


### PR DESCRIPTION
## Description

This PR adds support for AMD Zen5/Turin CPUs in NCCL topology detection.The latest AMD Turin CPUs are interconnected via XGMI links with bandwidth ranging from 192-256 GB/s. However, the current NCCL codebase defines AMD_BW as only 16.0 GB, which significantly underestimates the actual bandwidth of Turin CPUs. This low bandwidth configuration causes the topology graph search to terminate prematurely, resulting in suboptimal channel configurations that cannot fully utilize the system's capabilities.

## Related Issues

N/A.

## Changes & Impact

Add detection for AMD Zen5/Turin CPUs during topology discovery and configure appropriate inter-CPU interconnect bandwidth.

## Performance Impact

In our test environment, we have 2 servers, each with 2 Zen5/Turin CPUs. Each CPU is connected to 1 NIC and 4 NVIDIA GPUs. Without this patch, the topology discovery could only create 1 channel using a single RDMA device. With this patch, the topology discovery identifies 2 channels, each configured with a different RDMA device, resulting in 2x improvement in allreduce performance.

