### PR TITLE
Fix cuMulticastUnbind silent swallow in ncclNvlsDeregBuffer

### DIFF
--- a/src/register/register.cc
+++ b/src/register/register.cc
@@ -100,10 +100,16 @@ static ncclResult_t regCleanup(struct ncclComm* comm, struct ncclReg* reg) {
     }
   }
   if (reg->state & NVLS_REG_COMPLETE) {
-    if (ncclNvlsDeregBuffer(comm, &reg->mcHandle, reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize) != ncclSuccess) {
-      WARN("rank %d deregister NVLS buffer %p dev %d ucsize %ld mcsize %ld failed", comm->rank, (void*)reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize);
-    }
+    // Propagate ncclNvlsDeregBuffer failure to the caller. Previously the
+    // return value was downgraded to a WARN and discarded, which combined
+    // with the CUCALL swallow inside ncclNvlsDeregBuffer meant that a
+    // failed cuMulticastUnbind never reached ncclCommDestroy's caller.
+    ncclResult_t deregRes = ncclNvlsDeregBuffer(comm, &reg->mcHandle, reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize);
     reg->regAddr = (CUdeviceptr)NULL;
+    if (deregRes != ncclSuccess) {
+      WARN("rank %d deregister NVLS buffer %p dev %d ucsize %ld mcsize %ld failed", comm->rank, (void*)reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize);
+      return deregRes;
+    }
   }
   if (reg->state & COLLNET_REG_COMPLETE) {
     if (ncclCollnetDeregBuffer(comm, reg->collnetProxyconn, reg->collnetHandle) != ncclSuccess) {

--- a/src/transport/nvls.cc
+++ b/src/transport/nvls.cc
@@ -112,9 +112,23 @@ ncclResult_t nvlsGroupUnbind(struct ncclComm *comm, size_t size, CUmemGenericAll
 }
 
 ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle *mcHandler, CUdeviceptr ptr, int dev, size_t ucsize, size_t mcsize) {
-  // unbind can trigger RM error if buffer is freed already by users
-  // however, it is safe to ignore the error, and unbind will succeed anyway
-  CUCALL(cuMulticastUnbind(*mcHandler, dev, 0/*mcOffset*/, ucsize));
+  // Propagate cuMulticastUnbind errors instead of swallowing them. The
+  // original code used CUCALL (see src/include/cudawrap.h), which discards
+  // the CUresult. A failing unbind leaves the multicast binding live in the
+  // CUDA driver context; cuMemRelease below only decrements the MC handle
+  // refcount and does not reverse the binding, so the caller is left with
+  // driver-level state that NCCL believes was released.
+  CUresult res = CUPFN(cuMulticastUnbind(*mcHandler, dev, 0/*mcOffset*/, ucsize));
+  if (res != CUDA_SUCCESS) {
+    const char* errStr = NULL;
+    (void) pfn_cuGetErrorString(res, &errStr);
+    WARN("cuMulticastUnbind failed (rank=%d dev=%d ucsize=%zu): CUresult=%d '%s'. "
+         "Multicast binding may remain live in the CUDA driver context.",
+         comm->rank, dev, ucsize, res, errStr ? errStr : "unknown");
+    // Skip the cuMem* cleanups — they can succeed superficially while the
+    // multicast binding is still live, masking the real state.
+    return ncclUnhandledCudaError;
+  }
   CUCHECK(cuMemUnmap(ptr, mcsize));
   CUCHECK(cuMemAddressFree(ptr, mcsize));
   CUCHECK(cuMemRelease(*mcHandler));


### PR DESCRIPTION
Partially fixes #2117 .

## Description

Propagate `cuMulticastUnbind` failures out of `ncclNvlsDeregBuffer` (was CUCALL-swallowed) and out of `regCleanup` (was downgraded to WARN). Without this, `ncclCommDeregister` / `ncclCommDestroy` report `ncclSuccess` even when driver-level multicast bindings remain live, which under cuda-checkpoint produces a poisoned process image. Full mechanism writeup and environment details are in #2117.

## Changes & Impact

Two files, +31 / -5.
- `src/transport/nvls.cc::ncclNvlsDeregBuffer` — capture `CUresult`, `WARN`, return `ncclUnhandledCudaError`, skip the now-unsafe `cuMem*` cleanups (they can succeed superficially while the multicast binding is still live).
- `src/register/register.cc::regCleanup` — propagate the dereg return value instead of WARN-and-continue.

No API change. No behavior change in the happy path (`cuMulticastUnbind` returning `CUDA_SUCCESS`).

## Performance Impact

Zero.

## Testing

Verified on NVIDIA B200 (driver 580.105.08, CUDA 12.8) with the forked 4-process reproducer attached to #2117  (full source inline there). Three runs with a ~5-line injection snippet applied to `ncclNvlsDeregBuffer` to force `cuMulticastUnbind` to return `CUDA_ERROR_UNKNOWN`:

| Run | NCCL build | injection | `ncclCommDeregister` return |
|-----|------------|-----------|-----------------------------|
| A   | unpatched `v2.27.5-1` | on  | 8 × `ncclSuccess` (bug reproduced — errors invisible) |
| B   | patched  `v2.27.5-1`  | on  | 8 × `ncclUnhandledCudaError` (fix surfaces the failure) |
| C   | patched  `v2.27.5-1`  | off | 8 × `ncclSuccess` (no regression in happy path) |

Reproducer workload per rank: `ncclCommInitRank` (4 ranks, 4 forked processes), `ncclMemAlloc` 64 MB × 2, `ncclCommRegister` send + recv, 5 × `ncclAllReduce` with `NCCL_ALGO=NVLS`, `ncclCommDeregister` (sync), `ncclCommDestroy`. 8 = 4 ranks × 2 registered buffers per rank.

Patch also applies cleanly to `master` at `6da4220` (NCCL 2.30.3-1 tip); the affected code region is unchanged between `v2.27.5-1` and current `master`.

Happy to add a regression test in `NVIDIA/nccl-tests` as a follow-up PR if the team wants one — the reproducer is already structured as a standalone C++ file that fits cleanly in that repo's conventions.
