### PR TITLE
Fix uninitialized comm->netDeviceType leading to CUDA illegal memory access

### DIFF
--- a/src/plugin/net.cc
+++ b/src/plugin/net.cc
@@ -214,6 +214,10 @@ static ncclResult_t ncclNetPluginAssignToComm(struct ncclComm* comm, int pluginI
     comm->ncclNet = netPluginLibs[pluginIndex].ncclNet;
     comm->ncclNetVer = netPluginLibs[pluginIndex].ncclNetVer;
     comm->netPluginIndex = pluginIndex;
+    ncclNetProperties_t props;
+    if (comm->ncclNet->getProperties(0, &props) == ncclSuccess) {
+      comm->netDeviceType = props.netDeviceType;
+    }
     netPluginLibs[pluginIndex].ncclNetPluginRefCount++;
     *isAssigned = true;
     INFO(NCCL_INIT|NCCL_NET, "Assigned NET plugin %s to comm", netPluginLibs[pluginIndex].ncclNet->name);
@@ -340,6 +344,7 @@ ncclResult_t ncclNetInitFromParent(struct ncclComm* comm, struct ncclComm* paren
   comm->netContext = parent->netContext;
   comm->collNetContext = parent->collNetContext;
   comm->ncclNet = parent->ncclNet;
+  comm->netDeviceType = parent->netDeviceType;
   comm->ncclCollNet = parent->ncclCollNet;
   comm->netPluginIndex = parent->netPluginIndex;
   if (comm->config.netName != NCCL_CONFIG_UNDEF_PTR && strcasecmp(comm->config.netName, parent->config.netName)) {


### PR DESCRIPTION
## Description

178b6b759074597777ce13438efb0e0ba625e429 added netDeviceType and initialized it in src/graph/topo.cc: https://github.com/NVIDIA/nccl/blob/178b6b759074597777ce13438efb0e0ba625e429/src/graph/topo.cc#L780

6aae37927840b2bd7b7d42d2f0050e75f88ee97f refactored the topo.cc loop but dropped the assignment of netDeviceType: https://github.com/NVIDIA/nccl/blob/6aae37927840b2bd7b7d42d2f0050e75f88ee97f/src/graph/topo.cc#L1151

This means that when using a net plugin that reports NCCL_NET_DEVICE_UNPACK and registering user buffers, comm->netDeviceType still reads as NCCL_NET_DEVICE_HOST, so the guard in sendrecv_reg.cc lets registration through, loadRecvConn sets both NetDeviceUnpack and NetRegMode, waitPeer() nulls the src pointer, and ncclNetDeviceUnpack dereferences NULL, causing CUDA illegal memory access.

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

