### PR TITLE
fix num_recv_tokens calculate error in nccl ep bench

### DIFF
--- a/contrib/nccl_ep/ep_bench.cu
+++ b/contrib/nccl_ep/ep_bench.cu
@@ -1982,7 +1982,7 @@ int main(int argc, char* argv[]) {
             fflush(stdout);
         }
     } else {
-        num_recv_tokens = config.max_tokens_per_rank * num_local_experts;
+        num_recv_tokens = config.max_tokens_per_rank * nRanks;
     }
     assert(num_recv_tokens);
 


### PR DESCRIPTION
## Description
When I was running ep_bench in HT mode, I encountered an “invalid argument” error, and it looks like this code error is what’s causing the problem.
This must match the allocation formula in nccl_ep.cc:998 `ep_group->max_recv_tokens = nRanks * max_tokens_per_rank`
Using num_local_experts here (instead of nRanks) overshoots when num_experts > nRanks^2, causing cudaMemcpyAsync at nccl_ep.cc:2090 to read past the IPC buffer (invalid argument).

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

