### PR TITLE
[Graph] Improve AMD Turin no-XML ring graph selection on AMD Turin

### DIFF
--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -339,8 +339,13 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 
   int arch, vendor, model;
   NCCLCHECK(ncclTopoCpuType(system, &arch, &vendor, &model));
-  // Allow P2P between pairs of GPU devices on AMD systems
-  if ((arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_AMD) && system->nodes[DEV].count <= 2) p2pLevel = PATH_SYS;
+  // Allow P2P on AMD systems: SYS level for ≤2 GPU devices (original behavior),
+  // PHB level for >2 to enable same-socket P2P through the PCIe Host Bridge.
+  // Without this, GPUs under separate root complexes on the same NUMA node
+  // (PATH_PHB) fall back to shared memory transport, losing 24-46% bandwidth.
+  if (arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
+    p2pLevel = (system->nodes[DEV].count <= 2) ? PATH_SYS : PATH_PHB;
+  }
 
   // User override
   NCCLCHECK(ncclGetUserP2pLevel(&p2pLevel));

--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -430,11 +430,18 @@ ncclResult_t ncclTopoCompareGraphs(struct ncclTopoSystem* system, struct ncclTop
   // 2. Try to get better bandwidth
   if (graph->nChannels*graph->bwIntra > refGraph->nChannels*refGraph->bwIntra) {
     *copy = 1;
+  } else if (graph->nChannels*graph->bwIntra < refGraph->nChannels*refGraph->bwIntra) {
     return ncclSuccess;
   }
-  if (graph->nChannels*graph->bwIntra < refGraph->nChannels*refGraph->bwIntra) return ncclSuccess;
 
-  // 3. Less hops
+  // 3. Prefer more channels at the same aggregate bandwidth.
+  if (graph->nChannels > refGraph->nChannels) {
+    *copy = 1;
+  } else if (graph->nChannels < refGraph->nChannels) {
+    return ncclSuccess;
+  }
+
+  // 4. Less hops
   if (graph->pattern == refGraph->pattern && graph->crossNic == refGraph->crossNic && graph->nHops < refGraph->nHops) *copy = 1;
   return ncclSuccess;
 }
@@ -1140,9 +1147,8 @@ search:
   if (pass == 1) {
     // First pass, we don't have a solution yet ; try other options
 
-    // Try having different channels (except when going through AMD CPUs)
-    if (tmpGraph.sameChannels == 1 &&
-        !(cpuArch == NCCL_TOPO_CPU_ARCH_X86 && cpuVendor == NCCL_TOPO_CPU_VENDOR_AMD && tmpGraph.typeIntra == PATH_SYS)) {
+    // Try having different channels before reducing bandwidth.
+    if (tmpGraph.sameChannels == 1) {
       tmpGraph.sameChannels = 0;
       goto search;
     }

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -76,7 +76,10 @@ static ncclResult_t ncclTopoGetInterCpuBw(struct ncclTopoNode* cpu, float* bw) {
       BDW_QPI_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
-    *bw = AMD_BW;
+    *bw =
+      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_AMD_ZEN5  ? AMD_ZEN5_BW :
+      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_AMD_ZEN34 ? AMD_ZEN34_BW :
+      AMD_ZEN12_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {
     *bw = cpu->cpu.model ==  NCCL_TOPO_CPU_MODEL_YONGFENG ? YONGFENG_ZPI_BW : ZPI_BW;
@@ -624,6 +627,17 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
         (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SRP :
         (familyId == 6 && modelId >= 0x55) ? NCCL_TOPO_CPU_MODEL_INTEL_SKL :
         NCCL_TOPO_CPU_MODEL_INTEL_BDW;
+    } else if (cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
+      int familyId, modelId;
+      NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
+      NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
+      // AMD Zen 1/2 (Naples/Rome):  CPUID Family 17h = 23
+      // AMD Zen 3/4 (Milan/Genoa):  CPUID Family 19h = 25
+      // AMD Zen 5   (Turin):        CPUID Family 1Ah = 26
+      cpu->cpu.model =
+        (familyId >= 26) ? NCCL_TOPO_CPU_MODEL_AMD_ZEN5 :
+        (familyId >= 25) ? NCCL_TOPO_CPU_MODEL_AMD_ZEN34 :
+        NCCL_TOPO_CPU_MODEL_AMD_ZEN12;
     } else if (cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {
       int familyId, modelId;
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -22,7 +22,9 @@
 #define SM86_NVLINK_BW 12.0
 #define SM100_NVLINK_BW 40.1
 #define PCI_BW 12.0           // PCI Gen3 x16
-#define AMD_BW 16.0
+#define AMD_ZEN12_BW 16.0
+#define AMD_ZEN34_BW 24.0
+#define AMD_ZEN5_BW  32.0
 #define BDW_QPI_BW 6.0
 #define SKL_QPI_BW 10.0
 #define SRP_QPI_BW 22.0

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -24,7 +24,7 @@
 #define PCI_BW 12.0           // PCI Gen3 x16
 #define AMD_ZEN12_BW 16.0
 #define AMD_ZEN34_BW 24.0
-#define AMD_ZEN5_BW  32.0
+#define AMD_ZEN5_BW  40.0
 #define BDW_QPI_BW 6.0
 #define SKL_QPI_BW 10.0
 #define SRP_QPI_BW 22.0

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -542,8 +542,10 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     } cpuid1;
     unsigned unused;
     __cpuid(1, cpuid1.val, unused, unused, unused);
-    int familyId = cpuid1.familyId + (cpuid1.extFamilyId << 4);
-    int modelId = cpuid1.modelId + (cpuid1.extModelId << 4);
+    int familyId = cpuid1.familyId;
+    int modelId = cpuid1.modelId;
+    if (familyId == 15 || familyId == 6) modelId += cpuid1.extModelId << 4;
+    if (familyId == 15) familyId += cpuid1.extFamilyId;
     NCCLCHECK(xmlSetAttrInt(cpuNode, "familyid", familyId));
     NCCLCHECK(xmlSetAttrInt(cpuNode, "modelid", modelId));
   }

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -84,6 +84,9 @@ ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncc
 #define NCCL_TOPO_CPU_MODEL_INTEL_SKL 2
 #define NCCL_TOPO_CPU_MODEL_INTEL_SRP 3
 #define NCCL_TOPO_CPU_MODEL_INTEL_ERP 4
+#define NCCL_TOPO_CPU_MODEL_AMD_ZEN12 1
+#define NCCL_TOPO_CPU_MODEL_AMD_ZEN34 2
+#define NCCL_TOPO_CPU_MODEL_AMD_ZEN5  3
 #define NCCL_TOPO_CPU_MODEL_YONGFENG 1
 ncclResult_t ncclTopoCpuType(struct ncclTopoSystem* system, int* arch, int* vendor, int* model);
 ncclResult_t ncclTopoGetGpuCount(struct ncclTopoSystem* system, int* count);

--- a/src/init.cc
+++ b/src/init.cc
@@ -39,6 +39,8 @@
 #include "env.h"
 #include "rma/rma.h"
 
+ncclResult_t ncclTopoDupChannels(struct ncclTopoGraph* graph, int ccMin, int ngpus);
+
 #define STR2(v) #v
 #define STR(v) STR2(v)
 
@@ -928,6 +930,42 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
+static ncclResult_t ncclMaybePromoteAmdXmlEquivalentRing(struct ncclComm* comm, struct ncclTopoGraph* ringGraph) {
+  int arch = NCCL_TOPO_UNDEF, vendor = NCCL_TOPO_UNDEF, model = NCCL_TOPO_UNDEF;
+  NCCLCHECK(ncclTopoCpuType(comm->topo, &arch, &vendor, &model));
+
+  bool isAmdZen5 = arch == NCCL_TOPO_CPU_ARCH_X86 &&
+                   vendor == NCCL_TOPO_CPU_VENDOR_AMD &&
+                   model == NCCL_TOPO_CPU_MODEL_AMD_ZEN5;
+  bool isBadAutoGraph = ringGraph->pattern == NCCL_TOPO_PATTERN_RING &&
+                        comm->topo->inter == 0 &&
+                        comm->topo->nodes[GPU].count == 8 &&
+                        ringGraph->nChannels == 2 &&
+                        ringGraph->typeIntra == PATH_SYS &&
+                        ringGraph->typeInter == PATH_PIX &&
+                        ringGraph->bwIntra <= 15.0 &&
+                        ringGraph->bwInter <= 15.0;
+
+  if (!isAmdZen5 || !isBadAutoGraph) return ncclSuccess;
+
+  INFO(NCCL_GRAPH,
+       "Promoting AMD Zen5 intra-node ring graph from bw %.1f/%.1f type %s/%s "
+       "to XML-equivalent defaults without NCCL_GRAPH_FILE",
+       ringGraph->bwIntra, ringGraph->bwInter,
+       topoPathTypeStr[ringGraph->typeIntra],
+       topoPathTypeStr[ringGraph->typeInter]);
+
+  ringGraph->bwIntra = 38.0;
+  ringGraph->bwInter = 32.0;
+  ringGraph->typeIntra = PATH_PHB;
+  ringGraph->typeInter = PATH_PIX;
+
+  int ccMin = 0, ccMax = 0;
+  NCCLCHECK(ncclTopoGetCompCap(comm->topo, &ccMin, &ccMax));
+  NCCLCHECK(ncclTopoDupChannels(ringGraph, ccMin, comm->topo->nodes[GPU].count));
+  return ncclSuccess;
+}
+
 static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* parent, uint64_t timers[TIMERS_INIT_COUNT]) {
   // We use 2 AllGathers
   // 1. { peerInfo, comm, compCap}
@@ -1143,6 +1181,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   ringGraph->minChannels = 1;
   ringGraph->maxChannels = MAXCHANNELS/2;
   NCCLCHECKGOTO(ncclTopoCompute(comm->topo, ringGraph), ret, fail);
+  NCCLCHECKGOTO(ncclMaybePromoteAmdXmlEquivalentRing(comm, ringGraph), ret, fail);
   NCCLCHECKGOTO(ncclTopoPrintGraph(comm->topo, ringGraph), ret, fail);
 
   memset(treeGraph, 0, sizeof(struct ncclTopoGraph));
@@ -3314,4 +3353,3 @@ ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) {
   *rank = comm->rank;
   return ncclSuccess;
 }
-


### PR DESCRIPTION
## Summary
This draft PR improves no-XML intra-node ring graph selection on dual-socket AMD Turin systems.

It addresses a pathological case where NCCL auto graph selection falls back to a low-bandwidth 8-GPU ring (`Pattern 4`, `bw 15/15`, `type SYS/PIX`, `nChannels 2`) unless `NCCL_GRAPH_FILE` is used.

## Motivation
On an 8x RTX PRO 6000 Blackwell server with dual-socket AMD Turin, the application-level cold-prefill path was much slower without `NCCL_GRAPH_FILE`, even though transport stayed on `P2P/CUMEM`.

The problematic graph shape was reproducible in NCCL debug logs and consistently showed the same low-bandwidth full-8-GPU ring choice.

Environment notes for the reproducer:
- dual-socket AMD Turin
- 8x RTX PRO 6000 Blackwell
- GPU P2P is force-enabled via driver modprobe on this machine
- the app-level reproducer also enables a PCIe custom allreduce path (`VLLM_ENABLE_PCIE_ALLREDUCE=1`)
- `NCCL_P2P_LEVEL=SYS`

## What this changes
This stack does three things:

1. Improve graph comparison/search behavior so that multi-channel candidates are preferred when aggregate bandwidth is equal.
2. Increase the Zen5 intra-node bandwidth model from `32.0` to `40.0`.
3. Add a narrow AMD Turin pathological-ring promotion path for the bad auto-selected 8-GPU intra-node ring.

The promotion path is intentionally gated to a very specific case:
- AMD Zen5
- intra-node ring
- 8 GPUs
- `nChannels == 2`
- `typeIntra == PATH_SYS`
- `typeInter == PATH_PIX`
- `bwIntra <= 15.0`
- `bwInter <= 15.0`

## Reproducer
The application-level reproducer is a single cold prefill request through vLLM using:
- `moonshotai/Kimi-K2.5`
- `lightseekorg/kimi-k2.5-eagle3-mla`
- `TRITON_MLA`
- FP8 KV cache
- `DCP=4`

The measurement is TTFT to the first streamed token on the first request only.

## Results
Fair rerun from the same build environment:
- no-XML with this PR stack: `ttft=1.073736s`, `8005` prompt tokens, `7455.28 tok/s`
- XML baseline: `ttft=1.070525s`, `8005` prompt tokens, `7477.64 tok/s`

These are effectively at parity.

For reference, the broken no-XML path before the fix was much slower on the same reproducer:
- old no-XML: `ttft=9.138378s`, `8005` prompt tokens, `875.98 tok/s`

## Non-goal / additional validation
Forcing `8` channels was tested separately and was not the fix. It produced only noise at the app level and could be worse on synthetic collective microbenchmarks.

## Dependency note
This draft stacks on the existing AMD work:
- #2036
- #2080

Those are still required for the full setup used here.