### PR TITLE
Align GIN cross-NIC default with classic graph search semantics

### DIFF
--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -998,7 +998,7 @@ float sm100SpeedArrayInter[] = { 96.0, 86.0, 80.0, 48.0, 45.1, 42.0, 40.0, 30.0,
 #define NSPEEDSINTER_SM100 (sizeof(sm100SpeedArrayInter)/sizeof(float))
 
 ncclResult_t ncclTopoCheckCrossNicSupport(bool* supported) {
-  *supported = (ncclParamCrossNic() != 0);
+  *supported = (ncclParamCrossNic() == 1);
   return ncclSuccess;
 }
 


### PR DESCRIPTION
## Summary

`ncclTopoCheckCrossNicSupport` currently returns `true` whenever
`NCCL_CROSS_NIC != 0`, which means the default value `2` commits the
GIN init path to `NCCL_GIN_CONNECTION_FULL` (any-to-any across NICs).
Unlike the classic graph search, GIN has no retry/fallback path, so
this choice is load-bearing and not correctable after init.

The classic graph search interprets the same default `NCCL_CROSS_NIC=2`
differently (`src/graph/search.cc:1011-1015, 1157-1163`): it starts with
`graph->crossNic = 0` (rail-aligned) and only retries with cross-NIC if
the rail-aligned search can't satisfy bandwidth/latency. On rail-aligned
fabrics the first attempt succeeds and cross-NIC is never used.

This change aligns GIN's default with that classic behavior by requiring
an explicit opt-in (`NCCL_CROSS_NIC=1`) to advertise cross-NIC support
to GIN. `NCCL_CROSS_NIC=0` and `NCCL_CROSS_NIC=2` both keep GIN in
`CONNECTION_RAIL`.

## Effect

| `NCCL_CROSS_NIC` | Before | After |
|------------------|--------|-------|
| unset (default 2) | `CONNECTION_FULL` | `CONNECTION_RAIL` |
| `=0` | `CONNECTION_RAIL` | `CONNECTION_RAIL` |
| `=1` | `CONNECTION_FULL` | `CONNECTION_FULL` |

Classic graph search behavior is unchanged (it reads `ncclParamCrossNic()`
directly, not through this helper).