### PR TITLE
Fix P2P useMemcpy under read mode

### DIFF
--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -460,6 +460,7 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   recv->transportResources = resources;
   int useRead, intermediateRank;
   NCCLCHECK(p2pGetInfo(comm, myInfo, peerInfo, &useRead, &intermediateRank));
+  if (useMemcpy) useRead = 0;
 
   static_assert(sizeof(struct p2pConnectInfo) <= sizeof(struct ncclConnect), "p2p Connect Info is too big");
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;


### PR DESCRIPTION
## Description

When NCCL_P2P_USE_CUDA_MEMCPY is enabled, p2pSendSetup forces useRead to 0, but p2pRecvSetup kept the value returned by p2pGetInfo. On Ampere systems where p2pGetInfo selects read mode, the connect path can later hit the existing read + memcpy guard and return ncclInternalError.

## Changes & Impact

Make p2pRecvSetup match p2pSendSetup by forcing useRead to 0 when useMemcpy is enabled.


