### PR TITLE
fix: replace sprintf/strcpy with bounds-checked snprintf/strncpy

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -218,15 +218,19 @@ static void ncclDebugInit() {
         ncclDebugTimestampFormat[i+j] = ' ';
         ncclDebugTimestampMaxSubseconds *= 10;
       }
-      strcpy(ncclDebugTimestampFormat+i+ncclDebugTimestampSubsecondDigits, tsFormat+i+replaceLen);
+      strncpy(ncclDebugTimestampFormat+i+ncclDebugTimestampSubsecondDigits, tsFormat+i+replaceLen,
+              sizeof(ncclDebugTimestampFormat)-i-ncclDebugTimestampSubsecondDigits);
+      ncclDebugTimestampFormat[sizeof(ncclDebugTimestampFormat)-1] = '\0';
       break;
     }
   }
   if (ncclDebugTimestampSubsecondsStart == -1) {
     if (strlen(tsFormat) < sizeof(ncclDebugTimestampFormat)) {
-      strcpy(ncclDebugTimestampFormat, tsFormat);
+      strncpy(ncclDebugTimestampFormat, tsFormat, sizeof(ncclDebugTimestampFormat)-1);
+      ncclDebugTimestampFormat[sizeof(ncclDebugTimestampFormat)-1] = '\0';
     } else {
-      strcpy(ncclDebugTimestampFormat, "[%F %T] ");
+      strncpy(ncclDebugTimestampFormat, "[%F %T] ", sizeof(ncclDebugTimestampFormat)-1);
+      ncclDebugTimestampFormat[sizeof(ncclDebugTimestampFormat)-1] = '\0';
     }
   }
 
@@ -357,8 +361,10 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
                  ncclDebugTimestampSubsecondDigits+1,
                  "%0*" PRIu64, ncclDebugTimestampSubsecondDigits,
                  (uint64_t)(nowNs / (1000000000L/ncclDebugTimestampMaxSubseconds)));
-        strcpy(    localTimestampFormat+ncclDebugTimestampSubsecondsStart+ncclDebugTimestampSubsecondDigits,
-               ncclDebugTimestampFormat+ncclDebugTimestampSubsecondsStart+ncclDebugTimestampSubsecondDigits);
+        strncpy(   localTimestampFormat+ncclDebugTimestampSubsecondsStart+ncclDebugTimestampSubsecondDigits,
+               ncclDebugTimestampFormat+ncclDebugTimestampSubsecondsStart+ncclDebugTimestampSubsecondDigits,
+               sizeof(localTimestampFormat)-ncclDebugTimestampSubsecondsStart-ncclDebugTimestampSubsecondDigits);
+        localTimestampFormat[sizeof(localTimestampFormat)-1] = '\0';
       }
 
       // Format the time. If it runs out of space, fall back on a simpler format.

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -301,8 +301,10 @@ static ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName)
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) return ncclSuccess;
   for (int i=index+1; i<node->nAttrs; i++) {
-    strcpy(node->attrs[i-1].key, node->attrs[i].key);
-    strcpy(node->attrs[i-1].value, node->attrs[i].value);
+    strncpy(node->attrs[i-1].key, node->attrs[i].key, MAX_STR_LEN);
+    node->attrs[i-1].key[MAX_STR_LEN] = '\0';
+    strncpy(node->attrs[i-1].value, node->attrs[i].value, MAX_STR_LEN);
+    node->attrs[i-1].value[MAX_STR_LEN] = '\0';
   }
   node->nAttrs--;
   return ncclSuccess;

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -142,7 +142,7 @@ const char *ncclSocketToString(const union ncclSocketAddress *addr, char *buf, c
    * (When not set, this will still happen in case the node's name cannot be determined.)
    */
   if (getnameinfo(saddr, sizeof(union ncclSocketAddress), host, NI_MAXHOST, service, NI_MAXSERV, flag)) goto fail;
-  sprintf(buf, "%s<%s>", host, service);
+  snprintf(buf, SOCKET_NAME_MAXLEN+1, "%s<%s>", host, service);
   return buf;
 fail:
   if (buf)

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -25,9 +25,9 @@ int ncclCudaCompCap() {
 }
 
 ncclResult_t int64ToBusId(int64_t id, char* busId) {
-  sprintf(busId, "%04lx:%02lx:%02lx.%01lx",
-          (unsigned long)((id) >> 20), (unsigned long)((id & 0xff000) >> 12),
-          (unsigned long)((id & 0xff0) >> 4), (unsigned long)(id & 0xf));
+  snprintf(busId, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE, "%04lx:%02lx:%02lx.%01lx",
+           (unsigned long)((id) >> 20), (unsigned long)((id & 0xff000) >> 12),
+           (unsigned long)((id & 0xff0) >> 4), (unsigned long)(id & 0xf));
   return ncclSuccess;
 }
 

--- a/src/os/linux_ipcsocket.cc
+++ b/src/os/linux_ipcsocket.cc
@@ -60,7 +60,8 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
 
   TRACE(NCCL_INIT|NCCL_P2P, "UDS: Creating socket %s%s", temp, useAbstractSocket ? " (abstract)" : "");
 
-  strcpy(cliaddr.sun_path, temp);
+  strncpy(cliaddr.sun_path, temp, sizeof(cliaddr.sun_path)-1);
+  cliaddr.sun_path[sizeof(cliaddr.sun_path)-1] = '\0';
   if (useAbstractSocket) {
     cliaddr.sun_path[0] = '\0'; // Linux abstract socket trick
   }
@@ -71,7 +72,8 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   }
 
   handle->fd = fd;
-  strcpy(handle->socketName, temp);
+  strncpy(handle->socketName, temp, NCCL_IPC_SOCKNAME_LEN-1);
+  handle->socketName[NCCL_IPC_SOCKNAME_LEN-1] = '\0';
 
   handle->abortFlag = abortFlag;
   // Mark socket as non-blocking
@@ -190,7 +192,8 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     WARN("UDS: Cannot connect to provided name for socket. Name too large");
     return ncclInternalError;
   }
-  strcpy(cliaddr.sun_path, temp);
+  strncpy(cliaddr.sun_path, temp, sizeof(cliaddr.sun_path)-1);
+  cliaddr.sun_path[sizeof(cliaddr.sun_path)-1] = '\0';
 
   int useAbstractSocket = ncclParamIpcUseAbstractSocket();
   if (useAbstractSocket) {

--- a/src/plugin/gin.cc
+++ b/src/plugin/gin.cc
@@ -204,7 +204,8 @@ static void initPluginLibsOnceFunc() {
       if ((strlen(ginPluginName)+1) <= MAX_STR_LEN) {
         ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateLoadReady;
         ginPluginLibs[pluginCounter].ncclGinPluginRefCount = ncclParamGinPluginRefCount();
-        strcpy(ginPluginLibs[pluginCounter].name, ginPluginName);
+        strncpy(ginPluginLibs[pluginCounter].name, ginPluginName, MAX_STR_LEN-1);
+        ginPluginLibs[pluginCounter].name[MAX_STR_LEN-1] = '\0';
         pluginCounter++;
       } else {
         INFO(NCCL_NET|NCCL_ENV,"NCCL_GIN_PLUGIN list contains a plugin name %s longer than %d characters, ignoring it.", ginPluginName, MAX_STR_LEN);
@@ -216,7 +217,9 @@ static void initPluginLibsOnceFunc() {
     // Add default gin plugin
     ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateLoadReady;
     ginPluginLibs[pluginCounter].ncclGinPluginRefCount = ncclParamGinPluginRefCount();
-    strcpy(ginPluginLibs[pluginCounter++].name, defaultGinPlugin);
+    strncpy(ginPluginLibs[pluginCounter].name, defaultGinPlugin, MAX_STR_LEN-1);
+    ginPluginLibs[pluginCounter].name[MAX_STR_LEN-1] = '\0';
+    pluginCounter++;
   }
 
   // Also check if the NET plugin has GIN support

--- a/src/plugin/net.cc
+++ b/src/plugin/net.cc
@@ -269,7 +269,8 @@ static void initPluginLibsOnceFunc() {
       if((strlen(netPluginName)+1) <= MAX_STR_LEN) {
         netPluginLibs[pluginCounter].ncclNetPluginState = ncclNetPluginStateLoadReady;
         netPluginLibs[pluginCounter].ncclNetPluginRefCount = ncclParamNetPluginRefCount();
-        strcpy(netPluginLibs[pluginCounter].name, netPluginName);
+        strncpy(netPluginLibs[pluginCounter].name, netPluginName, MAX_STR_LEN-1);
+        netPluginLibs[pluginCounter].name[MAX_STR_LEN-1] = '\0';
         pluginCounter++;
       } else {
         INFO(NCCL_NET|NCCL_ENV,"NCCL_NET_PLUGIN list contains a plugin name %s longer than %d characters, ignoring it.", netPluginName, MAX_STR_LEN);
@@ -281,7 +282,9 @@ static void initPluginLibsOnceFunc() {
     // Add default net plugin
     netPluginLibs[pluginCounter].ncclNetPluginState = ncclNetPluginStateLoadReady;
     netPluginLibs[pluginCounter].ncclNetPluginRefCount = ncclParamNetPluginRefCount();
-    strcpy(netPluginLibs[pluginCounter++].name, defaultNetPlugin);
+    strncpy(netPluginLibs[pluginCounter].name, defaultNetPlugin, MAX_STR_LEN-1);
+    netPluginLibs[pluginCounter].name[MAX_STR_LEN-1] = '\0';
+    pluginCounter++;
   }
 
   // Add 2 internal ib and socket plugins

--- a/src/plugin/profiler.cc
+++ b/src/plugin/profiler.cc
@@ -196,22 +196,22 @@ static void printProfilerEventMask(int mask) {
   if (!mask) return;
 
   char enabled[512] = {0};
-  int pos = 0;
-  if (mask & ncclProfileGroup)        pos += sprintf(enabled + pos, "Group ");
-  if (mask & ncclProfileColl)         pos += sprintf(enabled + pos, "Coll ");
-  if (mask & ncclProfileP2p)          pos += sprintf(enabled + pos, "P2p ");
-  if (mask & ncclProfileProxyOp)      pos += sprintf(enabled + pos, "ProxyOp ");
-  if (mask & ncclProfileProxyStep)    pos += sprintf(enabled + pos, "ProxyStep ");
-  if (mask & ncclProfileProxyCtrl)    pos += sprintf(enabled + pos, "ProxyCtrl ");
-  if (mask & ncclProfileKernelCh)     pos += sprintf(enabled + pos, "KernelCh ");
-  if (mask & ncclProfileNetPlugin)    pos += sprintf(enabled + pos, "NetPlugin ");
-  if (mask & ncclProfileGroupApi)     pos += sprintf(enabled + pos, "GroupApi ");
-  if (mask & ncclProfileCollApi)      pos += sprintf(enabled + pos, "CollApi ");
-  if (mask & ncclProfileP2pApi)       pos += sprintf(enabled + pos, "P2pApi ");
-  if (mask & ncclProfileKernelLaunch) pos += sprintf(enabled + pos, "KernelLaunch ");
-  if (mask & ncclProfileCeColl)       pos += sprintf(enabled + pos, "CeColl ");
-  if (mask & ncclProfileCeSync)       pos += sprintf(enabled + pos, "CeSync ");
-  if (mask & ncclProfileCeBatch)      pos += sprintf(enabled + pos, "CeBatch ");
+  size_t pos = 0;
+  if (mask & ncclProfileGroup)        pos += snprintf(enabled + pos, sizeof(enabled) - pos, "Group ");
+  if (mask & ncclProfileColl)         pos += snprintf(enabled + pos, sizeof(enabled) - pos, "Coll ");
+  if (mask & ncclProfileP2p)          pos += snprintf(enabled + pos, sizeof(enabled) - pos, "P2p ");
+  if (mask & ncclProfileProxyOp)      pos += snprintf(enabled + pos, sizeof(enabled) - pos, "ProxyOp ");
+  if (mask & ncclProfileProxyStep)    pos += snprintf(enabled + pos, sizeof(enabled) - pos, "ProxyStep ");
+  if (mask & ncclProfileProxyCtrl)    pos += snprintf(enabled + pos, sizeof(enabled) - pos, "ProxyCtrl ");
+  if (mask & ncclProfileKernelCh)     pos += snprintf(enabled + pos, sizeof(enabled) - pos, "KernelCh ");
+  if (mask & ncclProfileNetPlugin)    pos += snprintf(enabled + pos, sizeof(enabled) - pos, "NetPlugin ");
+  if (mask & ncclProfileGroupApi)     pos += snprintf(enabled + pos, sizeof(enabled) - pos, "GroupApi ");
+  if (mask & ncclProfileCollApi)      pos += snprintf(enabled + pos, sizeof(enabled) - pos, "CollApi ");
+  if (mask & ncclProfileP2pApi)       pos += snprintf(enabled + pos, sizeof(enabled) - pos, "P2pApi ");
+  if (mask & ncclProfileKernelLaunch) pos += snprintf(enabled + pos, sizeof(enabled) - pos, "KernelLaunch ");
+  if (mask & ncclProfileCeColl)       pos += snprintf(enabled + pos, sizeof(enabled) - pos, "CeColl ");
+  if (mask & ncclProfileCeSync)       pos += snprintf(enabled + pos, sizeof(enabled) - pos, "CeSync ");
+  if (mask & ncclProfileCeBatch)      pos += snprintf(enabled + pos, sizeof(enabled) - pos, "CeBatch ");
   INFO(NCCL_INIT, "Profiler event mask: 0x%x (%d) - Enabled: %s", mask, mask, enabled);
 }
 

--- a/src/ras/client.cc
+++ b/src/ras/client.cc
@@ -196,8 +196,10 @@ retry:
     err = errno;
     if (getnameinfo(ai->ai_addr, ai->ai_addrlen, hostBuf, sizeof(hostBuf), portBuf, sizeof(portBuf),
                     NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
-      strcpy(hostBuf, hostName);
-      strcpy(portBuf, port);
+      strncpy(hostBuf, hostName, sizeof(hostBuf)-1);
+      hostBuf[sizeof(hostBuf)-1] = '\0';
+      strncpy(portBuf, port, sizeof(portBuf)-1);
+      portBuf[sizeof(portBuf)-1] = '\0';
     }
     fprintf(stderr, "Connecting to %s:%s: %s\n", hostBuf, portBuf, strerror(err));
     close(sock);
@@ -217,7 +219,8 @@ retry:
   }
 
   // Exchange the RAS client handshake.
-  strcpy(msgBuf, "CLIENT PROTOCOL " STR(NCCL_RAS_CLIENT_PROTOCOL) "\n");
+  strncpy(msgBuf, "CLIENT PROTOCOL " STR(NCCL_RAS_CLIENT_PROTOCOL) "\n", sizeof(msgBuf)-1);
+  msgBuf[sizeof(msgBuf)-1] = '\0';
   if (socketWrite(sock, msgBuf, strlen(msgBuf)) != strlen(msgBuf)) {
     if (errno == EAGAIN || errno == EWOULDBLOCK) {
       goto timeout;


### PR DESCRIPTION
## Issues addressed

**Buffer overflow risk from unbounded string operations:**
- `sprintf()` writes with no size limit — any format expansion exceeding the buffer is undefined behavior
- `strcpy()` copies with no bounds check — source strings longer than the destination overflow silently

These are flagged by flawfinder (CWE-120, CWE-134), cpplint (`runtime/printf`), and gcc `-Wformat-truncation`.

## Changes

**Commit 1 — `test: add snprintf/strncpy unit tests with source verification`**
Tests first (TDD ordering). 25 table-driven test cases covering:
- `snprintf` boundary conditions, return-value overflow, incremental buffer fill, PCI bus ID format
- `strncpy` null-termination guarantees, Unix socket path (108B) and `MAX_STR_LEN` (256B) boundaries
- Source-verification tests that grep changed files for `snprintf`/`strncpy` presence (intentionally FAIL on unfixed code)

**Commit 2 — `fix: replace sprintf/strcpy with bounds-checked snprintf/strncpy`**
Mechanical replacements across 9 files:
| File | Change |
|------|--------|
| `src/debug.cc` | `strcpy` → `strncpy` for timestamp format strings |
| `src/graph/xml.h` | `strcpy` → `strncpy` for XML attribute key/value copying |
| `src/misc/socket.cc` | `sprintf` → `snprintf` for socket address formatting |
| `src/misc/utils.cc` | `sprintf` → `snprintf` for PCI bus ID formatting |
| `src/os/linux_ipcsocket.cc` | `strcpy` → `strncpy` for Unix domain socket paths |
| `src/plugin/gin.cc` | `strcpy` → `strncpy` for GIN plugin name copying |
| `src/plugin/net.cc` | `strcpy` → `strncpy` for net plugin name copying |
| `src/plugin/profiler.cc` | `sprintf` → `snprintf` with `size_t` position counter |
| `src/ras/client.cc` | `strcpy` → `strncpy` for RAS client hostname/port/handshake |

Pattern for all `strncpy` replacements:
```c
strncpy(dst, src, sizeof(dst)-1);
dst[sizeof(dst)-1] = '\0';
```

## Test plan
- [ ] Verify `snprintf` return values are handled correctly (no silent truncation bugs)
- [ ] Verify all `strncpy` calls have explicit null-termination
- [ ] Run `tests/c/test_buffer_overflow` — all 25 cases should PASS
- [ ] Build with `-Wall -Wextra` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)