### PR TITLE
symmetric/all_gather_gin: tunable ring chunk size

### DIFF
--- a/src/device/symmetric/all_gather_gin.cuh
+++ b/src/device/symmetric/all_gather_gin.cuh
@@ -15,7 +15,8 @@ __device__ __forceinline__ void ncclSymkRun_AllGather_RailRing_LsaSTMC(struct nc
   ncclSymkArgsHandler handler(args);
   ncclTeam rail = ncclTeamRail(handler.comm);
   ncclGin gin(handler.comm, (int)(blockIdx.x % handler.comm.ginContextCount));
-  constexpr int chunkSize = ncclSymkAllGather_RailRing_ChunkSize;
+  size_t chunkSize = args->allGatherRailRingChunkSize > 0 ?
+    size_t(args->allGatherRailRingChunkSize) : size_t(ncclSymkAllGather_RailRing_ChunkSize);
   ncclGinSignal_t railSignals = handler.ginSyncHandle.railSignals + blockIdx.x * rail.nRanks;
   ncclBarrierSession<ncclCoopCta> bar(cta, ncclTeamTagWorld(), gin, blockIdx.x, /*multimem=*/true);
   int nextPeer = (rail.rank + 1) % rail.nRanks;

--- a/src/include/sym_kernels.h
+++ b/src/include/sym_kernels.h
@@ -90,6 +90,7 @@ struct alignas(16) ncclSymkDevWorkArgs {
   struct ncclSymkDevComm kcomm;
   int nMaxChannels;
   int maxDynamicSmem;
+  int allGatherRailRingChunkSize;
   // starting of channelWorkRange will be aligned to 16 bytes
   // channelWorkRange[nChannels];
   // ncclSymDevWork[nWorks];
@@ -141,6 +142,7 @@ ncclResult_t ncclGetSymRegType(struct ncclDevrWindow* sendWin, struct ncclDevrWi
 
 int ncclSymkLLKernelMask();
 int ncclSymkDynamicSmemKernelMask();
+int ncclSymkAllGatherRailRingChunkSize();
 
 constexpr int ncclSymkAllGather_RailRing_ChunkSize = 1<<20;
 #endif

--- a/src/scheduler/symmetric_sched.cc
+++ b/src/scheduler/symmetric_sched.cc
@@ -262,6 +262,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
   workBufPtr = argsBuf->getWorks(nMaxChannels);
   argsBuf->nMaxChannels = nMaxChannels;
   argsBuf->maxDynamicSmem = maxDynamicSmem;
+  argsBuf->allGatherRailRingChunkSize = ncclSymkAllGatherRailRingChunkSize();
 
   while (!ncclIntruQueueEmpty(symTaskQueue)) {
     struct ncclSymkDevWork devWork = {};

--- a/src/sym_kernels.cc
+++ b/src/sym_kernels.cc
@@ -12,6 +12,7 @@
 #include "transport.h"
 #include <cmath>
 #include <cfloat>
+#include <climits>
 
 constexpr char const* kernelName[] = {
   // Must align with enum ncclSymkKernelId definition in src/include/sym_kernels.h
@@ -146,6 +147,14 @@ static uint32_t kernelMask_user() {
 NCCL_PARAM(SymCTAs, "SYM_CTAS", 0)
 NCCL_PARAM(SymGinKernelsEnable, "SYM_GIN_KERNELS_ENABLE", 1)
 NCCL_PARAM(SymTmaEnable, "SYM_TMA_ENABLE", 0)
+NCCL_PARAM(SymAllGatherRailRingChunkSize, "SYM_ALLGATHER_RAIL_RING_CHUNKSIZE", ncclSymkAllGather_RailRing_ChunkSize)
+
+int ncclSymkAllGatherRailRingChunkSize() {
+  int64_t v = ncclParamSymAllGatherRailRingChunkSize();
+  if (v <= 0) return ncclSymkAllGather_RailRing_ChunkSize;
+  if (v > INT_MAX) return INT_MAX;
+  return (int)v;
+}
 
 static double softmin(double x, double ceiling, double softness) {
   // looks like a smooth version of: min(x, ceiling)


### PR DESCRIPTION
Introduce `NCCL_SYM_ALLGATHER_RAIL_RING_CHUNKSIZE` to allow the
`AllGather_RailRing_LsaSTMC` GIN kernel's ring chunk size to be
overridden at runtime. Default behavior is unchanged (1 MB).

The optimal chunk size depends on network and topology; on some
configurations larger chunks (e.g. 4 MB) deliver materially better
busbw than the current 1 MB default by amortizing per-WR overhead
better across the NIC. Making it tunable lets users sweep without
patching.

The env var feeds into a new int field on `ncclSymkDevWorkArgs` so
the kernel can read it per-launch; when unset (=0), the kernel
falls back to the existing compile-time constant.

## Testing
for 64 ranks, (8 ranks on each nvld, across 8 nvl domains, cx8):
I think maybe 4MB could be better default but I leave that decision to NCCL dev team.
 
We can get peak perf with just 4 CTAs

<img width="946" height="619" alt="Screenshot 2026-04-28 at 3 15 29 PM" src="https://github.com/user-attachments/assets/a8ae9af3-5aa0-4091-93d6-937709f99a30" />
