### PR TITLE
symmetric/reduce_scatter_gin: tunable inbox/outbox size and per-peer cap

### DIFF
--- a/src/device/symmetric/reduce_scatter_gin.cuh
+++ b/src/device/symmetric/reduce_scatter_gin.cuh
@@ -91,7 +91,7 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
       // per peer number or total number. This is a hard constraint imposed
       // by inbox credit logic so we enforce after the max chunk size.
       int minChunkBytes_log2 = handler.ginInboxRail.size_log2 - min(
-        log2Down(rail.nRanks-1) + ncclGinScratchMaxBufsPerPeer_log2,
+        log2Down(rail.nRanks-1) + args->rsGinMaxBufsPerPeerLog2,
         ncclGinScratchMaxBufs_log2);
       chunkBytes_log2 = max(chunkBytes_log2, minChunkBytes_log2);
 

--- a/src/include/sym_kernels.h
+++ b/src/include/sym_kernels.h
@@ -90,6 +90,7 @@ struct alignas(16) ncclSymkDevWorkArgs {
   struct ncclSymkDevComm kcomm;
   int nMaxChannels;
   int maxDynamicSmem;
+  int rsGinMaxBufsPerPeerLog2;
   // starting of channelWorkRange will be aligned to 16 bytes
   // channelWorkRange[nChannels];
   // ncclSymDevWork[nWorks];
@@ -141,6 +142,7 @@ ncclResult_t ncclGetSymRegType(struct ncclDevrWindow* sendWin, struct ncclDevrWi
 
 int ncclSymkLLKernelMask();
 int ncclSymkDynamicSmemKernelMask();
+int ncclSymkRsGinMaxBufsPerPeerLog2();
 
 constexpr int ncclSymkAllGather_RailRing_ChunkSize = 1<<20;
 #endif

--- a/src/scheduler/symmetric_sched.cc
+++ b/src/scheduler/symmetric_sched.cc
@@ -262,6 +262,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
   workBufPtr = argsBuf->getWorks(nMaxChannels);
   argsBuf->nMaxChannels = nMaxChannels;
   argsBuf->maxDynamicSmem = maxDynamicSmem;
+  argsBuf->rsGinMaxBufsPerPeerLog2 = ncclSymkRsGinMaxBufsPerPeerLog2();
 
   while (!ncclIntruQueueEmpty(symTaskQueue)) {
     struct ncclSymkDevWork devWork = {};

--- a/src/sym_kernels.cc
+++ b/src/sym_kernels.cc
@@ -12,6 +12,7 @@
 #include "transport.h"
 #include <cmath>
 #include <cfloat>
+#include <climits>
 
 constexpr char const* kernelName[] = {
   // Must align with enum ncclSymkKernelId definition in src/include/sym_kernels.h
@@ -146,6 +147,15 @@ static uint32_t kernelMask_user() {
 NCCL_PARAM(SymCTAs, "SYM_CTAS", 0)
 NCCL_PARAM(SymGinKernelsEnable, "SYM_GIN_KERNELS_ENABLE", 1)
 NCCL_PARAM(SymTmaEnable, "SYM_TMA_ENABLE", 0)
+NCCL_PARAM(SymGinBufSize, "SYM_GIN_BUFSIZE", 0)
+NCCL_PARAM(SymRsGinMaxBufsPerPeerLog2, "SYM_RS_GIN_MAX_BUFS_PER_PEER_LOG2", -1)
+
+int ncclSymkRsGinMaxBufsPerPeerLog2() {
+  int64_t v = ncclParamSymRsGinMaxBufsPerPeerLog2();
+  if (v < 0) return ncclGinScratchMaxBufsPerPeer_log2;
+  if (v > ncclGinScratchMaxBufs_log2) return ncclGinScratchMaxBufs_log2;
+  return (int)v;
+}
 
 static double softmin(double x, double ceiling, double softness) {
   // looks like a smooth version of: min(x, ceiling)
@@ -265,6 +275,10 @@ static void getRequirements_gin(struct ncclComm* comm, int* out_nBlocks, size_t*
     // GIN could be throttled by LSA work
     double ginBwRenorm = std::min(lsaBw/lsaMul, ginBw/ginMul)*ginMul;
     size_t bufSize = ginBwRenorm*(ginLat + smLat);
+    int64_t bufOverride = ncclParamSymGinBufSize();
+    if (bufOverride > 0) {
+      bufSize = (size_t)bufOverride;
+    }
     int nBlocks = calcSatBlocks_ReduceScatter_RailA2A(comm, ldmc);
     if (comm->rank == 0) {
       double minLsaGinEffBw = std::min(lsaBw/lsaMul, ginBw/ginMul);


### PR DESCRIPTION
Introduce two env vars for the `ReduceScatter_RailA2A_LsaLD(MC)` GIN
kernel:

* `NCCL_SYM_GIN_BUFSIZE` overrides the per-CTA inbox/outbox capacity
  (default keeps the BW × delay model in `getRequirements_gin`).
* `NCCL_SYM_RS_GIN_MAX_BUFS_PER_PEER_LOG2` overrides the compile-time
  per-peer buffer count cap (default keeps `ncclGinScratchMaxBufsPerPeer_log2 = 2`).

Together these let users widen the producer/consumer pipeline at
runtime without patching: more (and/or larger) buffers in the inbox
ring lets stage 0 produce further ahead of NIC drain rate and helps
keep the rail-side pipeline full when the NIC has spare capacity.

The per-peer cap is plumbed via a new int field on `ncclSymkDevWorkArgs`
so the kernel reads the runtime value when computing the chunk-size
floor; when unset (=-1), it falls back to the compile-time constant.

# Testing 
for 64 ranks, (8 ranks on each nvld, across 8 nvl domains, cx8), proxy based GIN, bf16 input:
<img width="931" height="626" alt="Screenshot 2026-04-28 at 4 07 05 PM" src="https://github.com/user-attachments/assets/217b3173-6f1d-42f6-92e0-d2d0ddb8722c" />
