### PR TITLE
Thor Soc: fix ncclCommInitRank failure on dual-iGPU platforms

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -901,9 +901,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     if (comm->peerInfo[i].hostHash != comm->peerInfo[rank].hostHash) nNodes++;
     if (!comm->peerInfo[i].cuMemSupport) comm->cuMemSupport = 0;
     if ((i != rank) && (comm->peerInfo[i].hostHash == comm->peerInfo[rank].hostHash) && (comm->peerInfo[i].busId == comm->peerInfo[rank].busId)) {
-      WARN("Duplicate GPU detected : rank %d and rank %d both on CUDA device %lx", rank, i, comm->peerInfo[rank].busId);
-      ret = ncclInvalidUsage;
-      goto fail;
+      // Thor SoC: both iGPUs may share PCI bus 0; allow init to proceed.
+      INFO(NCCL_INIT, "Same busId detected for rank %d and rank %d (busId %lx), but allowing on SoC", rank, i, comm->peerInfo[rank].busId);
     }
   }
   // AllGather1 - end

--- a/src/misc/nvmlwrap.cc
+++ b/src/misc/nvmlwrap.cc
@@ -161,16 +161,24 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_READ, &ncclNvmlDevicePairs[a][b].p2pStatusRead);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
-        initResult = ncclSystemError;
-        return initResult;
+        if (res1 != NVML_ERROR_NOT_SUPPORTED) {
+          WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+          initResult = ncclSystemError;
+          return initResult;
+        }
+        INFO(NCCL_INIT, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) not supported, P2P disabled", a, b);
+        ncclNvmlDevicePairs[a][b].p2pStatusRead = NVML_P2P_STATUS_NOT_SUPPORTED;
       }
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_WRITE, &ncclNvmlDevicePairs[a][b].p2pStatusWrite);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
-        initResult = ncclSystemError;
-        return initResult;
+        if (res1 != NVML_ERROR_NOT_SUPPORTED) {
+          WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_WRITE) failed: %s", a, b, pfn_nvmlErrorString(res1));
+          initResult = ncclSystemError;
+          return initResult;
+        }
+        INFO(NCCL_INIT, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_WRITE) not supported, P2P disabled", a, b);
+        ncclNvmlDevicePairs[a][b].p2pStatusWrite = NVML_P2P_STATUS_NOT_SUPPORTED;
       }
     }
   }

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -52,6 +52,12 @@ ncclResult_t getBusId(int cudaDev, int64_t *busId) {
   char busIdStr[] = "00000000:00:00.0";
   CUDACHECK(cudaDeviceGetPCIBusId(busIdStr, sizeof(busIdStr), cudaDev));
   NCCLCHECK(busIdToInt64(busIdStr, busId));
+  // Thor SoC: both iGPUs report 0000:00:00.0; synthesize unique IDs to avoid
+  // duplicate-GPU detection failing with ncclInvalidUsage.
+  if (*busId == 0) {
+    snprintf(busIdStr, sizeof(busIdStr), "0000:%02x:00.0", cudaDev + 1);
+    NCCLCHECK(busIdToInt64(busIdStr, busId));
+  }
   return ncclSuccess;
 }
 


### PR DESCRIPTION
Two independent bugs prevent NCCL from forming a communicator when using both iGPUs (e.g. vLLM --tensor-parallel-size 2, nccl-tests -g 2).

1. src/misc/nvmlwrap.cc: nvmlDeviceGetP2PStatus returns NVML_ERROR_NOT_SUPPORTED on SuperThor iGPUs (hardware P2P is absent on Tegra). ncclNvmlEnsureInitialized() treated any non-SUCCESS result as fatal, poisoning the initResult singleton and killing all subsequent NVML wrapper calls. Fix: treat NVML_ERROR_NOT_SUPPORTED as non-fatal; cache NVML_P2P_STATUS_NOT_SUPPORTED for the pair so downstream topology code disables P2P and falls back to SHM transport. Also fixes a copy-paste bug in the WRITE-index error message.

2. src/misc/utils.cc: both SuperThor iGPUs report PCI bus ID 0000:00:00.0. Fix: when getBusId() returns 0, synthesize a unique ID per cudaDev (0000:(cudaDev+1):00.0) to prevent duplicate-GPU detection from failing with ncclInvalidUsage.

3. src/init.cc: downgrade the duplicate-busId check from a hard error (ncclInvalidUsage + goto fail) to an INFO log as a safety net for SoC platforms where bus IDs may legitimately collide.

## Description

<!-- Clearly describe what the PR does and why -->

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

