### PR TITLE
GIN: implement reset-without-zeroing for signals and counters

### DIFF
--- a/src/gin/gin_host_proxy.cc
+++ b/src/gin/gin_host_proxy.cc
@@ -67,6 +67,8 @@ struct ginProxyCtx {
   void *signalsMhandle;
   void *signalsGinHandle;
   uint64_t *signalsDev;
+  uint64_t *signalOffsetsDev;
+  uint64_t *counterOffsetsDev;
   bool hasError;
   int nContexts;
   int nCountersPerContext;
@@ -485,6 +487,14 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
   }
   proxyCtx->nSignalsPerContext = config->nSignals;
 
+  // Allocate offset arrays for reset-without-zeroing (GPU memory, zeroed)
+  if (config->nSignals) {
+    NCCLCHECK(ncclCudaCalloc(&proxyCtx->signalOffsetsDev, config->nSignals * nContexts, NULL));
+  }
+  if (config->nCounters) {
+    NCCLCHECK(ncclCudaCalloc(&proxyCtx->counterOffsetsDev, config->nCounters * nContexts, NULL));
+  }
+
   NCCLCHECK(ncclCalloc(&proxyCtx->hostGpuCtx, nContexts));
   NCCLCHECK(ncclCalloc(&devGpuCtxArray_h, nContexts));
   for (int contextId = 0; contextId < nContexts; contextId++) {
@@ -506,6 +516,8 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
     devGpuCtx_h->queueSize = hostGpuCtx->queueSize;
     devGpuCtx_h->counters = proxyCtx->countersDev + contextId * config->nCounters;
     devGpuCtx_h->signals = proxyCtx->signalsDev + contextId * config->nSignals;
+    devGpuCtx_h->signalOffsets = proxyCtx->signalOffsetsDev + contextId * config->nSignals;
+    devGpuCtx_h->counterOffsets = proxyCtx->counterOffsetsDev + contextId * config->nCounters;
     devGpuCtx_h->pis = hostGpuCtx->pis;
 
     // Allocate the GFD queues, CIs, counters, signals and test/wait variables on the either the CPU

--- a/src/include/nccl_device/gin/gdaki/gin_gdaki.h
+++ b/src/include/nccl_device/gin/gdaki/gin_gdaki.h
@@ -494,19 +494,19 @@ struct ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_GDAKI> {
 
 template <>
 struct ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_GDAKI> {
-  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
+  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
     using nccl::utility::loadConst;
     ncclGinGdakiGPUContext* gdaki = &((struct ncclGinGdakiGPUContext*)ctx.handle)[ctx.contextId];
-    return loadConst(&gdaki->counters_table.buffer) + counterId;
+    return {loadConst(&gdaki->counters_table.buffer) + counterId, 0};
   }
 };
 
 template <>
 struct ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_GDAKI> {
-  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx ctx, ncclGinSignal_t signalId) {
+  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx ctx, ncclGinSignal_t signalId) {
     using nccl::utility::loadConst;
     ncclGinGdakiGPUContext* gdaki = &((struct ncclGinGdakiGPUContext*)ctx.handle)[ctx.contextId];
-    return loadConst(&gdaki->signals_table.buffer) + signalId;
+    return {loadConst(&gdaki->signals_table.buffer) + signalId, 0};
   }
 };
 

--- a/src/include/nccl_device/gin/gin_device_common.h
+++ b/src/include/nccl_device/gin/gin_device_common.h
@@ -147,14 +147,19 @@ struct ncclGinApi_PutValue {
                                       uint32_t optFlags = ncclGinOptFlagsDefault);
 };
 
+struct ncclGinOffsetPtr {
+  uint64_t* ptr;
+  uint64_t offset;
+};
+
 template <ncclNetDeviceType backend>
 struct ncclGinApi_GetSignalPtr {
-  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx, int peer, ncclGinSignal_t signalId);
+  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx, int peer, ncclGinSignal_t signalId);
 };
 
 template <ncclNetDeviceType backend>
 struct ncclGinApi_GetCounterPtr {
-  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx, int peer, ncclGinCounter_t counterId);
+  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx, int peer, ncclGinCounter_t counterId);
 };
 
 template <ncclNetDeviceType backend>

--- a/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -303,10 +303,10 @@ struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_PROXY> {
 
 template <>
 struct ncclGinApi_GetCounterPtr<NCCL_NET_DEVICE_GIN_PROXY> {
-  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
+  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
     ncclGinProxyGpuCtx_t* proxyCtx = &((ncclGinProxyGpuCtx_t*)ctx.handle)[ctx.contextId];
-    uint64_t* counter = nccl::utility::loadConst(&proxyCtx->counters) + counterId;
-    return counter;
+    return {nccl::utility::loadConst(&proxyCtx->counters) + counterId,
+            nccl::utility::loadConst(&proxyCtx->counterOffsets)[counterId]};
   }
 };
 
@@ -315,16 +315,17 @@ struct ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_PROXY> {
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, ncclGinCounter_t counterId) {
     ncclGinProxyGpuCtx_t* proxyCtx = &((ncclGinProxyGpuCtx_t*)ctx.handle)[ctx.contextId];
     uint64_t* counter = nccl::utility::loadConst(&proxyCtx->counters) + counterId;
-    *counter = 0;
+    uint64_t* offsetPtr = nccl::utility::loadConst(&proxyCtx->counterOffsets) + counterId;
+    *offsetPtr = cuda::atomic_ref<uint64_t>{*counter}.load(cuda::memory_order_relaxed);
   }
 };
 
 template <>
 struct ncclGinApi_GetSignalPtr<NCCL_NET_DEVICE_GIN_PROXY> {
-  NCCL_DEVICE_INLINE static uint64_t* call(ncclGinCtx ctx, ncclGinSignal_t signalId) {
+  NCCL_DEVICE_INLINE static ncclGinOffsetPtr call(ncclGinCtx ctx, ncclGinSignal_t signalId) {
     ncclGinProxyGpuCtx_t* proxyCtx = &((ncclGinProxyGpuCtx_t*)ctx.handle)[ctx.contextId];
-    uint64_t* signal = nccl::utility::loadConst(&proxyCtx->signals) + signalId;
-    return signal;
+    return {nccl::utility::loadConst(&proxyCtx->signals) + signalId,
+            nccl::utility::loadConst(&proxyCtx->signalOffsets)[signalId]};
   }
 };
 
@@ -336,7 +337,9 @@ struct ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_PROXY> {
       uint64_t* signalPtr = (uint64_t*)ncclGetLocalPointer(signal.vaSignal.ncclWindow, signal.vaSignal.signalOffset);
       *signalPtr = 0;
     } else {
-      nccl::utility::loadConst(&proxyCtx->signals)[signal.indexedSignal.signalId] = 0;
+      uint64_t* signalPtr = nccl::utility::loadConst(&proxyCtx->signals) + signal.indexedSignal.signalId;
+      uint64_t* offsetPtr = nccl::utility::loadConst(&proxyCtx->signalOffsets) + signal.indexedSignal.signalId;
+      *offsetPtr = cuda::atomic_ref<uint64_t>{*signalPtr}.load(cuda::memory_order_relaxed);
     }
   }
 };

--- a/src/include/nccl_device/gin/proxy/gin_proxy_device_host_common.h
+++ b/src/include/nccl_device/gin/proxy/gin_proxy_device_host_common.h
@@ -147,6 +147,8 @@ typedef struct {
 
   uint64_t *counters;
   uint64_t *signals;
+  uint64_t *signalOffsets;
+  uint64_t *counterOffsets;
 } ncclGinProxyGpuCtx_t;
 
 #endif

--- a/src/include/nccl_device/impl/gin__funcs.h
+++ b/src/include/nccl_device/impl/gin__funcs.h
@@ -723,10 +723,11 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitCounter(
   uint32_t steps = 0;
   coop.sync();
   if (coop.thread_rank() == 0) {
-    uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), counter);
+    auto ctr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), counter);
+    least += ctr.offset;
     uint64_t got;
     #pragma unroll 1
-    do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+    do got = cuda::atomic_ref<uint64_t>{*ctr.ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
   }
   coop.sync();
@@ -745,10 +746,11 @@ NCCL_DEVICE_INLINE void ncclGinWaitCounter(
   coop.sync();
   if (coop.thread_rank() == 0) {
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
-    uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(ctx, counter);
+    auto ctr = ncclGinCall<ncclGinApi_GetCounterPtr>(ctx, counter);
+    least += ctr.offset;
     uint64_t got;
     #pragma unroll 1
-    do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+    do got = cuda::atomic_ref<uint64_t>{*ctr.ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(net->comm.abortFlag, steps));
   }
   coop.sync();
@@ -758,9 +760,10 @@ NCCL_DEVICE_INLINE void ncclGinWaitCounter(
 #if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readCounter(ncclGinCounter_t counter, int bits, cuda::memory_order ord) const {
-  uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), counter);
+  auto ctr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), counter);
   uint64_t mask = uint64_t(-1)>>(64-bits);
-  return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+  uint64_t raw = cuda::atomic_ref<uint64_t>{*ctr.ptr}.load(ord);
+  return (raw - ctr.offset) & mask;
 }
 
 NCCL_DEVICE_INLINE uint64_t ncclGinReadCounter(
@@ -770,9 +773,10 @@ NCCL_DEVICE_INLINE uint64_t ncclGinReadCounter(
     cuda::memory_order ord
   ) {
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
-  uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(ctx, counter);
+  auto ctr = ncclGinCall<ncclGinApi_GetCounterPtr>(ctx, counter);
   uint64_t mask = uint64_t(-1)>>(64-bits);
-  return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+  uint64_t raw = cuda::atomic_ref<uint64_t>{*ctr.ptr}.load(ord);
+  return (raw - ctr.offset) & mask;
 }
 #endif
 
@@ -800,9 +804,10 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::increaseSignalShadow(ncclGi
 #if NCCL_CHECK_CUDACC
 template<unsigned beMask>
 NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclGinSignal_t signal, int bits, cuda::memory_order ord) const {
-  uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
+  auto sig = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
   uint64_t mask = uint64_t(-1)>>(64-bits);
-  return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+  uint64_t raw = cuda::atomic_ref<uint64_t>{*sig.ptr}.load(ord);
+  return (raw - sig.offset) & mask;
 }
 
 template<unsigned beMask>
@@ -819,9 +824,10 @@ NCCL_DEVICE_INLINE uint64_t ncclGinReadSignal(
     cuda::memory_order ord
   ) {
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
-  uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(ctx, signal);
+  auto sig = ncclGinCall<ncclGinApi_GetSignalPtr>(ctx, signal);
   uint64_t mask = uint64_t(-1)>>(64-bits);
-  return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+  uint64_t raw = cuda::atomic_ref<uint64_t>{*sig.ptr}.load(ord);
+  return (raw - sig.offset) & mask;
 }
 #endif
 
@@ -954,10 +960,11 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclG
   uint32_t steps = 0;
   coop.sync();
   if (coop.thread_rank() == 0) {
-    uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
+    auto sig = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
+    least = least + sig.offset;
     uint64_t got;
     #pragma unroll 1
-    do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+    do got = cuda::atomic_ref<uint64_t>{*sig.ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
   }
   coop.sync();
@@ -994,10 +1001,11 @@ NCCL_DEVICE_INLINE void ncclGinWaitSignal(
   coop.sync();
   if (coop.thread_rank() == 0) {
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
-    uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(ctx, signal);
+    auto sig = ncclGinCall<ncclGinApi_GetSignalPtr>(ctx, signal);
+    least = least + sig.offset;
     uint64_t got;
     #pragma unroll 1
-    do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+    do got = cuda::atomic_ref<uint64_t>{*sig.ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(net->comm.abortFlag, steps));
   }
   coop.sync();
@@ -1012,11 +1020,11 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop c
   uint32_t steps = 0;
   coop.sync();
   if (coop.thread_rank() == 0) {
-    uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
-    uint64_t least = this->_signalShadows[signal];
+    auto sig = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
+    uint64_t least = this->_signalShadows[signal] + sig.offset;
     uint64_t got;
     #pragma unroll 1
-    do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
+    do got = cuda::atomic_ref<uint64_t>{*sig.ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
   }
   coop.sync();
@@ -1033,10 +1041,14 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop
   uint64_t before64 = this->_signalShadows[signal];
   uint64_t after64;
   if (coop.thread_rank() == 0) {
-    uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
+    auto sig = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
+    uint64_t offset = sig.offset;
+    uint64_t least = before64 + leastDelta + offset;
     #pragma unroll 1
-    do after64 = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
-    while (!nccl::utility::rollingLessEq(before64 + leastDelta, after64, bits) && !testAbort(this->comm.abortFlag, steps));
+    do after64 = cuda::atomic_ref<uint64_t>{*sig.ptr}.load(ord);
+    while (!nccl::utility::rollingLessEq(least, after64, bits) && !testAbort(this->comm.abortFlag, steps));
+    // Convert NIC value back to logical space for shadow
+    after64 = after64 - offset;
     this->_signalShadows[signal] = after64;
   }
   if (ncclCoopWithinWarp(coop) && bits <= 32) { // do a single __shfl_sync instead of 2


### PR DESCRIPTION
## Description

Replace signal/counter reset-by-zeroing in GIN with an offset-based scheme.
Instead of writing zero to the underlying atomic, resetSignal and
resetCounter snapshot the current value into a per-context offset
array. Subsequent reads and waits subtract the offset, making the
signal/counter appear reset without modifying the NIC-visible value.

## Related Issues

Original PR against 2.30 https://github.com/NVIDIA/nccl/pull/2093

## Changes & Impact

None

## Performance Impact

Improved performance on p5en with GIN.

