### PR TITLE
nccl_ep: Fix integer overflow in inter-node N2N warp at 8+ nodes

### DIFF
--- a/contrib/nccl_ep/device/hybrid_ep.cuh
+++ b/contrib/nccl_ep/device/hybrid_ep.cuh
@@ -974,11 +974,11 @@ __forceinline__ __device__ void N2N_warp_group_device_function(const int local_r
       int remote_node_id = remote_idx < node_rank ? remote_idx : remote_idx + 1;
       int rank_in_remote = remote_idx < node_rank ? node_rank - 1 : node_rank;
 
-      int dense_dst_offset = smem_mr_info_ptr->rdma_inter_node_group_packed_offset +
-                               rank_in_remote * smem_mr_info_ptr->max_tokens_per_dest *
-                               smem_mr_info_ptr->bytes_per_entry +
-                               static_cast<size_t>(chunk_idx * NUM_OF_TOKENS_PER_CHUNK) *
-                               smem_mr_info_ptr->bytes_per_entry;
+      size_t dense_dst_offset = smem_mr_info_ptr->rdma_inter_node_group_packed_offset +
+                                static_cast<size_t>(rank_in_remote) * smem_mr_info_ptr->max_tokens_per_dest *
+                                smem_mr_info_ptr->bytes_per_entry +
+                                static_cast<size_t>(chunk_idx * NUM_OF_TOKENS_PER_CHUNK) *
+                                smem_mr_info_ptr->bytes_per_entry;
 
       // Create a bitmask of tokens that need to be written. One word per 32 tokens.
       int32_t need_write_bitmask[NUM_OF_TOKENS_PER_CHUNK / 32];


### PR DESCRIPTION
## Description

Fix integer overflow in inter-node N2N warp at 8+ nodes encountered when running NCCL EP benchmark using high throughput mode. 

The `dense_dst_offset` variable in the inter-node N2N warp of the dispatch kernel was declared as int, causing signed 32-bit overflow when computing RDMA write destination offsets at 8 nodes. The offset calculation `(rank_in_remote * max_tokens_per_dest * bytes_per_entry + chunk_offset * bytes_per_entry)` exceeds `INT32_MAX` (~2.1 GB) with large GIN buffers, producing a negative value that sign-extends to a bogus 64-bit address. Later in `net.put()`, RDMA write failed with this bogus address falling out of the MR region.


## Changes & Impact

This commit changes `dense_dst_offset` from `int` to `size_t`.


