### PR TITLE
fix num_recv_tokens calculation issue

### DIFF
--- a/contrib/nccl_ep/ep_bench.cu
+++ b/contrib/nccl_ep/ep_bench.cu
@@ -1982,7 +1982,7 @@ int main(int argc, char* argv[]) {
             fflush(stdout);
         }
     } else {
-        num_recv_tokens = config.max_tokens_per_rank * num_local_experts;
+        num_recv_tokens = config.max_tokens_per_rank * nRanks;
     }
     assert(num_recv_tokens);
 

--- a/contrib/nccl_ep/ep_test.cu
+++ b/contrib/nccl_ep/ep_test.cu
@@ -344,7 +344,7 @@ int main(int argc, char* argv[])
   }
   else {
   // Specific to this test
-    num_recv_tokens = config.max_tokens_per_rank * num_local_experts;
+    num_recv_tokens = config.max_tokens_per_rank * nRanks;
   }
   assert(num_recv_tokens);
 

--- a/contrib/nccl_ep/ep_test.py
+++ b/contrib/nccl_ep/ep_test.py
@@ -343,7 +343,7 @@ def main():  # noqa: C901 — intentionally kept as a single function to mirror 
     if disable_max_tokens:
         num_recv_tokens = nccl.ncclEpHandleGetNumRecvTokens(ep_handle)
     else:
-        num_recv_tokens = config.max_tokens_per_rank * num_local_experts
+        num_recv_tokens = config.max_tokens_per_rank * n_ranks
     assert num_recv_tokens > 0
 
     # -- dispatch config ----------------------------------------------------


### PR DESCRIPTION
## Description
num_recv_tokens calculated from nRanks. 

<!-- Clearly describe what the PR does and why -->

## Related Issues
ep_bench will fail if nRanks != num_local_experts
<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

