### PR TITLE
bootstrap: Fix data race in network init flag

### DIFF
--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -15,6 +15,7 @@
 #include "ras.h"
 #include <mutex>
 #include "os.h"
+#include <atomic>
 #include <thread>
 #include <chrono>
 
@@ -99,15 +100,15 @@ struct bootstrapRootArgs {
 /* Init functions */
 static char bootstrapNetIfName[MAX_IF_NAME_SIZE+1];
 static union ncclSocketAddress bootstrapNetIfAddr;
-static int bootstrapNetInitDone = 0;
+static std::atomic<int> bootstrapNetInitDone{0};
 static std::mutex bootstrapNetMutex;
 
 NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
 
 ncclResult_t bootstrapNetInit() {
-  if (bootstrapNetInitDone == 0) {
+  if (bootstrapNetInitDone.load(std::memory_order_acquire) == 0) {
     std::lock_guard<std::mutex> lock(bootstrapNetMutex);
-    if (bootstrapNetInitDone == 0) {
+    if (bootstrapNetInitDone.load(std::memory_order_relaxed) == 0) {
       const char* env = ncclGetEnv("NCCL_COMM_ID");
       int nIfs = 0;
       if (env) {
@@ -133,7 +134,7 @@ ncclResult_t bootstrapNetInit() {
       snprintf(line, sizeof(line), " %s:", bootstrapNetIfName);
       ncclSocketToString(&bootstrapNetIfAddr, line+strlen(line));
       INFO(NCCL_BOOTSTRAP, "Bootstrap: Using%s", line);
-      bootstrapNetInitDone = 1;
+      bootstrapNetInitDone.store(1, std::memory_order_release);
     }
   }
   return ncclSuccess;


### PR DESCRIPTION
## Description

The bootstrapNetInitDone variable in bootstrapNetInit was declared as int, 
causing a data race when concurrent callers read it before taking bootstrapNetMutex
while another thread writes it after completing bootstrap network interface initialization.

This commit changes bootstrapNetInitDone from int to std::atomic<int> and
uses acquire/release ordering around the double-checked initialization path.

## Related Issues

#2062

## Changes & Impact

Use an atomic boot initial flag

