### PR TITLE
Improve diagnostic logging in ncclShadowPoolFree error path

### DIFF
--- a/src/allocator.cc
+++ b/src/allocator.cc
@@ -422,7 +422,9 @@ ncclResult_t ncclShadowPoolFree(struct ncclShadowPool* pool, void* devObj, cudaS
   struct ncclShadowObject** pobj = &pool->table[b];
   while (true) {
     if (*pobj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      WARN("ncclShadowPoolFree: Device object %p not found in shadow pool (hash bucket %lu). "
+           "This may indicate a use-after-free or double-free error. Pool has %lu objects.",
+           devObj, b, pool->count);
       return ncclInternalError;
     }
     if ((*pobj)->devObj == devObj) break;


### PR DESCRIPTION


## Description

- Enhanced WARN message when device object not found in shadow pool
- Include device pointer address for better debugging
- Include hash bucket index to identify which bucket caused issue
- Include total object count in pool for context
- Help distinguish between use-after-free vs double-free vs corruption
- Makes debugging memory issues in shadow pools much easier

## Changes & Impact
Example
Before: WARN: Device object does not exist in shadow pool.
After: WARN: ncclShadowPoolFree: Device object 0x7f2c40000000 not found in shadow pool (hash bucket 42). This may indicate...
WARN: ncclShadowPoolFree: Device object 0x1234567890ab not found in shadow pool (hash bucket 8). This may indicate...
WARN: ncclShadowPoolFree: Device object 0xdeadbeefcafe not found in shadow pool (hash bucket 127). This may indicate...

