### PR TITLE
bootstrap, socket: handle bad magic without blocking caller

### DIFF
--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -272,6 +272,27 @@ struct extInfo {
 #define NET_HANDLE(h, rank)    ((h) + (rank * NCCL_NET_HANDLE_MAXSIZE))
 #define BOOTSTRAP_HANDLE(h, i) ((struct ncclBootstrapHandle*)((char*)h + i * NCCL_UNIQUE_ID_BYTES))
 
+// Bootstrap-side accept wrapper. ncclSocketAccept's default behavior
+// (retryOnBadMagic=true) loops internally on bad-magic events, which can
+// monopolize CPU and starve legitimate peer connects when a non-NCCL TCP
+// peer hits the bootstrap listen socket. We pass retryOnBadMagic=false and
+// drive the retry from here: close the rejected socket, yield 1ms, retry.
+// abortFlag is honored between iterations.
+static ncclResult_t bootstrapAccept(struct ncclSocket* sock, struct ncclSocket* listenSock,
+                                    volatile uint32_t* abortFlag) {
+  while (1) {
+    if (abortFlag != NULL && COMPILER_ATOMIC_LOAD(abortFlag, std::memory_order_acquire) != 0) {
+      return ncclInternalError;
+    }
+    NCCLCHECK(ncclSocketInit(sock));
+    NCCLCHECK(ncclSocketAccept(sock, listenSock, /*retryOnBadMagic=*/false));
+    if (sock->state != ncclSocketStateBadMagic) return ncclSuccess;
+    INFO(NCCL_INIT|NCCL_NET, "bootstrap: rejected bad-magic peer connection on listen sock, retrying accept");
+    (void)ncclSocketClose(sock);
+    usleep(1000);
+  }
+}
+
 static ncclResult_t rootSend(union ncclSocketAddress* addr, uint64_t magic, union ringConnectInfo* info) {
   ncclResult_t res = ncclSuccess;
   struct ncclSocket sock;
@@ -310,8 +331,8 @@ static void* bootstrapRoot(void* rargs) {
   /* Receive addresses from all ranks */
   do {
     struct ncclSocket sock;
-    NCCLCHECKGOTO(ncclSocketInit(&sock), res, out);
-    NCCLCHECKGOTO(ncclSocketAccept(&sock, listenSock), res, out);
+    // No abortFlag: bootstrapRoot is a detached thread without a comm.
+    NCCLCHECKGOTO(bootstrapAccept(&sock, listenSock, /*abortFlag=*/NULL), res, out);
     NCCLCHECKGOTO(socketRecv(&sock, &info, sizeof(info)), res, out);
     NCCLCHECKGOTO(ncclSocketClose(&sock), res, out);
 
@@ -604,8 +625,7 @@ static ncclResult_t netRingConnect(void* ctx, ncclNet_t* net, struct bootstrapLi
 static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
   NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag));
   NCCLCHECK(ncclSocketConnect(sendSocket));
-  NCCLCHECK(ncclSocketInit(recvSocket));
-  NCCLCHECK(ncclSocketAccept(recvSocket, listenSock));
+  NCCLCHECK(bootstrapAccept(recvSocket, listenSock, abortFlag));
   return ncclSuccess;
 }
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
@@ -781,8 +801,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   // get info on my "next" rank in the bootstrap ring from root
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RECV]);
   if(curr_root >= 0){
-    NCCLCHECK(ncclSocketInit(&sock));
-    NCCLCHECK(ncclSocketAccept(&sock, &listenSockRoot));
+    NCCLCHECK(bootstrapAccept(&sock, &listenSockRoot, comm->abortFlag));
     NCCLCHECK(socketRecv(&sock, &nextPeer, sizeof(nextPeer)));
     NCCLCHECK(ncclSocketClose(&sock));
     NCCLCHECK(ncclSocketClose(&listenSockRoot));
@@ -1041,8 +1060,7 @@ static ncclResult_t socketAccept(void* commState, int peer, int tag, struct nccl
   // Then look for new connections
   while (1) {
     struct socketAckInfo ack = {0};
-    NCCLCHECKGOTO(ncclSocketInit(sock), ret, fail);
-    NCCLCHECKGOTO(ncclSocketAccept(sock, &STATE_LISTEN(state, peerSocket)), ret, fail);
+    NCCLCHECKGOTO(bootstrapAccept(sock, &STATE_LISTEN(state, peerSocket), state->abortFlag), ret, fail);
     NCCLCHECKGOTO(socketRecv(sock, &ack, sizeof(struct socketAckInfo)), ret, fail);
     // Match: tag must match, and peer must match (peer < 0 means wildcard)
     if (ack.tag == tag && (peer < 0 || ack.rank == peer)) return ncclSuccess;

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -414,6 +414,12 @@ static ncclResult_t socketFinalizeConnect(struct ncclSocket* sock) {
 }
 
 static ncclResult_t socketProgressState(struct ncclSocket* sock) {
+  // BadMagic is set by socketFinalizeAccept on magic mismatch. The reset in
+  // ncclSocketAccept's do-while only fires while that loop runs; this covers
+  // the path where a caller re-enters via ncclSocketReady with state=BadMagic.
+  if (sock->state == ncclSocketStateBadMagic) {
+    sock->state = ncclSocketStateAccepting;
+  }
   if (sock->state == ncclSocketStateAccepting) {
     NCCLCHECK(ncclOsSocketTryAccept(sock));
   }


### PR DESCRIPTION
## Description

### Overview
This PR extends the bad-magic handling in #1808 / PR #1834 (commits `8fdd98c` and follow-up `7310803`) to the bootstrap layer and the async-mode progress path, both of which remain vulnerable on `v2.30u1`.

**Provenance and verification status.** This PR is derived from a corresponding fix we developed and verified in RCCL ([ROCm/rccl#2177](https://github.com/ROCm/rccl/pull/2177)) where the same hang reproduced reliably at scale and is no longer observed after the fix. We have not independently observed or reproduced the equivalent hang in NCCL, and the NCCL patch in this PR has not been tested at production scale. We are submitting it upstream because the relevant code paths in NCCL `v2.30u1` are structurally identical to the RCCL paths we patched, and the residual gaps described below are present in current `v2.30u1` HEAD.

**Branch target.** Targeting `v2.30u1` rather than `master` because the prior bad-magic fixes were merged to `v2.30u1`; this follows the same convention.

### Why the existing fixes are not enough

Issue #1808 / PR #1834 added `ncclSocketStateBadMagic` and a `retryOnBadMagic` parameter to `ncclSocketAccept`, then set `retryOnBadMagic=false` at the proxy and ras callsites so the do-while inside `ncclSocketAccept` exits on bad-magic events instead of looping forever.

That change covers proxy and ras only. Two remaining gaps:

**Gap 1: Bootstrap accept callsites (sync-mode monopolization)**

Four `ncclSocketAccept` callsites in `bootstrap.cc` (`bootstrapRoot`, `socketRingConnect`, `bootstrapInit`, `socketAccept`) retain the default `retryOnBadMagic=true`. When a non-NCCL peer hits the bootstrap listen socket, the do-while resets state from `BadMagic` back to `Accepting` after each event and continues. Once the bad-magic queue is drained, `accept()` returns `EAGAIN` (the listen socket is non-blocking), state stays `Accepting`, and the loop spins. The bootstrap thread is trapped inside `ncclSocketAccept` and cannot service legitimate peer connects. A single stuck rank cascade-hangs the whole job's `commInit`.

**Gap 2: Async-mode `ncclSocketReady` callers (silent stall)**

`socketFinalizeAccept` transitions to `BadMagic` on magic mismatch. `socketProgressState`'s if-cascade has no case for `BadMagic` — the only `BadMagic` reset lives inside `ncclSocketAccept`'s do-while and only fires while that loop runs. Async-mode callers re-enter `socketProgressState` via `ncclSocketReady` (e.g. transport accept path); if state lands on `BadMagic` there, `ncclSocketReady` returns `*running=0` indefinitely. The thread is not stuck (it continues servicing other work), but the specific per-`recvComm` accept stage stops making progress and any global PG depending on that peer-pair handshake hangs.

This is a regression introduced by `8fdd98c`'s addition of the `BadMagic` terminal state. Pre-`8fdd98c` code had no `BadMagic` state to get stuck at.

## Related Issues

#1808 / PR #1834

## Changes & Impact

### Added a`bootstrap.cc` — `bootstrapAccept` wrapper

```c
static ncclResult_t bootstrapAccept(struct ncclSocket* sock, struct ncclSocket* listenSock,
                                    volatile uint32_t* abortFlag) {
  while (1) {
    if (abortFlag != NULL && COMPILER_ATOMIC_LOAD(abortFlag, std::memory_order_acquire) != 0) {
      return ncclInternalError;
    }
    NCCLCHECK(ncclSocketInit(sock));
    NCCLCHECK(ncclSocketAccept(sock, listenSock, /*retryOnBadMagic=*/false));
    if (sock->state != ncclSocketStateBadMagic) return ncclSuccess;
    INFO(NCCL_INIT|NCCL_NET, "bootstrap: rejected bad-magic peer connection on listen sock, retrying accept");
    (void)ncclSocketClose(sock);
    usleep(1000);
  }
}
```

Pass `retryOnBadMagic=false` so `ncclSocketAccept` returns control to this wrapper after each bad-magic event; close the rejected socket; yield 1 ms (avoid 100% CPU busy-spin under sustained flood); honor `abortFlag` between iterations. The four bootstrap callsites are updated to call this helper.

### `misc/socket.cc` — `socketProgressState` BadMagic recovery

```c
static ncclResult_t socketProgressState(struct ncclSocket* sock) {
  if (sock->state == ncclSocketStateBadMagic) {
    sock->state = ncclSocketStateAccepting;
  }
  if (sock->state == ncclSocketStateAccepting) {
    NCCLCHECK(ncclOsSocketTryAccept(sock));
  }
  ...
}
```

Makes the if-cascade self-healing: any caller (sync or async) that re-enters `socketProgressState` with `state=BadMagic` gets state reset to `Accepting` and progresses normally on the next poll. Sync callers that pass `retryOnBadMagic=false` (proxy, ras, the new `bootstrapAccept`) are unaffected: their state only becomes `BadMagic` after `socketProgressState` returns inside the loop, the do-while exits, and the caller observes `BadMagic` before the next `socketProgressState` call.

([ROCm/rccl#2177](https://github.com/ROCm/rccl/pull/2177)) has more details on the observed symptoms without the fix.
And init hang disappears with this PR.

## Performance Impact

I expect there to be no performance concerns regarding this PR. Init hang fix is not on the perf critical path.