### PR TITLE
fix(build): check for IB verbs extension(s) support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2015-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#                                   (c) 2026      Barcelona Supercomputing Center
 # SPDX-License-Identifier: Apache-2.0
 #
 # See LICENSE.txt for more license information
@@ -10,6 +11,19 @@ include ../makefiles/version.mk
 ##### src files
 INCEXPORTS  := nccl.h nccl_device.h \
 	$(patsubst include/%,%,$(wildcard include/nccl_device/*.h include/nccl_device/*/*.h include/nccl_device/*/*/*.h))
+
+# NOTE: Make sure that platform supports IBV extension(s), do not assume it.
+ifneq ($(RDMA_CORE), 0)
+TEST_FILE = temp__file.c
+IBV_HAS_ACTIVE_SPEED_EX := $(shell printf "#include <infiniband/verbs.h>\nint main(void) { struct ibv_port_attr a; a.active_speed_ex = 0; return 0; }" > $(TEST_FILE); \
+	if $(CC) -c $(TEST_FILE) -o /dev/null > /dev/null 2>&1; then echo 1; else echo 0; fi; \
+	rm -f $(TEST_FILE))
+else
+# Stubs do have support for it.
+IBV_HAS_ACTIVE_SPEED_EX := 1
+endif
+CFLAGS += -DIBV_HAS_ACTIVE_SPEED_EX=$(IBV_HAS_ACTIVE_SPEED_EX)
+CXXFLAGS += -DIBV_HAS_ACTIVE_SPEED_EX=$(IBV_HAS_ACTIVE_SPEED_EX)
 
 # On Linux use real net_socket and net_ib; on Windows use stubs (avoid multiple definition)
 TRANSPORT_CC = $(wildcard transport/*.cc)

--- a/src/transport/net_ib/CMakeLists.txt
+++ b/src/transport/net_ib/CMakeLists.txt
@@ -1,3 +1,26 @@
+# NOTE: Make sure that platform supports IBV extension(s), do not assume it.
+if(RDMA_CORE)
+    include(CheckCSourceCompiles)
+
+    check_c_source_compiles("
+    #include <infiniband/verbs.h>
+    int main(void) {
+        struct ibv_port_attr a;
+        a.active_speed_ex = 0;
+        return 0;
+    }
+    " IBV_HAS_ACTIVE_SPEED_EX)
+else()
+    # Stubs do have support for it.
+    set(IBV_HAS_ACTIVE_SPEED_EX ON)
+endif ()
+if(IBV_HAS_ACTIVE_SPEED_EX)
+    add_compile_definitions(IBV_HAS_ACTIVE_SPEED_EX=1)
+else()
+    add_compile_definitions(IBV_HAS_ACTIVE_SPEED_EX=0)
+endif()
+
+
 # Transport sources
 set(NET_IB_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/common.cc

--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -354,12 +354,13 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
               ncclIbDevs[ncclNIbDevs].portAttr = portAttr;
               ncclIbDevs[ncclNIbDevs].portNum = port_num;
               ncclIbDevs[ncclNIbDevs].link = portAttr.link_layer;
+#if IBV_HAS_ACTIVE_SPEED_EX
               if (portAttr.active_speed_ex) {
                 // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
                 ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed_ex) * ncclIbWidth(portAttr.active_width);
-              } else {
+              } else
+#endif
                 ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed) * ncclIbWidth(portAttr.active_width);
-              }
               ncclIbDevs[ncclNIbDevs].context = context;
               ncclIbDevs[ncclNIbDevs].pdRefs = 0;
               ncclIbDevs[ncclNIbDevs].pd = NULL;


### PR DESCRIPTION
## Description

Latest NCCL implementations added support for
Infiniband extension features, such as `active_speed_ex` in `struct ibv_port_attr`. However, such additional support was not added in a backward compatible way.
This fix adds proper configuration-time checks to make sure the Infiniband installation supports newer features and extensions, instead of blindly assuming they are supported,
causing compile errors in the "net_ib" transport component.

Credits: AccelCom @ Barcelona Supercomputing Center

## Related Issues

N/A.

## Changes & Impact

N/A.

## Performance Impact

N/A.

