### PR TITLE
Fix GIN init context leak

### DIFF
--- a/src/plugin/gin.cc
+++ b/src/plugin/gin.cc
@@ -104,14 +104,21 @@ fail:
 
 static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* pluginLib) {
   int ndev;
+  bool ginInitCompleted = false;
   // Init must be called for each new comm to set the right context
   if (pluginLib->state >= ncclGinPluginStateInitReady && pluginLib->ncclGin) {
     if (!pluginLib->ncclGin->init || pluginLib->ncclGin->init(&comm->ginContext, comm->commHash, ncclDebugLog) != ncclSuccess) {
       pluginLib->state = ncclGinPluginStateDisabled;
+    } else {
+      ginInitCompleted = true;
     }
   }
   if (pluginLib->state == ncclGinPluginStateInitReady && pluginLib->ncclGin) {
     if (pluginLib->ncclGin->devices(&ndev) != ncclSuccess || ndev <= 0) {
+      if (ginInitCompleted) {
+        pluginLib->ncclGin->finalize(comm->ginContext);
+        comm->ginContext = nullptr;
+      }
       pluginLib->state = ncclGinPluginStateDisabled;
     } else {
       pluginLib->physDevs = ndev;


### PR DESCRIPTION

## Summary

Fix a small per-rank GIN initialization context leak.

`ncclGinPluginInit()` initializes GIN and RMA plugin contexts before checking
whether the plugin reports usable devices. If `devices()` fails or reports no
devices after `init()` succeeds, the plugin is disabled, but the just-created
context was not finalized.

This patch tracks whether each `init()` call completed successfully. If the
following `devices()` check fails, the corresponding context is finalized and
the comm context pointer is cleared before disabling the plugin.

## Root Cause

`ncclGinIbInitType()` allocates a `ncclNetCommConfig_t` context and returns it
through `ctx`:

```cpp
ncclNetCommConfig_t* netCommConfig = nullptr;
NCCLCHECK(ncclCalloc(&netCommConfig, 1));
netCommConfig->trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
*ctx = netCommConfig;
```

When `ncclGinPluginInit()` later disables the plugin because `devices()` fails
or returns no devices, that context was not released.

## Validation

Built successfully:

```bash
make -C /home/hongfei/nccl -j$(nproc) src.build
```

Valgrind smoke test:

```text
2 ranks
CUDA_VISIBLE_DEVICES=2,3
tests:
  all_reduce_perf_mpi
  all_gather_perf_mpi
  reduce_scatter_perf_mpi
args:
  -b 4 -e 4 -f 2 -g 1 -n 1 -w 0 -c 0
```

To reduce third-party network-stack noise during validation:

```bash
NCCL_IB_DISABLE=1
OMPI_MCA_pml=ob1
OMPI_MCA_btl=self,vader,tcp
OMPI_MCA_mtl=^ofi
```

Before this patch, after filtering MPI/OpenMPI/UCX/verbs/CUDA driver
allocations, Valgrind reported a stable NCCL-owned leak:

```text
definitely lost: 8 bytes / rank

stack:
ncclCallocDebug<ncclNetCommConfig_v12_t>
ncclGinIbInitType
ncclGinPluginInit
ncclGinInit
commAlloc
ncclCommInitRankFunc
```

After this patch, the same tests report no NCCL-owned definite/indirect leak
records:

```text
all_reduce:        nccl_definite_indirect_count = 0
all_gather:        nccl_definite_indirect_count = 0
reduce_scatter:    nccl_definite_indirect_count = 0
```

All three tests also completed successfully with:

```text
Out of bounds values : 0 OK
Collective test concluded
```

## Notes

Valgrind still reports third-party noise from MPI/OpenMPI and CUDA driver paths,
for example `cuLibraryLoadData`, but those records are outside the NCCL-owned
GIN/RMA context leak fixed here.
```
