### PR TITLE
fix(net/ib): add rank logging and tracking for IB communications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ examples/**/allreduce
 examples/**/allreduce_ub
 examples/**/allreduce_sm
 examples/**/allreduce_device_api
+
+src/include/plugin/net_observ/ruijie-json.grpc.pb.h
+src/include/plugin/net_observ/ruijie-json.pb.h
+src/plugin/net_observ/ruijie-json.grpc.pb.cc
+src/plugin/net_observ/ruijie-json.pb.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ set(NCCL_PRIVATE_INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}/device
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include/plugin
+    ${PLUGIN_NET_OBSERV_INCLUDES}
     ${CUDAToolkit_INCLUDE_DIRS}
     ${CUDAToolkit_INCLUDE_DIRS}/cccl
     ${CMAKE_BINARY_DIR}/obj/include

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,6 +32,7 @@ LIBSRCFILES := \
 	$(wildcard plugin/tuner/*.cc) \
 	$(wildcard plugin/profiler/*.cc) \
 	$(wildcard plugin/env/*.cc) \
+	$(wildcard plugin/net_observ/*.cc) \
 	$(wildcard nccl_device/*.cc) \
 	$(wildcard scheduler/*.cc) \
 	$(wildcard gin/*.cc) \
@@ -228,8 +229,8 @@ $(PKGDIR)/%.pc : %.pc
 $(OBJDIR)/%.o : %.cc $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
-	$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
-	@$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -I$(DOCA_HOME)/include -M $< > $(@:%.o=%.d.tmp)
+	$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -Iplugin/include -I$(DOCA_HOME)/include -c $< -o $@
+	@$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -Iplugin/include -I$(DOCA_HOME)/include -M $< > $(@:%.o=%.d.tmp)
 	@sed "0,/^.*:/s//$(subst /,\/,$@):/" $(@:%.o=%.d.tmp) > $(@:%.o=%.d)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:%.o=%.d.tmp) | fmt -1 | \
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,6 +17,14 @@ ifeq ($(NCCL_OS_LINUX), 1)
 TRANSPORT_CC := $(filter-out transport/net_socket_stub.cc transport/net_ib_stub.cc,$(TRANSPORT_CC))
 endif
 
+# Protobuf/gRPC generated files for ruijie-json proto (must be defined before LIBSRCFILES)
+RUIJIE_JSON_PB_SRC := plugin/net_observ/ruijie-json.pb.cc plugin/net_observ/ruijie-json.grpc.pb.cc
+RUIJIE_JSON_PB_HDR := include/plugin/net_observ/ruijie-json.pb.h include/plugin/net_observ/ruijie-json.grpc.pb.h
+RUIJIE_JSON_INC    := include/plugin/net_observ
+PROTOC             := protoc
+GRPC_CPP_PLUGIN    := /usr/bin/grpc_cpp_plugin
+RUIJIE_JSON_PROTO  := plugin/net_observ/ruijie-json.proto
+
 LIBSRCFILES := \
 	bootstrap.cc channel.cc collectives.cc debug.cc enqueue.cc group.cc \
 	init.cc proxy.cc transport.cc mnnvl.cc allocator.cc dev_runtime.cc sym_kernels.cc ce_coll.cc mem_manager.cc \
@@ -32,7 +40,8 @@ LIBSRCFILES := \
 	$(wildcard plugin/tuner/*.cc) \
 	$(wildcard plugin/profiler/*.cc) \
 	$(wildcard plugin/env/*.cc) \
-	$(wildcard plugin/net_observ/*.cc) \
+	$(filter-out $(RUIJIE_JSON_PB_SRC),$(wildcard plugin/net_observ/*.cc)) \
+	$(RUIJIE_JSON_PB_SRC) \
 	$(wildcard nccl_device/*.cc) \
 	$(wildcard scheduler/*.cc) \
 	$(wildcard gin/*.cc) \
@@ -86,7 +95,7 @@ LIBOBJ     := $(LIBSRCFILES:%.cc=$(OBJDIR)/%.o)
 BINOBJ     := $(BINSRCFILES:%.cc=$(OBJDIR)/%.o)
 PARAMBINOBJ     := $(PARAMBINSRCFILES:%.cc=$(OBJDIR)/%.o)
 DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d) $(PARAMBINOBJ:%.o=%.d)
-LDFLAGS    += -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+LDFLAGS    += -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -lprotobuf -lgrpc++ -lgrpc -lgpr -labsl_strings -labsl_synchronization -labsl_time -labsl_status
 INCPLUGIN  := include/plugin
 
 DEVMANIFEST := $(BUILDDIR)/obj/device/manifest
@@ -97,19 +106,40 @@ $(GIT_VERSION_FILE): ALWAYS_REBUILD
 	@mkdir -p $(dir $@)
 	@./misc/generate_git_version.py $@
 
+# Proto compilation for ruijie-json
+RUIJIE_JSON_PB_STAMP := $(OBJDIR)/.ruijie-json-proto-stamp
+
+$(RUIJIE_JSON_PB_STAMP): $(RUIJIE_JSON_PROTO)
+	@printf "Generating %-35s\n" "ruijie-json proto/grpc files"
+	mkdir -p include/plugin/net_observ
+	$(PROTOC) --proto_path=plugin/net_observ \
+		--cpp_out=plugin/net_observ \
+		--grpc_out=plugin/net_observ \
+		--plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN) \
+		$(RUIJIE_JSON_PROTO)
+	mv plugin/net_observ/ruijie-json.pb.h include/plugin/net_observ/ruijie-json.pb.h
+	mv plugin/net_observ/ruijie-json.grpc.pb.h include/plugin/net_observ/ruijie-json.grpc.pb.h
+	@mkdir -p $(dir $@) && touch $@
+
+$(RUIJIE_JSON_PB_SRC) $(RUIJIE_JSON_PB_HDR): $(RUIJIE_JSON_PB_STAMP)
+
+$(RUIJIE_JSON_PB_SRC:%.cc=$(OBJDIR)/%.o): $(RUIJIE_JSON_PB_STAMP)
+
 # DOCA GPUNetIO definitions
 DOCA_HOME        ?= transport/net_ib/gdaki/doca-gpunetio
 DOCA_INC_INSTALL := $(INCDIR)/nccl_device/gin/gdaki/doca_gpunetio
 DOCA_OBJDIR      := $(OBJDIR)/transport/net_ib/gdaki/doca-gpunetio
 DOCA_INCLUDES    := $(DOCA_HOME)/include/doca_gpunetio_device.h $(wildcard $(DOCA_HOME)/include/common/*.h) $(wildcard $(DOCA_HOME)/include/device/*.cuh)
 DOCA_INCTARGETS  := $(DOCA_INCLUDES:$(DOCA_HOME)/include/%=$(DOCA_INC_INSTALL)/%)
-INCTARGETS       += $(DOCA_INCTARGETS)
+INCTARGETS += $(DOCA_INCTARGETS)
 DOCA_LIBSRC      := doca_verbs_qp.cpp doca_verbs_cq.cpp doca_verbs_device_attr.cpp doca_verbs_umem.cpp doca_verbs_srq.cpp doca_verbs_uar.cpp doca_gpunetio.cpp doca_gpunetio_log.cpp doca_gpunetio_high_level.cpp doca_verbs_cuda_wrapper.cpp doca_verbs_mlx5dv_wrapper.cpp doca_verbs_ibv_wrapper.cpp doca_gpunetio_gdrcopy.cpp
 DOCA_LIBOBJ      := $(DOCA_LIBSRC:%.cpp=$(DOCA_OBJDIR)/%.o)
 LIBOBJ           += $(DOCA_LIBOBJ)
 
 ##### rules
-build : lib staticlib binary
+build : proto lib staticlib binary
+
+proto : $(RUIJIE_JSON_PB_STAMP)
 
 lib : $(INCTARGETS) $(LIBDIR)/$(LIBTARGET) $(PKGDIR)/$(PKGTARGET)
 
@@ -229,8 +259,8 @@ $(PKGDIR)/%.pc : %.pc
 $(OBJDIR)/%.o : %.cc $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
-	$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -Iplugin/include -I$(DOCA_HOME)/include -c $< -o $@
-	@$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -Iplugin/include -I$(DOCA_HOME)/include -M $< > $(@:%.o=%.d.tmp)
+	$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -I$(RUIJIE_JSON_INC) -Iplugin/include -I$(DOCA_HOME)/include -c $< -o $@
+	@$(CXX) -I. -I$(INCDIR) -I$(OBJDIR)/include $(CXXFLAGS) -Iinclude -I$(INCPLUGIN) -I$(RUIJIE_JSON_INC) -Iplugin/include -I$(DOCA_HOME)/include -M $< > $(@:%.o=%.d.tmp)
 	@sed "0,/^.*:/s//$(subst /,\/,$@):/" $(@:%.o=%.d.tmp) > $(@:%.o=%.d)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:%.o=%.d.tmp) | fmt -1 | \
                 sed -e 's/^ *//' -e 's/$$/:/' >> $(@:%.o=%.d)

--- a/src/include/plugin/net_observ/net_observ.h
+++ b/src/include/plugin/net_observ/net_observ.h
@@ -8,4 +8,234 @@
 #ifndef NCCL_NET_OBSERV_H_
 #define NCCL_NET_OBSERV_H_
 
-#endif // NCCL_NET_OBSERV_H_
+#include <string>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <regex>
+#include <cstdint>
+#include <array>
+
+#include <grpcpp/server_builder.h>
+
+// For gethostname and gethostbyname
+#include <unistd.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+
+#include "ruijie-json.pb.h"
+#include "ruijie-json.grpc.pb.h"
+
+namespace net_observ {
+
+extern const char* const COLOR_RED;
+extern const char* const COLOR_YELLOW;
+extern const char* const COLOR_GREEN;
+extern const char* const COLOR_CYAN;
+extern const char* const COLOR_MAGENTA;
+extern const char* const COLOR_BOLD;
+extern const char* const COLOR_DIM;
+extern const char* const COLOR_RESET;
+
+enum class AlertLevel {
+  PREDICTIVE,
+  CONFIRMED
+};
+
+extern const char* const RETRANS_COUNTER_NAMES[];
+extern const int RETRANS_COUNTER_NAMES_COUNT;
+
+extern const std::regex NCCL_HCA_PATTERN;
+extern const std::regex NCCL_PEER_IP_PATTERN;
+
+struct NicCounterSnapshot {
+  double timestamp;
+  std::map<std::string, int64_t> counters;
+};
+
+struct NicDeviceInfo {
+  std::string ibDevName;
+  int portNum;
+  std::string sysfsPath;
+};
+
+struct PortMappingInfo {
+  std::string node;
+  std::vector<int> ranks;
+  std::string rdmaNic;
+};
+
+struct Incident {
+  int incidentId;
+  std::string incidentTag;
+  std::string portName;
+  std::string switchName;
+  std::string deviceModel;
+  int64_t dropCount;
+  std::string timestamp;
+  std::vector<int> affectedRanks;
+  std::vector<std::string> faultPaths;
+  std::string rdmaNic;
+  std::map<std::string, int64_t> nicDelta;
+  bool hasRetryGrowth;
+  double createTime;
+  bool confirmed;
+  double confirmTime;
+  std::string ncclError;
+};
+
+struct LldpNeighborInfo {
+  std::string switchPort;
+  std::string nodeIp;
+  std::string remotePortDesc;
+  std::string remoteChassisId;
+  std::string remoteSysName;
+  std::string remoteSysDesc;
+  int64_t timeMark;
+};
+
+struct LldpTopologyEntry {
+  std::string switchPort;
+  std::string nodeIp;
+  std::string rdmaNic;
+  std::string description;
+};
+
+class TopologyConfig {
+ public:
+  std::string switchIp;
+  std::string switchName;
+  int grpcPort;
+  std::map<std::string, PortMappingInfo> portMapping;
+
+  std::vector<std::string> getPortsForNode(const std::string& nodeIp) const;
+  std::vector<int> getRanksForPort(const std::string& portName) const;
+  std::string getNodeForPort(const std::string& portName) const;
+  std::string getRdmaNicForPort(const std::string& portName) const;
+  std::vector<std::string> getAllPorts() const;
+  std::string getPortByNodeAndNic(const std::string& nodeIp, const std::string& rdmaNic) const;
+
+  static TopologyConfig loadFromFile(const std::string& configPath);
+};
+
+class NicCounterReader {
+ public:
+  static constexpr const char* IB_SYSFS_BASE = "/sys/class/infiniband";
+
+  NicCounterReader();
+
+  std::vector<std::string> discoverNics();
+  void captureBaseline(const std::string& nicKey = "");
+  std::map<std::string, int64_t> readDelta(const std::string& nicKey);
+  std::pair<bool, std::map<std::string, int64_t>> checkNicRetrans(const std::string& rdmaNic);
+
+ private:
+  std::map<std::string, NicDeviceInfo> deviceCache_;
+  std::map<std::string, NicCounterSnapshot> baselines_;
+
+  std::map<std::string, int64_t> readCounters(const std::string& nicKey);
+};
+
+class SwitchEventServicer : public ruijie_json::Json::Service {
+ public:
+  grpc::Status JsonSend(grpc::ServerContext* context,
+                        const ruijie_json::JsonRequest* request,
+                        ruijie_json::JsonReply* response) override;
+  grpc::Status JsonStreamSend(grpc::ServerContext* context,
+                              grpc::ServerReaderWriter<ruijie_json::JsonReply,
+                              ruijie_json::JsonRequest>* stream) override;
+
+  std::vector<ruijie_json::JsonRequest> getPendingEvents();
+
+ private:
+  std::mutex mtx_;
+  std::vector<ruijie_json::JsonRequest> events_;
+};
+
+class NetworkObserver {
+ public:
+  NetworkObserver(TopologyConfig* topology, int rank, double pollInterval = 2.0);
+  ~NetworkObserver();
+
+  int start();
+  void stop();
+  void confirmFromException(const std::string& errorText);
+
+  // Direct IB error handling from transport layer
+  void handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus);
+
+  // Accessors for C interface functions
+  NicCounterReader& getNicReader() { return nicReader_; }
+  std::unordered_map<std::string, Incident>& getActiveIncidents() { return activeIncidents_; }
+  std::mutex& getIncidentsMutex() { return incidentsMutex_; }
+
+ private:
+  TopologyConfig* topology_;
+  int rank_;
+  double pollInterval_;
+
+  volatile bool stopRequested_;
+  std::unique_ptr<std::thread> monitorThread_;
+  std::unique_ptr<grpc::Server> grpcServer_;
+  SwitchEventServicer eventServicer_;
+
+  int incidentId_;
+  NicCounterReader nicReader_;
+  std::unordered_map<std::string, Incident> activeIncidents_;
+  std::mutex incidentsMutex_;
+
+  void monitorLoop();
+  void handleEvent(const ruijie_json::JsonRequest& event);
+  void handleSwitchDropEvent(const ruijie_json::JsonRequest& event);
+  void handleLldpEvent(const ruijie_json::JsonRequest& event);
+  std::string formatTimestamp(const std::string& timestampRaw);
+  std::vector<std::string> buildFaultPath(const std::vector<std::string>& affectedPorts,
+                                           const std::string& deviceModel,
+                                           const std::string& peerPort = "");
+  std::string formatCounterDelta(const std::map<std::string, int64_t>& delta);
+  void emitSwitchDropAlert(const Incident& incident);
+  void emitPredictiveAlert(const Incident& incident);
+  void emitConfirmedAlert(const Incident& incident);
+
+  std::vector<LldpNeighborInfo> parseLldpJson(const std::string& jsonString);
+  std::string inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp = "");
+  void updateTopologyFromLldp(const std::vector<LldpNeighborInfo>& lldpInfos,
+                              const std::string& deviceModel);
+  void printLldpTopology(const std::vector<LldpTopologyEntry>& entries);
+
+  // SSH remote query helpers
+  std::string getLocalIpAddress();
+  std::string executeCommand(const std::string& cmd);
+  std::string queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev);
+};
+
+std::string extractJsonString(const std::string& json, const std::string& key);
+int64_t extractJsonInt(const std::string& json, const std::string& key);
+
+// ---- Global singleton management (integrated into NCCL init) ----
+// Reads NCCL_NET_OBSERV_ENABLE, NCCL_NET_OBSERV_CONFIG, NCCL_NET_OBSERV_POLL_INTERVAL
+// env vars and manages the NetworkObserver lifecycle automatically.
+// Returns 0 on success, non-zero on failure (ncclSuccess/ncclSystemError convention).
+int ncclNetObservInit(void);
+void ncclNetObservFinalize(void);
+
+// ---- Rank topology update (called after ncclCommInitRank) ----
+// Updates the topology mapping with rank distribution information from NCCL comm.
+// This should be called after ncclCommInitRank to get accurate rank-to-node mapping.
+// nodeRanks: array of rank lists for each node, indexed by node ID
+void ncclNetObservUpdateRankTopology(const std::vector<std::vector<int>>& nodeRanks);
+
+// ---- IB error handling (called from net_ib/p2p.cc) ----
+// Directly handles IB completion queue errors from the IB transport layer.
+// This provides faster error detection compared to parsing NCCL exceptions.
+// rdmaNic: RDMA NIC device name (e.g., "mlx5_0")
+// peerIp: Peer node IP address (optional, can be empty)
+// wcStatus: IB work completion status code
+void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus);
+
+}  // namespace net_observ
+
+#endif  // NCCL_NET_OBSERV_H_

--- a/src/include/plugin/net_observ/net_observ.h
+++ b/src/include/plugin/net_observ/net_observ.h
@@ -66,6 +66,7 @@ struct PortMappingInfo {
   std::string node;
   std::vector<int> ranks;
   std::string rdmaNic;
+  std::string rdmaNicIp;  // RDMA NIC IP address (e.g., "192.168.1.17")
 };
 
 struct Incident {
@@ -87,6 +88,11 @@ struct Incident {
   std::string ncclError;
 };
 
+struct RdmaNicInfo {
+  std::string name;  // e.g., "mlx5_0"
+  std::string ip;    // e.g., "192.168.1.17"
+};
+
 struct LldpNeighborInfo {
   std::string switchPort;
   std::string nodeIp;
@@ -101,6 +107,7 @@ struct LldpTopologyEntry {
   std::string switchPort;
   std::string nodeIp;
   std::string rdmaNic;
+  std::string rdmaNicIp;  // RDMA NIC IP address (e.g., "192.168.1.17")
   std::string description;
 };
 
@@ -117,6 +124,7 @@ class TopologyConfig {
   std::string getRdmaNicForPort(const std::string& portName) const;
   std::vector<std::string> getAllPorts() const;
   std::string getPortByNodeAndNic(const std::string& nodeIp, const std::string& rdmaNic) const;
+  std::string getPortByRdmaNicIp(const std::string& rdmaNicIp) const;
 
   static TopologyConfig loadFromFile(const std::string& configPath);
 };
@@ -202,7 +210,7 @@ class NetworkObserver {
   void emitConfirmedAlert(const Incident& incident);
 
   std::vector<LldpNeighborInfo> parseLldpJson(const std::string& jsonString);
-  std::string inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp = "");
+  RdmaNicInfo inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp = "");
   void updateTopologyFromLldp(const std::vector<LldpNeighborInfo>& lldpInfos,
                               const std::string& deviceModel);
   void printLldpTopology(const std::vector<LldpTopologyEntry>& entries);
@@ -210,7 +218,7 @@ class NetworkObserver {
   // SSH remote query helpers
   std::string getLocalIpAddress();
   std::string executeCommand(const std::string& cmd);
-  std::string queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev);
+  RdmaNicInfo queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev);
 };
 
 std::string extractJsonString(const std::string& json, const std::string& key);

--- a/src/include/plugin/net_observ/net_observ.h
+++ b/src/include/plugin/net_observ/net_observ.h
@@ -1,0 +1,11 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef NCCL_NET_OBSERV_H_
+#define NCCL_NET_OBSERV_H_
+
+#endif // NCCL_NET_OBSERV_H_

--- a/src/include/plugin/net_observ/net_observ.h
+++ b/src/include/plugin/net_observ/net_observ.h
@@ -162,10 +162,9 @@ class NetworkObserver {
 
   int start();
   void stop();
-  void confirmFromException(const std::string& errorText);
 
   // Direct IB error handling from transport layer
-  void handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus);
+  void handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus, int tpRank, int tpRemoteRank);
 
   // Accessors for C interface functions
   NicCounterReader& getNicReader() { return nicReader_; }
@@ -194,7 +193,9 @@ class NetworkObserver {
   std::string formatTimestamp(const std::string& timestampRaw);
   std::vector<std::string> buildFaultPath(const std::vector<std::string>& affectedPorts,
                                            const std::string& deviceModel,
-                                           const std::string& peerPort = "");
+                                           const std::string& peerPort = "",
+                                           int tpRank = -1,
+                                           int tpRemoteRank = -1);
   std::string formatCounterDelta(const std::map<std::string, int64_t>& delta);
   void emitSwitchDropAlert(const Incident& incident);
   void emitPredictiveAlert(const Incident& incident);
@@ -234,7 +235,7 @@ void ncclNetObservUpdateRankTopology(const std::vector<std::vector<int>>& nodeRa
 // rdmaNic: RDMA NIC device name (e.g., "mlx5_0")
 // peerIp: Peer node IP address (optional, can be empty)
 // wcStatus: IB work completion status code
-void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus);
+void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus, int tpRank, int tpRemoteRank);
 
 }  // namespace net_observ
 

--- a/src/include/plugin/net_observ/net_observ.h
+++ b/src/include/plugin/net_observ/net_observ.h
@@ -193,6 +193,7 @@ class NetworkObserver {
   NicCounterReader nicReader_;
   std::unordered_map<std::string, Incident> activeIncidents_;
   std::mutex incidentsMutex_;
+  bool lldpHandled_;
 
   void monitorLoop();
   void handleEvent(const ruijie_json::JsonRequest& event);

--- a/src/init.cc
+++ b/src/init.cc
@@ -29,6 +29,8 @@
 #include "profiler.h"
 #include "mnnvl.h"
 #include <sys/stat.h>
+#include <vector>
+#include <string>
 #include "param.h"
 #include "nvtx_payload_schemas.h"
 #include "utils.h"
@@ -38,6 +40,13 @@
 #include "os.h"
 #include "env.h"
 #include "rma/rma.h"
+
+// Forward declarations for net_observ singleton (managed via env vars)
+namespace net_observ {
+int ncclNetObservInit(void);
+void ncclNetObservFinalize(void);
+void ncclNetObservUpdateRankTopology(const std::vector<std::vector<int>>& nodeRanks);
+}
 
 #define STR2(v) #v
 #define STR(v) STR2(v)
@@ -149,6 +158,9 @@ static void initOnceFunc() {
   NCCLCHECKGOTO(bootstrapNetInit(), initResult, exit);
 
   initNvtxRegisteredEnums();
+  // Initialize NetworkObserver (controlled by NCCL_NET_OBSERV_ENABLE env var)
+  net_observ::ncclNetObservInit();
+  atexit(net_observ::ncclNetObservFinalize);
 exit:;
 }
 
@@ -2415,6 +2427,28 @@ ncclResult_t ncclCommInitRank(ncclComm_t* newcomm, int nranks, ncclUniqueId comm
 
   NVTX3_RANGE_ADD_PAYLOAD(CommInitRank, NcclNvtxParamsCommInitRankSchema,
     NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+
+  // Update NetworkObserver with rank topology information
+  // This allows the observer to know which ranks belong to which nodes
+  if (*newcomm && (*newcomm)->nNodes > 0) {
+    struct ncclComm* comm = *newcomm;
+    std::vector<std::vector<int>> nodeRanks;
+
+    // Get ranks for each node (indexed by node ID)
+    for (int node = 0; node < comm->nNodes; node++) {
+      std::vector<int> ranks;
+      for (int rank = 0; rank < comm->nRanks; rank++) {
+        if (comm->rankToNode[rank] == node) {
+          ranks.push_back(rank);
+        }
+      }
+      nodeRanks.push_back(ranks);
+    }
+
+    if (!nodeRanks.empty()) {
+      net_observ::ncclNetObservUpdateRankTopology(nodeRanks);
+    }
+  }
 
   return ncclSuccess;
 }

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -24,3 +24,6 @@ set(PLUGIN_SOURCES
 
 # Add plugin sources to parent scope
 set(PLUGIN_SOURCES ${PLUGIN_SOURCES} PARENT_SCOPE)
+
+# Pass net_observ include path up to parent scope
+set(PLUGIN_NET_OBSERV_INCLUDES ${PLUGIN_NET_OBSERV_INCLUDES} PARENT_SCOPE)

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(net)
 add_subdirectory(gin)
 add_subdirectory(tuner)
 add_subdirectory(env)
+add_subdirectory(net_observ)
 
 # Plugin sources
 set(PLUGIN_SOURCES
@@ -18,6 +19,7 @@ set(PLUGIN_SOURCES
     ${PLUGIN_PROFILER_SOURCES}
     ${PLUGIN_TUNER_SOURCES}
     ${PLUGIN_ENV_SOURCES}
+    ${PLUGIN_NET_OBSERV_SOURCES}
 )
 
 # Add plugin sources to parent scope

--- a/src/plugin/net_observ/CMakeLists.txt
+++ b/src/plugin/net_observ/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Net observ plugin sources
+set(PLUGIN_NET_OBSERV_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/net_observ.cc
+)
+
+# Add net observ plugin sources to parent scope
+set(PLUGIN_NET_OBSERV_SOURCES ${PLUGIN_NET_OBSERV_SOURCES} PARENT_SCOPE)

--- a/src/plugin/net_observ/CMakeLists.txt
+++ b/src/plugin/net_observ/CMakeLists.txt
@@ -1,7 +1,46 @@
 # Net observ plugin sources
+
+find_package(Protobuf REQUIRED)
+find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
+
+set(RUIJIE_JSON_PROTO ${CMAKE_CURRENT_SOURCE_DIR}/ruijie-json.proto)
+set(RUIJIE_JSON_GEN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(RUIJIE_JSON_GEN_HDR_DIR ${CMAKE_SOURCE_DIR}/src/include/plugin/net_observ)
+
+set(RUIJIE_JSON_PB_HDR ${RUIJIE_JSON_GEN_HDR_DIR}/ruijie-json.pb.h)
+set(RUIJIE_JSON_PB_SRC ${RUIJIE_JSON_GEN_SRC_DIR}/ruijie-json.pb.cc)
+set(RUIJIE_JSON_GRPC_HDR ${RUIJIE_JSON_GEN_HDR_DIR}/ruijie-json.grpc.pb.h)
+set(RUIJIE_JSON_GRPC_SRC ${RUIJIE_JSON_GEN_SRC_DIR}/ruijie-json.grpc.pb.cc)
+
+add_custom_command(
+  OUTPUT ${RUIJIE_JSON_PB_SRC} ${RUIJIE_JSON_PB_HDR} ${RUIJIE_JSON_GRPC_SRC} ${RUIJIE_JSON_GRPC_HDR}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${RUIJIE_JSON_GEN_HDR_DIR}
+  COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS --proto_path=${CMAKE_CURRENT_SOURCE_DIR}
+         --cpp_out=${RUIJIE_JSON_GEN_SRC_DIR}
+         --grpc_out=${RUIJIE_JSON_GEN_SRC_DIR}
+         --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}
+         ${RUIJIE_JSON_PROTO}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${RUIJIE_JSON_GEN_SRC_DIR}/ruijie-json.pb.h
+    ${RUIJIE_JSON_PB_HDR}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${RUIJIE_JSON_GEN_SRC_DIR}/ruijie-json.grpc.pb.h
+    ${RUIJIE_JSON_GRPC_HDR}
+  COMMAND ${CMAKE_COMMAND} -E remove
+    ${RUIJIE_JSON_GEN_SRC_DIR}/ruijie-json.pb.h
+    ${RUIJIE_JSON_GEN_SRC_DIR}/ruijie-json.grpc.pb.h
+  DEPENDS ${RUIJIE_JSON_PROTO}
+  COMMENT "Compiling ruijie-json.proto"
+)
+
 set(PLUGIN_NET_OBSERV_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/net_observ.cc
+    ${RUIJIE_JSON_PB_SRC}
+    ${RUIJIE_JSON_GRPC_SRC}
 )
+
+set(PLUGIN_NET_OBSERV_INCLUDES ${RUIJIE_JSON_GEN_HDR_DIR} PARENT_SCOPE)
 
 # Add net observ plugin sources to parent scope
 set(PLUGIN_NET_OBSERV_SOURCES ${PLUGIN_NET_OBSERV_SOURCES} PARENT_SCOPE)

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -873,6 +873,34 @@ void NetworkObserver::emitPredictiveAlert(const Incident& incident) {
        COLOR_MAGENTA, COLOR_BOLD, COLOR_RESET);
 }
 
+static void writeAlertToLogFile(const std::string& logFilePath, const std::string& message) {
+  if (logFilePath.empty()) return;
+
+  int fd = open(logFilePath.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (fd < 0) {
+    return;
+  }
+
+  struct flock fl;
+  memset(&fl, 0, sizeof(fl));
+  fl.l_type = F_WRLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;
+
+  if (fcntl(fd, F_SETLKW, &fl) == -1) {
+    close(fd);
+    return;
+  }
+
+  ssize_t written = write(fd, message.c_str(), message.length());
+  (void)written;
+
+  fl.l_type = F_UNLCK;
+  fcntl(fd, F_SETLK, &fl);
+  close(fd);
+}
+
 /**
  * @brief 输出已确认告警（CONFIRMED级别）
  * @param incident 告警事件对象
@@ -901,6 +929,36 @@ void NetworkObserver::emitConfirmedAlert(const Incident& incident) {
     snprintf(elapsedBuf, sizeof(elapsedBuf), "%.1fs", elapsed);
     elapsedStr = elapsedBuf;
   }
+
+  std::ostringstream oss;
+  oss << "========================================================================\n";
+  oss << "[NETWORK_ADVISOR][CONFIRMED] RDMA Timeout - Fault Path Confirmed!\n";
+  oss << "========================================================================\n";
+  oss << "  Incident ID:    " << incident.incidentTag << "\n";
+  oss << "  Original Time:  " << incident.timestamp << "\n";
+  oss << "  Confirmed At:   " << confirmTs << "\n";
+  oss << "  Time to Confirm: " << elapsedStr << "\n";
+  oss << "  Affected Ranks: " << rankStr << "\n";
+  oss << "  Affected Port:  " << incident.portName << "\n";
+  oss << "  Switch Drop:    " << (long)incident.dropCount << " packets\n";
+  oss << "  RDMA NIC:       " << incident.rdmaNic << "\n";
+  oss << "  NIC Counter Delta (cumulative):\n";
+  for (const auto& entry : incident.nicDelta) {
+    std::string marker;
+    if (entry.first == "roce_adp_retrans" || entry.first == "roce_adp_retrans_to") marker = " <<<";
+    oss << "    " << entry.first << ": +" << (long)entry.second << marker << "\n";
+  }
+  for (const auto& pathLine : incident.faultPaths) {
+    oss << "  Confirmed Fault Path: " << pathLine << "\n";
+  }
+  if (!incident.ncclError.empty()) {
+    oss << "  NCCL Error:    " << incident.ncclError << "\n";
+  }
+  oss << "  Root Cause:     [Confirmed] Switch drop caused RDMA timeout on " << incident.rdmaNic << "\n";
+  oss << "  Impact:         Training stalled, NCCL timeout likely\n";
+  oss << "  Status:        CONFIRMED - RDMA timeout reached\n";
+  oss << "  Suggestion:     Immediate action required: check " << incident.portName << " and " << incident.rdmaNic << "\n";
+  oss << "========================================================================\n\n";
 
   fprintf(stderr, "%s%s========================================================================%s\n", COLOR_RED, COLOR_BOLD,
        COLOR_RESET);
@@ -938,6 +996,8 @@ void NetworkObserver::emitConfirmedAlert(const Incident& incident) {
        COLOR_CYAN, COLOR_RESET, incident.portName.c_str(), incident.rdmaNic.c_str());
   fprintf(stderr, "%s%s========================================================================%s\n",
        COLOR_RED, COLOR_BOLD, COLOR_RESET);
+
+  writeAlertToLogFile("/tmp/net_observ.log", oss.str());
 }
 
 /**

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -213,6 +213,13 @@ std::string TopologyConfig::getPortByNodeAndNic(const std::string& nodeIp, const
   return "";
 }
 
+std::string TopologyConfig::getPortByRdmaNicIp(const std::string& rdmaNicIp) const {
+  for (const auto& entry : portMapping) {
+    if (entry.second.rdmaNicIp == rdmaNicIp) return entry.first;
+  }
+  return "";
+}
+
 /**
  * @brief 从JSON配置文件加载拓扑配置
  * @param configPath 配置文件路径
@@ -292,6 +299,7 @@ TopologyConfig TopologyConfig::loadFromFile(const std::string& configPath) {
     PortMappingInfo info;
     info.node = extractJsonString(portObj, "node");
     info.rdmaNic = extractJsonString(portObj, "rdma_nic");
+    info.rdmaNicIp = extractJsonString(portObj, "rdma_nic_ip");
 
     // Parse ranks array
     auto ranksStart = portObj.find("\"ranks\"");
@@ -1294,44 +1302,87 @@ std::string NetworkObserver::executeCommand(const std::string& cmd) {
 }
 
 /**
- * @brief 通过SSH远程查询节点的RDMA NIC名称
+ * @brief 通过SSH远程查询节点的RDMA NIC名称和IP
  * @param remoteIp 远程节点IP地址
  * @param netdev 网卡设备名（如"ens43f0np0"）
- * @return RDMA NIC名称（如"mlx5_0"），查询失败返回空字符串
+ * @return RdmaNicInfo（name=mlx5设备名，ip=RDMA NIC IP），查询失败返回空name
  *
- * 通过SSH连接到远程节点，读取/sys/class/net/<netdev>/device/infiniband获取mlx5设备名
+ * 通过SSH连接到远程节点，读取/sys/class/net/<netdev>/device/infiniband获取mlx5设备名，
+ * 再通过ip命令获取该设备的IP地址。
  * 需要预先配置SSH免密登录
  *
  * 注意：使用BatchMode=yes防止密码提示阻塞
  */
-std::string NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev) {
+RdmaNicInfo NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev) {
+  RdmaNicInfo result;
   // 构建SSH命令，使用BatchMode防止密码提示阻塞
   // -o BatchMode=yes: 禁止交互式密码提示
   // -o ConnectTimeout=3: 连接超时3秒
   // -o StrictHostKeyChecking=no: 不检查主机密钥
   std::string sshCmd = "ssh -o BatchMode=yes -o ConnectTimeout=3 -o StrictHostKeyChecking=no " + remoteIp +
-                       " 'ls /sys/class/net/" + netdev + "/device/infiniband/ 2>/dev/null | grep mlx5_'";
+                       " 'mlx5_dev=$(ls /sys/class/net/" + netdev + "/device/infiniband/ 2>/dev/null | grep mlx5_); "
+                       "if [ -n \"$mlx5_dev\" ]; then "
+                       "  net_iface=$(ls /sys/class/infiniband/$mlx5_dev/device/net/ 2>/dev/null | head -1); "
+                       "  ip_addr=$(ip -o -4 addr show $net_iface 2>/dev/null | awk \"{print \\$4}\" | cut -d/ -f1); "
+                       "  echo \"$mlx5_dev $ip_addr\"; "
+                       "fi'";
 
-  std::string result = executeCommand(sshCmd);
+  std::string output = executeCommand(sshCmd);
+  output = trim(output);
 
-  if (!result.empty() && result.find("mlx5_") != std::string::npos) {
-    // 提取mlx5_X部分
-    size_t pos = result.find("mlx5_");
-    size_t end = pos + 5;
-    while (end < result.length() && result[end] >= '0' && result[end] <= '9') end++;
-    return result.substr(pos, end - pos);
+  if (!output.empty()) {
+    std::istringstream iss(output);
+    std::string namePart, ipPart;
+    iss >> namePart >> ipPart;
+    if (namePart.find("mlx5_") != std::string::npos) {
+      result.name = namePart;
+      result.ip = ipPart;
+    }
   }
 
-  INFO(NCCL_NET, "NET_OBSERV: Failed to query remote RDMA NIC from %s for %s (SSH may not be configured)",
-       remoteIp.c_str(), netdev.c_str());
-  return "";
+  if (result.name.empty()) {
+    INFO(NCCL_NET, "NET/OBSERV: Failed to query remote RDMA NIC from %s for %s (SSH may not be configured)",
+         remoteIp.c_str(), netdev.c_str());
+  }
+  return result;
 }
 
 /**
- * @brief 从服务器网卡描述获取RDMA NIC名称（支持本地和远程查询）
+ * @brief 从本地mlx5设备名获取对应的RDMA NIC IP地址
+ * @param mlx5Dev mlx5设备名（如"mlx5_0"）
+ * @return RDMA NIC IP地址（如"192.168.1.17"），获取失败返回空字符串
+ */
+static std::string getLocalRdmaNicIp(const std::string& mlx5Dev) {
+  std::string netDir = "/sys/class/infiniband/" + mlx5Dev + "/device/net/";
+  DIR* dir = opendir(netDir.c_str());
+  if (!dir) return "";
+  struct dirent* entry;
+  std::string netIface;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (entry->d_name[0] == '.') continue;
+    netIface = entry->d_name;
+    break;
+  }
+  closedir(dir);
+  if (netIface.empty()) return "";
+
+  std::string ipCmd = "ip -o -4 addr show " + netIface + " 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1";
+  FILE* fp = popen(ipCmd.c_str(), "r");
+  if (!fp) return "";
+  char buf[64];
+  std::string ip;
+  if (fgets(buf, sizeof(buf), fp)) {
+    ip = trim(buf);
+  }
+  pclose(fp);
+  return ip;
+}
+
+/**
+ * @brief 从服务器网卡描述获取RDMA NIC名称和IP（支持本地和远程查询）
  * @param portDesc 服务器侧网卡描述（如"ens43f0np0"、"mlx5_0"）
  * @param nodeIp 节点IP地址，用于判断是本地还是远程查询
- * @return 获取到的RDMA NIC名称（如"mlx5_0"），无法获取返回空字符串
+ * @return RdmaNicInfo（name=mlx5设备名，ip=RDMA NIC IP），无法获取返回空name
  *
  * 获取规则：
  * 1. 如果描述中包含"mlx5_"，直接提取mlx5_X部分
@@ -1341,13 +1392,18 @@ std::string NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, con
  *
  * 注意：SSH查询可能会失败，不影响主流程
  */
-std::string NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp) {
+RdmaNicInfo NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp) {
+  RdmaNicInfo result;
+
   // 如果描述中直接包含mlx5_，直接提取
   if (portDesc.find("mlx5_") != std::string::npos) {
     size_t pos = portDesc.find("mlx5_");
     size_t end = pos + 5;
     while (end < portDesc.length() && portDesc[end] >= '0' && portDesc[end] <= '9') end++;
-    return portDesc.substr(pos, end - pos);
+    result.name = portDesc.substr(pos, end - pos);
+    // Also fetch the IP for the local machine
+    result.ip = getLocalRdmaNicIp(result.name);
+    return result;
   }
 
   // 如果是网卡名（ens/enp/eth开头）
@@ -1371,31 +1427,34 @@ std::string NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDes
       if (dir) {
         struct dirent* entry;
         while ((entry = readdir(dir)) != nullptr) {
-          // 跳过 . 和 ..
           if (entry->d_name[0] == '.') continue;
-          // 查找 mlx5_X 格式的目录名
           std::string name(entry->d_name);
           if (name.find("mlx5_") != std::string::npos) {
+            result.name = name;
             closedir(dir);
-            return name;
+            break;
           }
         }
         closedir(dir);
       }
-      // 如果sysfs读取失败，回退到默认的mlx5_0
-      INFO(NCCL_NET, "NET_OBSERV: Failed to read IB device from sysfs for %s, fallback to mlx5_0",
-           portDesc.c_str());
-      return "mlx5_0";
+      if (result.name.empty()) {
+        // 如果sysfs读取失败，回退到默认的mlx5_0
+        INFO(NCCL_NET, "NET/OBSERV: Failed to read IB device from sysfs for %s, fallback to mlx5_0",
+             portDesc.c_str());
+        result.name = "mlx5_0";
+      }
+      // Get IP for the found mlx5 device
+      result.ip = getLocalRdmaNicIp(result.name);
+      return result;
     } else {
-      // 远程节点：通过SSH查询获取mlx5设备
-      // 注意：这需要预先配置SSH免密登录，否则会失败
-      INFO(NCCL_NET, "NET_OBSERV: Querying remote node %s for RDMA NIC of %s (requires SSH passwordless login)",
+      // 远程节点：通过SSH查询获取mlx5设备及其IP
+      INFO(NCCL_NET, "NET/OBSERV: Querying remote node %s for RDMA NIC of %s (requires SSH passwordless login)",
            nodeIp.c_str(), portDesc.c_str());
       return queryRemoteRdmaNic(nodeIp, portDesc);
     }
   }
 
-  return "";
+  return result;
 }
 
 /**
@@ -1420,7 +1479,9 @@ void NetworkObserver::updateTopologyFromLldp(const std::vector<LldpNeighborInfo>
     entry.switchPort = info.switchPort;
     entry.nodeIp = info.nodeIp;
     // 传递nodeIp以支持本地/远程查询判断
-    entry.rdmaNic = inferRdmaNicFromPortDesc(info.remotePortDesc, info.nodeIp);
+    RdmaNicInfo nicInfo = inferRdmaNicFromPortDesc(info.remotePortDesc, info.nodeIp);
+    entry.rdmaNic = nicInfo.name;
+    entry.rdmaNicIp = nicInfo.ip;
     entry.description = info.remoteSysName + " (" + info.remotePortDesc + ")";
 
     if (!entry.rdmaNic.empty()) {
@@ -1429,6 +1490,7 @@ void NetworkObserver::updateTopologyFromLldp(const std::vector<LldpNeighborInfo>
       PortMappingInfo pmInfo;
       pmInfo.node = entry.nodeIp;
       pmInfo.rdmaNic = entry.rdmaNic;
+      pmInfo.rdmaNicIp = entry.rdmaNicIp;
       topology_->portMapping[entry.switchPort] = pmInfo;
     }
   }
@@ -1729,14 +1791,14 @@ void ncclNetObservUpdateRankTopology(const std::vector<std::vector<int>>& nodeRa
 /**
  * @brief NetworkObserver成员方法：处理IB传输层错误
  * @param rdmaNic RDMA网卡设备名
- * @param peerIp 对端节点IP地址（可选）
+ * @param peerIp 对端RDMA NIC的IP地址（可选，如"192.168.1.17"）
  * @param wcStatus IB工作完成状态码
  *
  * 该函数在IB传输层检测到CQE错误时被调用，无需等待NCCL异常。
- * 相比confirmFromException的文本解析方式，这种方式更直接、更及时。
+ * peerIp是对端节点的RDMA NIC IP，用于在portMapping中通过rdmaNicIp字段查找对端交换机端口。
  */
 void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus, int tpRank, int tpRemoteRank) {
-  INFO(NCCL_NET, "NET_OBSERV: Direct IB error from %s, peer=%s, wc_status=%d, tpRank=%d, tpRemoteRank=%d",
+  INFO(NCCL_NET, "NET_OBSERV: Direct IB error from %s, peerRdmaNicIp=%s, wc_status=%d, tpRank=%d, tpRemoteRank=%d",
        rdmaNic.c_str(), peerIp.c_str(), wcStatus, tpRank, tpRemoteRank);
 
   std::lock_guard<std::mutex> lock(incidentsMutex_);
@@ -1768,34 +1830,21 @@ void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::strin
       incident->nicDelta = ret.second;
     }
 
-    // 如果提供了peerIp，更新故障路径
+    // If peerIp (peer RDMA NIC IP) is provided, update fault path by matching it in portMapping
     if (!peerIp.empty()) {
-      INFO(NCCL_NET, "NET/OBSERV: Building fault path for peerIp=%s, rdmaNic=%s, localPort=%s",
+      INFO(NCCL_NET, "NET/OBSERV: Building fault path for peerRdmaNicIp=%s, rdmaNic=%s, localPort=%s",
            peerIp.c_str(), incident->rdmaNic.c_str(), incident->portName.c_str());
-      std::string peerPort = topology_->getPortByNodeAndNic(peerIp, incident->rdmaNic);
+      // Lookup peer port by RDMA NIC IP in portMapping
+      std::string peerPort = topology_->getPortByRdmaNicIp(peerIp);
       if (!peerPort.empty()) {
-        INFO(NCCL_NET, "NET/OBSERV: Found peerPort via getPortByNodeAndNic: %s", peerPort.c_str());
+        INFO(NCCL_NET, "NET/OBSERV: Found peerPort via getPortByRdmaNicIp: %s", peerPort.c_str());
         incident->faultPaths = buildFaultPath(
             {incident->portName}, incident->deviceModel, peerPort, tpRank, tpRemoteRank);
       } else {
-        INFO(NCCL_NET, "NET/OBSERV: peerPort not found via getPortByNodeAndNic, searching portMapping...");
-        bool foundInMapping = false;
-        for (const auto& pmEntry : topology_->portMapping) {
-          if (pmEntry.second.node == peerIp) {
-            INFO(NCCL_NET, "NET/OBSERV: Found peerIp in portMapping: port=%s, node=%s",
-                 pmEntry.first.c_str(), pmEntry.second.node.c_str());
-            incident->faultPaths = buildFaultPath(
-                {incident->portName}, incident->deviceModel, pmEntry.first, tpRank, tpRemoteRank);
-            foundInMapping = true;
-            break;
-          }
-        }
-        if (!foundInMapping) {
-          INFO(NCCL_NET, "NET/OBSERV: peerIp %s not found in portMapping, fault path unchanged", peerIp.c_str());
-        }
+        INFO(NCCL_NET, "NET/OBSERV: peerRdmaNicIp %s not found in portMapping, fault path unchanged", peerIp.c_str());
       }
     } else {
-      INFO(NCCL_NET, "NET/OBSERV: peerIp is empty, skipping fault path update");
+      INFO(NCCL_NET, "NET/OBSERV: peerRdmaNicIp is empty, skipping fault path update");
     }
 
     // 确认告警
@@ -1821,7 +1870,7 @@ void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::strin
 /**
  * @brief C接口：处理IB传输层错误（从p2p.cc直接调用）
  * @param rdmaNic RDMA网卡设备名
- * @param peerIp 对端节点IP地址（可选）
+ * @param peerIp 对端RDMA NIC的IP地址（可选，如"192.168.1.17"）
  * @param wcStatus IB工作完成状态码
  */
 void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus, int tpRank, int tpRemoteRank) {
@@ -1834,7 +1883,7 @@ void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcS
   std::string nicName(rdmaNic);
   std::string peerIpStr(peerIp ? peerIp : "");
 
-  INFO(NCCL_NET, "NET/OBSERV: %s: Handling IB error (rdmaNic=%s, peerIp=%s, wcStatus=%d, tpRank=%d, tpRemoteRank=%d)",
+  INFO(NCCL_NET, "NET/OBSERV: %s: Handling IB error (rdmaNic=%s, peerRdmaNicIp=%s, wcStatus=%d, tpRank=%d, tpRemoteRank=%d)",
        __func__, rdmaNic, peerIpStr.c_str(), wcStatus, tpRank, tpRemoteRank);
 
   std::lock_guard<std::mutex> lock(g_netObservMutex);

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -1,0 +1,8 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "net_observ/net_observ.h"

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -6,3 +6,1819 @@
  *************************************************************************/
 
 #include "net_observ/net_observ.h"
+
+#include <fstream>
+#include <sstream>
+#include <cstring>
+#include <cstdlib>
+#include <chrono>
+#include <ctime>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <array>
+#include <memory>
+
+#include "checks.h"
+#include "param.h"
+
+namespace net_observ {
+
+const char* const COLOR_RED = "\033[91m";
+const char* const COLOR_YELLOW = "\033[93m";
+const char* const COLOR_GREEN = "\033[92m";
+const char* const COLOR_CYAN = "\033[96m";
+const char* const COLOR_MAGENTA = "\033[95m";
+const char* const COLOR_BOLD = "\033[1m";
+const char* const COLOR_DIM = "\033[2m";
+const char* const COLOR_RESET = "\033[0m";
+
+const char* const RETRANS_COUNTER_NAMES[] = {
+  "roce_adp_retrans",
+  "roce_adp_retrans_to",
+  "roce_slow_restart",
+  "roce_slow_restart_cnps",
+  "roce_slow_restart_cnp_acks",
+};
+const int RETRANS_COUNTER_NAMES_COUNT = sizeof(RETRANS_COUNTER_NAMES) / sizeof(RETRANS_COUNTER_NAMES[0]);
+
+const std::regex NCCL_HCA_PATTERN("hca\\s+(mlx5_\\d+)");
+const std::regex NCCL_PEER_IP_PATTERN("remoteGids?::ffff:([\\d.]+)");
+
+// ---- JSON field extraction helpers ----
+
+/**
+ * @brief 从JSON字符串中提取指定键的字符串值
+ * @param json 输入的JSON字符串
+ * @param key 要提取的字段名
+ * @return 字段对应的字符串值，未找到返回空字符串
+ * 
+ * 支持格式："key":"value" 或 "key" : "value"
+ */
+std::string extractJsonString(const std::string& json, const std::string& key) {
+  std::string search = "\"" + key + "\":\"";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) {
+    search = "\"" + key + "\" : \"";
+    pos = json.find(search);
+    if (pos == std::string::npos) return "";
+  }
+  pos += search.length();
+  auto end = json.find("\"", pos);
+  if (end == std::string::npos) return "";
+  return json.substr(pos, end - pos);
+}
+
+/**
+ * @brief 从JSON字符串中提取指定键的整数值
+ * @param json 输入的JSON字符串
+ * @param key 要提取的字段名
+ * @return 字段对应的整数值，未找到返回0
+ * 
+ * 支持格式："key":123 或 "key" : 123
+ */
+int64_t extractJsonInt(const std::string& json, const std::string& key) {
+  std::string search = "\"" + key + "\":";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) {
+    search = "\"" + key + "\" : ";
+    pos = json.find(search);
+    if (pos == std::string::npos) return 0;
+  }
+  pos += search.length();
+  while (pos < json.length() && (json[pos] == ' ' || json[pos] == '\t')) pos++;
+  std::string num;
+  while (pos < json.length() && json[pos] >= '0' && json[pos] <= '9') {
+    num += json[pos];
+    pos++;
+  }
+  if (num.empty()) return 0;
+  return std::stoll(num);
+}
+
+/**
+ * @brief 去除字符串首尾的空白字符
+ * @param s 输入字符串
+ * @return 去除空白后的字符串
+ * 
+ * 去除的字符包括：空格、制表符、换行符、回车符
+ */
+static std::string trim(const std::string& s) {
+  size_t start = 0;
+  while (start < s.length() && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r')) start++;
+  size_t end = s.length();
+  while (end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r')) end--;
+  return s.substr(start, end - start);
+}
+
+/**
+ * @brief 将JSON转义字符还原为原始字符
+ * @param s 包含转义序列的JSON字符串
+ * @return 还原后的字符串
+ *
+ * 处理的转义序列：\" → "，\\ → \，\/ → /
+ */
+static std::string unescapeJson(const std::string& s) {
+  std::string result;
+  for (size_t i = 0; i < s.length(); i++) {
+    if (s[i] == '\\' && i + 1 < s.length()) {
+      switch (s[i+1]) {
+        case '"': result += '"'; i++; break;
+        case '\\': result += '\\'; i++; break;
+        case '/': result += '/'; i++; break;
+        default: result += s[i]; break;
+      }
+    } else {
+      result += s[i];
+    }
+  }
+  return result;
+}
+
+// ---- TopologyConfig ----
+
+/**
+ * @brief 获取指定节点IP关联的所有交换机端口
+ * @param nodeIp 节点IP地址
+ * @return 端口名称列表
+ */
+std::vector<std::string> TopologyConfig::getPortsForNode(const std::string& nodeIp) const {
+  std::vector<std::string> result;
+  for (const auto& entry : portMapping) {
+    if (entry.second.node == nodeIp) result.push_back(entry.first);
+  }
+  return result;
+}
+
+/**
+ * @brief 获取指定端口关联的NCCL rank列表
+ * @param portName 交换机端口名称
+ * @return rank列表，端口不存在返回空列表
+ */
+std::vector<int> TopologyConfig::getRanksForPort(const std::string& portName) const {
+  auto it = portMapping.find(portName);
+  if (it != portMapping.end()) return it->second.ranks;
+  return {};
+}
+
+/**
+ * @brief 获取指定端口关联的节点IP
+ * @param portName 交换机端口名称
+ * @return 节点IP地址，端口不存在返回"unknown"
+ */
+std::string TopologyConfig::getNodeForPort(const std::string& portName) const {
+  auto it = portMapping.find(portName);
+  if (it != portMapping.end()) return it->second.node;
+  return "unknown";
+}
+
+/**
+ * @brief 获取指定端口关联的RDMA网卡名称
+ * @param portName 交换机端口名称
+ * @return RDMA网卡名称（如mlx5_0），端口不存在返回"unknown"
+ */
+std::string TopologyConfig::getRdmaNicForPort(const std::string& portName) const {
+  auto it = portMapping.find(portName);
+  if (it != portMapping.end()) return it->second.rdmaNic;
+  return "unknown";
+}
+
+/**
+ * @brief 获取所有已配置的交换机端口名称
+ * @return 端口名称列表
+ */
+std::vector<std::string> TopologyConfig::getAllPorts() const {
+  std::vector<std::string> result;
+  for (const auto& entry : portMapping) {
+    result.push_back(entry.first);
+  }
+  return result;
+}
+
+/**
+ * @brief 根据节点IP和RDMA网卡名称查找对应的交换机端口
+ * @param nodeIp 节点IP地址
+ * @param rdmaNic RDMA网卡名称
+ * @return 交换机端口名称，未找到返回空字符串
+ */
+std::string TopologyConfig::getPortByNodeAndNic(const std::string& nodeIp, const std::string& rdmaNic) const {
+  for (const auto& entry : portMapping) {
+    if (entry.second.node == nodeIp && entry.second.rdmaNic == rdmaNic) return entry.first;
+  }
+  return "";
+}
+
+/**
+ * @brief 从JSON配置文件加载拓扑配置
+ * @param configPath 配置文件路径
+ * @return 加载的TopologyConfig对象，失败返回空配置
+ *
+ * 解析字段：
+ * - switch_ip: 交换机IP地址
+ * - switch_name: 交换机名称
+ * - grpc_port: gRPC服务端口
+ * - port_mapping: 端口映射对象，包含node、rdma_nic、ranks等
+ */
+TopologyConfig TopologyConfig::loadFromFile(const std::string& configPath) {
+  std::ifstream file(configPath);
+  if (!file.is_open()) {
+    WARN("NET_OBSERV: Failed to open topology config file: %s", configPath.c_str());
+    return TopologyConfig{};
+  }
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  std::string content = buffer.str();
+
+  TopologyConfig cfg;
+  cfg.switchIp = extractJsonString(content, "switch_ip");
+  cfg.switchName = extractJsonString(content, "switch_name");
+  cfg.grpcPort = static_cast<int>(extractJsonInt(content, "grpc_port"));
+  if (cfg.grpcPort == 0) cfg.grpcPort = 50051;
+
+  // Parse port_mapping object
+  auto pmPos = content.find("\"port_mapping\"");
+  if (pmPos == std::string::npos) {
+    INFO(NCCL_NET, "NET_OBSERV: No port_mapping found in config");
+    return cfg;
+  }
+
+  auto objStart = content.find("{", pmPos);
+  if (objStart == std::string::npos) return cfg;
+
+  // Track brace depth to find the matching closing brace
+  int braceDepth = 0;
+  size_t i = objStart;
+  for (; i < content.length(); i++) {
+    if (content[i] == '{') braceDepth++;
+    else if (content[i] == '}') {
+      braceDepth--;
+      if (braceDepth == 0) break;
+    }
+  }
+  std::string pmContent = content.substr(objStart + 1, i - objStart - 1);
+
+  // Parse each port entry: "port_name": { ... }
+  size_t pos = 0;
+  while (pos < pmContent.length()) {
+    // Find the next quoted key (port name)
+    auto quoteStart = pmContent.find("\"", pos);
+    if (quoteStart == std::string::npos) break;
+    auto quoteEnd = pmContent.find("\"", quoteStart + 1);
+    if (quoteEnd == std::string::npos) break;
+    std::string portName = pmContent.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
+    pos = quoteEnd + 1;
+
+    // Find the value object start
+    auto valStart = pmContent.find("{", pos);
+    if (valStart == std::string::npos) break;
+
+    // Find matching closing brace
+    int depth = 1;
+    size_t valEnd = valStart + 1;
+    for (; valEnd < pmContent.length(); valEnd++) {
+      if (pmContent[valEnd] == '{') depth++;
+      else if (pmContent[valEnd] == '}') {
+        depth--;
+        if (depth == 0) break;
+      }
+    }
+    std::string portObj = pmContent.substr(valStart + 1, valEnd - valStart - 1);
+
+    PortMappingInfo info;
+    info.node = extractJsonString(portObj, "node");
+    info.rdmaNic = extractJsonString(portObj, "rdma_nic");
+
+    // Parse ranks array
+    auto ranksStart = portObj.find("\"ranks\"");
+    if (ranksStart != std::string::npos) {
+      auto arrStart = portObj.find("[", ranksStart);
+      if (arrStart != std::string::npos) {
+        auto arrEnd = portObj.find("]", arrStart);
+        if (arrEnd != std::string::npos) {
+          std::string arrStr = portObj.substr(arrStart + 1, arrEnd - arrStart - 1);
+          std::stringstream ss(arrStr);
+          std::string token;
+          while (std::getline(ss, token, ',')) {
+            token = trim(token);
+            if (!token.empty()) {
+              info.ranks.push_back(std::stoi(token));
+            }
+          }
+        }
+      }
+    }
+
+    cfg.portMapping[portName] = info;
+    pos = valEnd + 1;
+  }
+
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Loaded topology config: switch=%s, ports=%zu",
+       cfg.switchName.c_str(), cfg.portMapping.size());
+  return cfg;
+}
+
+// ---- NicCounterReader ----
+
+/**
+ * @brief NicCounterReader构造函数
+ */
+NicCounterReader::NicCounterReader() {}
+
+/**
+ * @brief 发现系统中所有InfiniBand/RDMA网卡设备
+ * @return 发现的网卡标识符列表（格式：devName:portNum）
+ *
+ * 扫描/sys/class/infiniband目录，枚举所有IB设备和端口，
+ * 填充deviceCache_并返回网卡键列表
+ */
+std::vector<std::string> NicCounterReader::discoverNics() {
+  std::vector<std::string> nics;
+  struct stat st;
+  if (stat(IB_SYSFS_BASE, &st) != 0 || !S_ISDIR(st.st_mode)) {
+    INFO(NCCL_NET, "NET_OBSERV: sysfs path %s not found, IB counter monitoring disabled", IB_SYSFS_BASE);
+    return nics;
+  }
+
+  DIR* dir = opendir(IB_SYSFS_BASE);
+  if (!dir) {
+    WARN("NET_OBSERV: Failed to open %s: %s", IB_SYSFS_BASE, strerror(errno));
+    return nics;
+  }
+
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (entry->d_name[0] == '.') continue;
+    std::string devName(entry->d_name);
+    std::string devPath = std::string(IB_SYSFS_BASE) + "/" + devName;
+    if (stat(devPath.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) continue;
+
+    std::string portsDir = devPath + "/ports";
+    if (stat(portsDir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) continue;
+
+    DIR* ports = opendir(portsDir.c_str());
+    if (!ports) continue;
+    struct dirent* portEntry;
+    while ((portEntry = readdir(ports)) != nullptr) {
+      if (portEntry->d_name[0] == '.') continue;
+      errno = 0;
+      char* endptr = nullptr;
+      long portNum = strtol(portEntry->d_name, &endptr, 10);
+      if (endptr == portEntry->d_name || *endptr != '\0' || errno != 0) continue;
+
+      std::string hwCountersDir = portsDir + "/" + portEntry->d_name + "/hw_counters";
+      NicDeviceInfo info;
+      info.ibDevName = devName;
+      info.portNum = static_cast<int>(portNum);
+      info.sysfsPath = hwCountersDir;
+
+      std::string nicKey = devName + ":" + portEntry->d_name;
+      deviceCache_[nicKey] = info;
+      nics.push_back(nicKey);
+
+      std::string retransPath = hwCountersDir + "/roce_adp_retrans";
+      struct stat rs;
+      bool available = (stat(retransPath.c_str(), &rs) == 0);
+      INFO(NCCL_NET, "NET_OBSERV: Discovered IB device: %s, roce_adp_retrans=%s",
+           nicKey.c_str(), available ? "available" : "unavailable");
+    }
+    closedir(ports);
+  }
+  closedir(dir);
+
+  return nics;
+}
+
+/**
+ * @brief 捕获指定网卡或所有网卡的计数器基线值
+ * @param nicKey 网卡标识符（如"mlx5_0:1"），为空则捕获所有网卡
+ *
+ * 读取当前计数器值并保存为基线，后续通过readDelta计算增量
+ */
+void NicCounterReader::captureBaseline(const std::string& nicKey) {
+  if (!nicKey.empty()) {
+    auto counters = readCounters(nicKey);
+    if (!counters.empty()) {
+      baselines_[nicKey] = NicCounterSnapshot{
+        std::chrono::duration<double>(std::chrono::system_clock::now().time_since_epoch()).count(),
+        counters
+      };
+      INFO(NCCL_NET, "NET_OBSERV: Baseline captured for %s", nicKey.c_str());
+    }
+  } else {
+    for (const auto& entry : deviceCache_) {
+      captureBaseline(entry.first);
+    }
+  }
+}
+
+/**
+ * @brief 读取指定网卡的硬件计数器值
+ * @param nicKey 网卡标识符（如"mlx5_0:1"）
+ * @return 计数器名称到值的映射
+ *
+ * 从/sys/class/infiniband/<dev>/ports/<port>/hw_counters/读取：
+ * - roce_adp_retrans
+ * - roce_adp_retrans_to
+ * - roce_slow_restart
+ * - roce_slow_restart_cnps
+ * - roce_slow_restart_cnp_acks
+ */
+std::map<std::string, int64_t> NicCounterReader::readCounters(const std::string& nicKey) {
+  auto it = deviceCache_.find(nicKey);
+  if (it == deviceCache_.end()) return {};
+
+  std::map<std::string, int64_t> counters;
+  const std::string& hwDir = it->second.sysfsPath;
+
+  struct stat st;
+  if (stat(hwDir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) return {};
+
+  for (int i = 0; i < RETRANS_COUNTER_NAMES_COUNT; i++) {
+    std::string fpath = hwDir + "/" + RETRANS_COUNTER_NAMES[i];
+    struct stat fs;
+    if (stat(fpath.c_str(), &fs) != 0) continue;
+
+    std::ifstream f(fpath);
+    if (!f.is_open()) continue;
+    std::string valStr;
+    std::getline(f, valStr);
+    f.close();
+    try {
+      counters[RETRANS_COUNTER_NAMES[i]] = std::stoll(trim(valStr));
+    } catch (...) {}
+  }
+
+  return counters.empty() ? std::map<std::string, int64_t>{} : counters;
+}
+
+/**
+ * @brief 计算指定网卡计数器自基线以来的增量
+ * @param nicKey 网卡标识符
+ * @return 计数器增量映射（只包含正值）
+ *
+ * 读取当前值并减去基线值，只返回有增长的计数器
+ */
+std::map<std::string, int64_t> NicCounterReader::readDelta(const std::string& nicKey) {
+  auto baseIt = baselines_.find(nicKey);
+  if (baseIt == baselines_.end()) return {};
+
+  auto current = readCounters(nicKey);
+  if (current.empty()) return {};
+
+  std::map<std::string, int64_t> delta;
+  for (const auto& curEntry : current) {
+    auto baseValIt = baseIt->second.counters.find(curEntry.first);
+    int64_t baseVal = (baseValIt != baseIt->second.counters.end()) ? baseValIt->second : 0;
+    int64_t d = curEntry.second - baseVal;
+    if (d > 0) delta[curEntry.first] = d;
+  }
+  return delta;
+}
+
+/**
+ * @brief 检查指定RDMA网卡是否有重传计数器增长
+ * @param rdmaNic RDMA网卡名称（如"mlx5_0"）
+ * @return pair<是否有重传增长, 聚合的计数器增量>
+ *
+ * 遍历该网卡的所有端口，聚合各端口的计数器增量，
+ * 并判断是否包含重传类计数器的增长
+ */
+std::pair<bool, std::map<std::string, int64_t>> NicCounterReader::checkNicRetrans(const std::string& rdmaNic) {
+  std::map<std::string, int64_t> aggregated;
+  bool hasRetryGrowth = false;
+
+  for (const auto& entry : deviceCache_) {
+    if (entry.first.find(rdmaNic) == std::string::npos) continue;
+    auto delta = readDelta(entry.first);
+    if (delta.empty()) continue;
+    for (const auto& deltaEntry : delta) {
+      bool isRetrans = false;
+      for (int i = 0; i < RETRANS_COUNTER_NAMES_COUNT; i++) {
+        if (deltaEntry.first == RETRANS_COUNTER_NAMES[i]) {
+          isRetrans = true;
+          break;
+        }
+      }
+      if (isRetrans) hasRetryGrowth = true;
+      aggregated[deltaEntry.first] += deltaEntry.second;
+    }
+  }
+
+  return {hasRetryGrowth, aggregated};
+}
+
+// ---- SwitchEventServicer ----
+
+/**
+ * @brief 处理交换机发送的单次JSON事件（Unary RPC）
+ * @param context gRPC上下文
+ * @param request JSON事件请求
+ * @param response 回复消息
+ * @return gRPC状态码
+ *
+ * 将收到的请求加入events_队列，返回ret=0表示成功接收
+ */
+grpc::Status SwitchEventServicer::JsonSend(
+    grpc::ServerContext* context,
+    const ruijie_json::JsonRequest* request,
+    ruijie_json::JsonReply* response) {
+  (void)context;
+  {
+    std::lock_guard<std::mutex> lock(mtx_);
+    events_.push_back(*request);
+  }
+  response->set_ret(0);
+  return grpc::Status::OK;
+}
+
+/**
+ * @brief 处理交换机发送的流式JSON事件（Streaming RPC）
+ * @param context gRPC上下文
+ * @param stream 双向流对象
+ * @return gRPC状态码
+ *
+ * 持续读取流中的事件请求，每个事件都加入队列并回复ACK(ret=0)
+ */
+grpc::Status SwitchEventServicer::JsonStreamSend(
+    grpc::ServerContext* context,
+    grpc::ServerReaderWriter<ruijie_json::JsonReply, ruijie_json::JsonRequest>* stream) {
+  ruijie_json::JsonRequest request;
+  while (stream->Read(&request)) {
+    {
+      std::lock_guard<std::mutex> lock(mtx_);
+      events_.push_back(request);
+    }
+    ruijie_json::JsonReply reply;
+    reply.set_ret(0);
+    stream->Write(reply);
+  }
+  return grpc::Status::OK;
+}
+
+/**
+ * @brief 获取所有待处理的事件请求
+ * @return 待处理事件列表，返回后队列被清空
+ *
+ * 线程安全地取出events_中的所有事件，使用move避免拷贝
+ */
+std::vector<ruijie_json::JsonRequest> SwitchEventServicer::getPendingEvents() {
+  std::lock_guard<std::mutex> lock(mtx_);
+  std::vector<ruijie_json::JsonRequest> events = std::move(events_);
+  events_.clear();
+  return events;
+}
+
+// ---- NetworkObserver ----
+
+/**
+ * @brief NetworkObserver构造函数
+ * @param topology 拓扑配置指针
+ * @param rank 当前NCCL rank
+ * @param pollInterval 事件轮询间隔（秒）
+ */
+NetworkObserver::NetworkObserver(TopologyConfig* topology, int rank, double pollInterval)
+  : topology_(topology)
+  , rank_(rank)
+  , pollInterval_(pollInterval)
+  , stopRequested_(false)
+  , incidentId_(0) {
+}
+
+/**
+ * @brief NetworkObserver析构函数
+ * 自动调用stop()停止监控线程和gRPC服务器
+ */
+NetworkObserver::~NetworkObserver() {
+  stop();
+}
+
+/**
+ * @brief 启动网络观测器
+ * @return 0表示成功，-1表示失败
+ *
+ * 启动流程：
+ * 1. 启动gRPC服务器监听事件
+ * 2. 发现IB网卡并捕获计数器基线
+ * 3. 启动监控线程轮询事件
+ */
+int NetworkObserver::start() {
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort("[::]:" + std::to_string(topology_->grpcPort),
+                           grpc::InsecureServerCredentials());
+  builder.RegisterService(&eventServicer_);
+  grpcServer_ = builder.BuildAndStart();
+  if (!grpcServer_) {
+    WARN("NET_OBSERV: Failed to start gRPC server on port %d", topology_->grpcPort);
+    return -1;
+  }
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: gRPC server started on port %d, waiting for switch connection...",
+       topology_->grpcPort);
+
+  auto discoveredNics = nicReader_.discoverNics();
+  if (!discoveredNics.empty()) {
+    nicReader_.captureBaseline();
+    INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: NIC counter baselines captured for %zu device(s)",
+         discoveredNics.size());
+  } else {
+    INFO(NCCL_NET, "NET_OBSERV: No IB NICs discovered, NIC-side counter monitoring disabled");
+  }
+
+  stopRequested_ = false;
+  monitorThread_ = std::make_unique<std::thread>(&NetworkObserver::monitorLoop, this);
+
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Observer started, switch_poll=%.1fs", pollInterval_);
+  return 0;
+}
+
+/**
+ * @brief 停止网络观测器
+ *
+ * 停止流程：
+ * 1. 设置停止标志
+ * 2. 等待监控线程结束
+ * 3. 关闭gRPC服务器
+ */
+void NetworkObserver::stop() {
+  stopRequested_ = true;
+  if (monitorThread_ && monitorThread_->joinable()) {
+    monitorThread_->join();
+  }
+  if (grpcServer_) {
+    grpcServer_->Shutdown();
+  }
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Observer stopped");
+}
+
+/**
+ * @brief 监控线程主循环
+ *
+ * 周期性执行：
+ * 1. 获取待处理事件
+ * 2. 调用handleEvent处理每个事件
+ * 3. 休眠pollInterval_秒
+ */
+void NetworkObserver::monitorLoop() {
+  while (!stopRequested_) {
+    try {
+      auto events = eventServicer_.getPendingEvents();
+      for (const auto& event : events) {
+        handleEvent(event);
+      }
+    } catch (const std::exception& e) {
+      INFO(NCCL_NET, "NET_OBSERV: Monitor error: %s", e.what());
+    }
+    std::this_thread::sleep_for(std::chrono::duration<double>(pollInterval_));
+  }
+}
+
+/**
+ * @brief 根据NCCL异常确认告警
+ * @param errorText NCCL错误文本
+ *
+ * 解析异常信息中的RDMA网卡和对端IP，
+ * 匹配activeIncidents_中的未确认告警并升级为CONFIRMED状态
+ */
+void NetworkObserver::confirmFromException(const std::string& errorText) {
+  std::string rdmaNic;
+  std::string peerIp;
+  bool isNcclIbError = false;
+
+  std::smatch match;
+
+  // Check for NCCL IB error patterns
+  const std::regex ibErrorPatterns[] = {
+    std::regex("IBV_WC_RETRY_EXC_ERR"),
+    std::regex("Got CQE with error"),
+    std::regex("Got completion.*status=IBV_WC_RETRY_EXC_ERR"),
+  };
+
+  for (const auto& pattern : ibErrorPatterns) {
+    if (std::regex_search(errorText, match, pattern)) {
+      isNcclIbError = true;
+      break;
+    }
+  }
+
+  if (!isNcclIbError) {
+    std::string ncclKeywords[] = {"NCCL", "nccl", "Distributed", "dist_backend"};
+    bool hasNcclKeyword = false;
+    for (const auto& kw : ncclKeywords) {
+      if (errorText.find(kw) != std::string::npos) {
+        hasNcclKeyword = true;
+        break;
+      }
+    }
+    if (!hasNcclKeyword) return;
+  }
+
+  if (std::regex_search(errorText, match, NCCL_HCA_PATTERN)) {
+    rdmaNic = match[1].str();
+  }
+
+  if (std::regex_search(errorText, match, NCCL_PEER_IP_PATTERN)) {
+    peerIp = match[1].str();
+  }
+
+  INFO(NCCL_NET, "NET_OBSERV: Caught NCCL exception, rdma_nic=%s, peer_ip=%s, is_ib_error=%d",
+       rdmaNic.c_str(), peerIp.c_str(), isNcclIbError);
+
+  std::unordered_map<std::string, Incident> incidentsSnapshot;
+  {
+    std::lock_guard<std::mutex> lock(incidentsMutex_);
+    incidentsSnapshot = activeIncidents_;
+  }
+
+  std::vector<Incident*> matched;
+  for (auto& entry : incidentsSnapshot) {
+    if (entry.second.confirmed) continue;
+    if (!rdmaNic.empty() && entry.second.rdmaNic == rdmaNic) {
+      matched.push_back(&entry.second);
+    } else if (rdmaNic.empty()) {
+      matched.push_back(&entry.second);
+    }
+  }
+
+  if (matched.empty() && !incidentsSnapshot.empty()) {
+    for (auto& entry : incidentsSnapshot) {
+      if (!entry.second.confirmed) matched.push_back(&entry.second);
+    }
+  }
+
+  for (auto* incident : matched) {
+    std::pair<bool, std::map<std::string, int64_t>> ret = nicReader_.checkNicRetrans(incident->rdmaNic);
+    if (!ret.second.empty()) {
+      incident->nicDelta = ret.second;
+    }
+
+    if (!peerIp.empty()) {
+      std::string peerPort = topology_->getPortByNodeAndNic(peerIp, incident->rdmaNic);
+      if (!peerPort.empty()) {
+        incident->faultPaths = buildFaultPath({incident->portName}, incident->deviceModel, peerPort);
+      } else {
+        for (const auto& pmEntry : topology_->portMapping) {
+          if (pmEntry.second.node == peerIp) {
+            incident->faultPaths = buildFaultPath({incident->portName}, incident->deviceModel, pmEntry.first);
+            break;
+          }
+        }
+      }
+    }
+
+    incident->confirmed = true;
+    incident->confirmTime = std::chrono::duration<double>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    incident->ncclError = errorText.substr(0, 200);
+    emitConfirmedAlert(*incident);
+  }
+}
+
+// 事件类型常量定义
+constexpr uint32_t GRPC_JSON_EVENT_SAMPLE_INGRESS_PORT_PKT_DROP = 0x00020000;
+constexpr uint32_t GRPC_JSON_EVENT_SAMPLE_LLDP_INFO = 0x10080000;
+
+/**
+ * @brief 统一事件处理入口
+ * @param event gRPC事件请求
+ *
+ * 根据event.json_event()的值分发到不同的处理函数：
+ * - 0x00020000 (INGRESS_PORT_PKT_DROP): 交换机端口丢包实时事件
+ * - 0x10080000 (LLDP_INFO): LLDP邻居信息周期性上报事件
+ */
+void NetworkObserver::handleEvent(const ruijie_json::JsonRequest& event) {
+  uint32_t eventId = event.json_event();
+
+  if (eventId == GRPC_JSON_EVENT_SAMPLE_LLDP_INFO) {
+    handleLldpEvent(event);
+  } else if (eventId == GRPC_JSON_EVENT_SAMPLE_INGRESS_PORT_PKT_DROP) {
+    handleSwitchDropEvent(event);
+  } else {
+    INFO(NCCL_NET, "NET_OBSERV: Unknown event type 0x%08x, skipping", eventId);
+  }
+}
+
+/**
+ * @brief 处理交换机端口丢包事件（实时事件）
+ * @param event gRPC事件请求
+ *
+ * 处理流程：
+ * 1. 提取端口名、丢包数、时间戳
+ * 2. 查询拓扑获取关联的rank和RDMA网卡
+ * 3. 检查NIC重传计数器
+ * 4. 根据重传状态生成WATCH/PREDICTIVE/CONFIRMED告警
+ */
+void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& event) {
+  std::string deviceModel = "unknown";
+  if (event.has_device_info()) {
+    deviceModel = event.device_info().device_model();
+  }
+
+  std::string jsonString = event.json_string();
+  std::string portName;
+  int64_t dropCount = 0;
+  std::string timestampRaw;
+
+  if (!jsonString.empty()) {
+    portName = extractJsonString(jsonString, "port_name");
+    dropCount = extractJsonInt(jsonString, "dropped");
+    timestampRaw = extractJsonString(jsonString, "timestamp");
+  }
+
+  if (portName.empty()) {
+    for (const auto& entry : topology_->portMapping) {
+      portName = entry.first;
+      break;
+    }
+  }
+  if (portName.empty()) {
+    INFO(NCCL_NET, "NET_OBSERV: Event has no port_name and topology has no ports, skipping");
+    return;
+  }
+
+  int incId = ++incidentId_;
+
+  auto affectedRanks = topology_->getRanksForPort(portName);
+  std::string rdmaNic = topology_->getRdmaNicForPort(portName);
+  auto pathLines = buildFaultPath({portName}, deviceModel);
+
+  std::pair<bool, std::map<std::string, int64_t>> ret = nicReader_.checkNicRetrans(rdmaNic);
+
+  INFO(NCCL_NET, "NET_OBSERV: Switch drop event (0x%08x) on %s, rdma_nic=%s, has_retry=%d",
+       GRPC_JSON_EVENT_SAMPLE_INGRESS_PORT_PKT_DROP, portName.c_str(), rdmaNic.c_str(), ret.first);
+
+  char tagBuf[64];
+  snprintf(tagBuf, sizeof(tagBuf), "NET-%d", 10000 + incId);
+
+  std::string formattedTs = formatTimestamp(timestampRaw);
+
+  Incident incident;
+  incident.incidentId = incId;
+  incident.incidentTag = tagBuf;
+  incident.portName = portName;
+  incident.switchName = topology_->switchName;
+  incident.deviceModel = deviceModel;
+  incident.dropCount = dropCount;
+  incident.timestamp = formattedTs;
+  incident.affectedRanks = affectedRanks;
+  incident.faultPaths = pathLines;
+  incident.rdmaNic = rdmaNic;
+  incident.nicDelta = ret.second;
+  incident.hasRetryGrowth = ret.first;
+  incident.createTime = std::chrono::duration<double>(
+      std::chrono::system_clock::now().time_since_epoch()).count();
+  incident.confirmed = false;
+  incident.confirmTime = 0;
+  incident.ncclError = "";
+
+  if (ret.first) {
+    auto retransToIt = ret.second.find("roce_adp_retrans_to");
+    bool hasRetransTo = (retransToIt != ret.second.end() && retransToIt->second > 0);
+    if (hasRetransTo) {
+      incident.confirmed = true;
+      incident.confirmTime = std::chrono::duration<double>(
+          std::chrono::system_clock::now().time_since_epoch()).count();
+      incident.ncclError = "roce_adp_retrans_to > 0: RDMA adaptive retransmission timeout reached";
+      emitSwitchDropAlert(incident);
+      emitConfirmedAlert(incident);
+    } else {
+      emitSwitchDropAlert(incident);
+      emitPredictiveAlert(incident);
+    }
+  } else {
+    emitSwitchDropAlert(incident);
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(incidentsMutex_);
+    activeIncidents_[portName] = incident;
+  }
+}
+
+/**
+ * @brief 输出交换机丢包告警（WATCH级别）
+ * @param incident 告警事件对象
+ *
+ * 黄色告警，表示检测到交换机丢包，正在监控NIC计数器
+ */
+void NetworkObserver::emitSwitchDropAlert(const Incident& incident) {
+  std::string rankStr;
+  for (size_t i = 0; i < incident.affectedRanks.size(); i++) {
+    if (i > 0) rankStr += ", ";
+    rankStr += "Rank-" + std::to_string(incident.affectedRanks[i]);
+  }
+  std::string nicRetryStr = incident.nicDelta.empty()
+    ? "Not yet detected (monitoring...)"
+    : formatCounterDelta(incident.nicDelta);
+
+  INFO(NCCL_NET, "%s%s%s", COLOR_YELLOW, COLOR_BOLD,
+       "========================================================================");
+  INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][WATCH] Switch Packet Drop Detected%s",
+       COLOR_YELLOW, COLOR_BOLD, COLOR_RESET);
+  INFO(NCCL_NET, "%s%s========================================================================",
+       COLOR_YELLOW, COLOR_RESET);
+  INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  INFO(NCCL_NET, "  %sTimestamp:%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  INFO(NCCL_NET, "  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
+  INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  INFO(NCCL_NET, "  %sDrop Count:%s     %ld", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  INFO(NCCL_NET, "  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  INFO(NCCL_NET, "  %sNIC Retry:%s      %s", COLOR_CYAN, COLOR_RESET, nicRetryStr.c_str());
+  for (const auto& pathLine : incident.faultPaths) {
+    INFO(NCCL_NET, "  %sFault Path:%s     %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
+  }
+  INFO(NCCL_NET, "  %sStatus:%s        %sWATCHING%s - Switch drop detected, checking NIC counters",
+       COLOR_CYAN, COLOR_RESET, COLOR_YELLOW, COLOR_RESET);
+  INFO(NCCL_NET, "%s%s========================================================================",
+       COLOR_YELLOW, COLOR_RESET);
+}
+
+/**
+ * @brief 输出预测性告警（PREDICTIVE级别）
+ * @param incident 告警事件对象
+ *
+ * 洋红色告警，表示交换机丢包导致RDMA重传但尚未超时，
+ * 预测可能发生NCCL超时，建议 preemptive 检查
+ */
+void NetworkObserver::emitPredictiveAlert(const Incident& incident) {
+  std::string rankStr;
+  for (size_t i = 0; i < incident.affectedRanks.size(); i++) {
+    if (i > 0) rankStr += ", ";
+    rankStr += "Rank-" + std::to_string(incident.affectedRanks[i]);
+  }
+
+  INFO(NCCL_NET, "%s%s%s", COLOR_MAGENTA, COLOR_BOLD,
+       "========================================================================");
+  INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][PREDICTIVE] RDMA Retransmission Detected - Fault Path Predicted%s",
+       COLOR_MAGENTA, COLOR_BOLD, COLOR_RESET);
+  INFO(NCCL_NET, "%s%s========================================================================",
+       COLOR_MAGENTA, COLOR_RESET);
+  INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  INFO(NCCL_NET, "  %sTimestamp:%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  INFO(NCCL_NET, "  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
+  INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  INFO(NCCL_NET, "  %sSwitch Drop:%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  INFO(NCCL_NET, "  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  INFO(NCCL_NET, "  %sNIC Counter Delta:%s", COLOR_CYAN, COLOR_RESET);
+  for (const auto& entry : incident.nicDelta) {
+    std::string marker = (entry.first == "roce_adp_retrans") ? " <<<" : "";
+    INFO(NCCL_NET, "    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
+  }
+  for (const auto& pathLine : incident.faultPaths) {
+    INFO(NCCL_NET, "  %sPredicted Fault Path:%s %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
+  }
+  INFO(NCCL_NET, "  %sRoot Cause:%s     [Congestion/Link Issue] Switch drop + NIC retry growth",
+       COLOR_CYAN, COLOR_RESET);
+  INFO(NCCL_NET, "  %sImpact:%s         RDMA retransmission in progress, training may degrade",
+       COLOR_CYAN, COLOR_RESET);
+  INFO(NCCL_NET, "  %sStatus:%s        %sPREDICTIVE%s - RDMA is retrying, timeout not yet reached",
+       COLOR_CYAN, COLOR_RESET, COLOR_MAGENTA, COLOR_RESET);
+  INFO(NCCL_NET, "  %sNext Step:%s      Waiting for NCCL IBV_WC_RETRY_EXC_ERR exception",
+       COLOR_CYAN, COLOR_RESET);
+  INFO(NCCL_NET, "  %sSuggestion:%s     Pre-emptive: check cable/optical module at %s",
+       COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  INFO(NCCL_NET, "%s%s========================================================================",
+       COLOR_MAGENTA, COLOR_RESET);
+}
+
+/**
+ * @brief 输出已确认告警（CONFIRMED级别）
+ * @param incident 告警事件对象
+ *
+ * 红色告警，表示RDMA重传超时已发生，NCCL训练可能已卡死，
+ * 需要立即处理
+ */
+void NetworkObserver::emitConfirmedAlert(const Incident& incident) {
+  std::string rankStr;
+  for (size_t i = 0; i < incident.affectedRanks.size(); i++) {
+    if (i > 0) rankStr += ", ";
+    rankStr += "Rank-" + std::to_string(incident.affectedRanks[i]);
+  }
+
+  auto now = std::chrono::system_clock::now();
+  auto nowTimeT = std::chrono::system_clock::to_time_t(now);
+  char confirmTs[64];
+  struct tm utcTm;
+  gmtime_r(&nowTimeT, &utcTm);
+  strftime(confirmTs, sizeof(confirmTs), "%Y-%m-%d %H:%M:%S UTC", &utcTm);
+
+  std::string elapsedStr = "N/A";
+  if (incident.confirmTime > 0) {
+    double elapsed = incident.confirmTime - incident.createTime;
+    char elapsedBuf[32];
+    snprintf(elapsedBuf, sizeof(elapsedBuf), "%.1fs", elapsed);
+    elapsedStr = elapsedBuf;
+  }
+
+  INFO(NCCL_NET, "%s%s%s", COLOR_RED, COLOR_BOLD,
+       "========================================================================");
+  INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][CONFIRMED] RDMA Timeout - Fault Path Confirmed!%s",
+       COLOR_RED, COLOR_BOLD, COLOR_RESET);
+  INFO(NCCL_NET, "%s%s========================================================================",
+       COLOR_RED, COLOR_RESET);
+  INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  INFO(NCCL_NET, "  %sOriginal Time:%s  %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  INFO(NCCL_NET, "  %sConfirmed At:%s   %s", COLOR_CYAN, COLOR_RESET, confirmTs);
+  INFO(NCCL_NET, "  %sTime to Confirm:%s %s", COLOR_CYAN, COLOR_RESET, elapsedStr.c_str());
+  INFO(NCCL_NET, "  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
+  INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  INFO(NCCL_NET, "  %sSwitch Drop:%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  INFO(NCCL_NET, "  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  INFO(NCCL_NET, "  %sNIC Counter Delta (cumulative):%s", COLOR_CYAN, COLOR_RESET);
+  for (const auto& entry : incident.nicDelta) {
+    std::string marker;
+    if (entry.first == "roce_adp_retrans" || entry.first == "roce_adp_retrans_to") marker = " <<<";
+    INFO(NCCL_NET, "    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
+  }
+  for (const auto& pathLine : incident.faultPaths) {
+    INFO(NCCL_NET, "  %sConfirmed Fault Path:%s %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
+  }
+  if (!incident.ncclError.empty()) {
+    INFO(NCCL_NET, "  %sNCCL Error:%s    %s", COLOR_CYAN, COLOR_RESET, incident.ncclError.c_str());
+  }
+  INFO(NCCL_NET, "  %sRoot Cause:%s     [Confirmed] Switch drop caused RDMA timeout on %s",
+       COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  INFO(NCCL_NET, "  %sImpact:%s         Training stalled, NCCL timeout likely",
+       COLOR_CYAN, COLOR_RESET);
+  INFO(NCCL_NET, "  %sStatus:%s        %s%sCONFIRMED%s - RDMA timeout reached",
+       COLOR_CYAN, COLOR_RESET, COLOR_RED, COLOR_BOLD, COLOR_RESET);
+  INFO(NCCL_NET, "  %sSuggestion:%s     Immediate action required: check %s and %s",
+       COLOR_CYAN, COLOR_RESET, incident.portName.c_str(), incident.rdmaNic.c_str());
+  INFO(NCCL_NET, "%s%s========================================================================",
+       COLOR_RED, COLOR_RESET);
+}
+
+/**
+ * @brief 格式化计数器增量为可读字符串
+ * @param delta 计数器增量映射
+ * @return 格式化后的字符串（如"adp_retrans=+15, slow_restart=+3"）
+ *
+ * 将计数器名称缩短（去掉roce_前缀），格式为"name=+value"
+ */
+std::string NetworkObserver::formatCounterDelta(const std::map<std::string, int64_t>& delta) {
+  if (delta.empty()) return "no change";
+  std::string result;
+  for (const auto& entry : delta) {
+    if (!result.empty()) result += ", ";
+    std::string shortName = entry.first;
+    auto underscorePos = entry.first.find('_');
+    if (underscorePos != std::string::npos) {
+      shortName = entry.first.substr(underscorePos + 1);
+    }
+    result += shortName + "=+" + std::to_string(entry.second);
+  }
+  return result;
+}
+
+/**
+ * @brief 构建故障路径描述字符串
+ * @param affectedPorts 受影响的交换机端口列表
+ * @param deviceModel 交换机设备型号
+ * @param peerPort 对端端口（可选，来自异常上下文）
+ * @return 故障路径描述列表
+ *
+ * 构建端到端路径：Rank-X -> mlx5_X -> Switch(port) -> Switch(peerPort) -> mlx5_X -> Rank-Y
+ */
+std::vector<std::string> NetworkObserver::buildFaultPath(
+    const std::vector<std::string>& affectedPorts,
+    const std::string& deviceModel,
+    const std::string& peerPort) {
+  if (affectedPorts.empty()) {
+    return {deviceModel + " (" + ")"};
+  }
+
+  std::vector<std::string> paths;
+  for (const auto& faultPort : affectedPorts) {
+    std::string srcNic = topology_->getRdmaNicForPort(faultPort);
+    std::string srcNode = topology_->getNodeForPort(faultPort);
+    auto srcRanks = topology_->getRanksForPort(faultPort);
+    if (srcRanks.empty()) continue;
+
+    std::vector<std::string> otherPorts;
+    if (!peerPort.empty()) {
+      otherPorts.push_back(peerPort);
+    } else {
+      for (const auto& pmEntry : topology_->portMapping) {
+        if (pmEntry.second.node != srcNode && pmEntry.second.rdmaNic == srcNic) {
+          otherPorts.push_back(pmEntry.first);
+        }
+      }
+    }
+
+    for (const auto& otherPort : otherPorts) {
+      if (otherPort == faultPort) continue;
+      auto dstRanks = topology_->getRanksForPort(otherPort);
+      if (dstRanks.empty()) continue;
+      std::string srcRankStr = "Rank-" + std::to_string(srcRanks[0]) + "~" + std::to_string(srcRanks.back());
+      std::string dstRankStr = "Rank-" + std::to_string(dstRanks[0]) + "~" + std::to_string(dstRanks.back());
+      std::string path = srcRankStr + " -> " + srcNic + " -> "
+          + deviceModel + "(" + faultPort + ") -> " + deviceModel + "(" + otherPort + ") -> "
+          + srcNic + " -> " + dstRankStr;
+      paths.push_back(path);
+    }
+  }
+  return paths;
+}
+
+/**
+ * @brief 格式化时间戳为可读字符串
+ * @param timestampRaw 原始时间戳字符串（支持秒/毫秒/微秒）
+ * @return 格式化后的UTC时间字符串（如"2026-05-18 16:30:00 UTC"）
+ *
+ * 自动检测时间戳精度（16位=微秒，13位=毫秒，10位=秒）并转换为UTC格式
+ */
+std::string NetworkObserver::formatTimestamp(const std::string& timestampRaw) {
+  if (timestampRaw.empty()) {
+    auto now = std::chrono::system_clock::now();
+    auto nowTimeT = std::chrono::system_clock::to_time_t(now);
+    char buf[64];
+    struct tm utcTm;
+    gmtime_r(&nowTimeT, &utcTm);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &utcTm);
+    return buf;
+  }
+
+  try {
+    int64_t ts = std::stoll(timestampRaw);
+    if (ts > 1000000000000000LL) {
+      ts /= 1000000;
+    } else if (ts > 1000000000000LL) {
+      ts /= 1000;
+    }
+    auto timeT = static_cast<time_t>(ts);
+    char buf[64];
+    struct tm utcTm;
+    gmtime_r(&timeT, &utcTm);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &utcTm);
+    return buf;
+  } catch (...) {}
+
+  auto now = std::chrono::system_clock::now();
+  auto nowTimeT = std::chrono::system_clock::to_time_t(now);
+  char buf[64];
+  struct tm utcTm;
+  gmtime_r(&nowTimeT, &utcTm);
+  strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &utcTm);
+  return buf;
+}
+
+// ---- LLDP Event Handling ----
+
+/**
+ * @brief 从JSON字符串中提取指定数组的第index个元素
+ * @param json 输入的JSON字符串
+ * @param arrayName 数组字段名（如"data"）
+ * @param index 要提取的元素索引（从0开始）
+ * @return 提取到的JSON对象字符串，失败返回空字符串
+ * 
+ * 示例：json = {"data":[{"a":1},{"b":2}]}, arrayName="data", index=1
+ *       返回：{"b":2}
+ */
+static std::string extractJsonArrayItem(const std::string& json, const std::string& arrayName, size_t index) {
+  std::string search = "\"" + arrayName + "\":";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) {
+    search = "\"" + arrayName + "\" :";
+    pos = json.find(search);
+    if (pos == std::string::npos) return "";
+  }
+  pos += search.length();
+  while (pos < json.length() && (json[pos] == ' ' || json[pos] == '\t')) pos++;
+  if (pos >= json.length() || json[pos] != '[') return "";
+  pos++;
+
+  size_t braceCount = 0;
+  size_t itemStart = pos;
+  size_t itemIdx = 0;
+
+  for (size_t i = pos; i < json.length(); i++) {
+    if (json[i] == '{') braceCount++;
+    else if (json[i] == '}') {
+      braceCount--;
+      if (braceCount == 0) {
+        if (itemIdx == index) {
+          return json.substr(itemStart, i - itemStart + 1);
+        }
+        itemIdx++;
+        itemStart = i + 1;
+        while (itemStart < json.length() && (json[itemStart] == ',' || json[itemStart] == ' ' || json[itemStart] == '\t' || json[itemStart] == '\n')) itemStart++;
+        if (itemStart < json.length() && json[itemStart] == '{') {
+          i = itemStart - 1;
+        }
+      }
+    }
+  }
+  return "";
+}
+
+/**
+ * @brief 统计JSON数组中的元素个数
+ * @param json 输入的JSON字符串
+ * @param arrayName 数组字段名
+ * @return 数组元素个数，失败返回0
+ * 
+ * 通过匹配大括号{}来计数，支持嵌套对象
+ */
+static size_t countJsonArrayItems(const std::string& json, const std::string& arrayName) {
+  std::string search = "\"" + arrayName + "\":";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) {
+    search = "\"" + arrayName + "\" :";
+    pos = json.find(search);
+    if (pos == std::string::npos) return 0;
+  }
+  pos += search.length();
+  while (pos < json.length() && (json[pos] == ' ' || json[pos] == '\t')) pos++;
+  if (pos >= json.length() || json[pos] != '[') return 0;
+  pos++;
+
+  size_t braceCount = 0;
+  size_t count = 0;
+
+  for (size_t i = pos; i < json.length(); i++) {
+    if (json[i] == '{') {
+      if (braceCount == 0) count++;
+      braceCount++;
+    } else if (json[i] == '}') {
+      braceCount--;
+    } else if (json[i] == ']' && braceCount == 0) {
+      break;
+    }
+  }
+  return count;
+}
+
+/**
+ * @brief 解析LLDP事件JSON字符串，提取邻居信息列表
+ * @param jsonString LLDP事件JSON字符串
+ * @return LLDP邻居信息列表
+ * 
+ * 解析字段包括：
+ * - lldp_rem_man_addr: 远端管理IP（服务器IP）
+ * - lldp_loc_port_desc: 本地端口描述（交换机端口）
+ * - lldp_rem_port_desc: 远端端口描述（服务器网卡名）
+ * - lldp_rem_chassis_id: 远端机箱ID（MAC地址）
+ * - lldp_rem_sys_name: 远端系统名称（主机名）
+ * - lldp_rem_sys_desc: 远端系统描述（OS信息）
+ * - lldp_rem_time_mark: 时间戳
+ */
+std::vector<LldpNeighborInfo> NetworkObserver::parseLldpJson(const std::string& jsonString) {
+  std::vector<LldpNeighborInfo> results;
+
+  size_t dataCount = countJsonArrayItems(jsonString, "data");
+  if (dataCount == 0) {
+    INFO(NCCL_NET, "NET_OBSERV: LLDP JSON has no 'data' array items");
+    return results;
+  }
+
+  for (size_t i = 0; i < dataCount; i++) {
+    std::string item = extractJsonArrayItem(jsonString, "data", i);
+    if (item.empty()) continue;
+
+    LldpNeighborInfo info;
+    info.nodeIp = extractJsonString(item, "lldp_rem_man_addr");
+    info.switchPort = extractJsonString(item, "lldp_loc_port_desc");
+    info.remotePortDesc = extractJsonString(item, "lldp_rem_port_desc");
+    info.remoteChassisId = extractJsonString(item, "lldp_rem_chassis_id");
+    info.remoteSysName = extractJsonString(item, "lldp_rem_sys_name");
+    info.remoteSysDesc = extractJsonString(item, "lldp_rem_sys_desc");
+    info.timeMark = extractJsonInt(item, "lldp_rem_time_mark");
+
+    if (!info.switchPort.empty() && !info.nodeIp.empty()) {
+      results.push_back(info);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * @brief 获取本机IP地址
+ * @return 本机IP地址字符串，获取失败返回空字符串
+ *
+ * 通过读取网络接口获取本机IP，优先返回非回环地址
+ */
+std::string NetworkObserver::getLocalIpAddress() {
+  // 首先尝试从环境变量获取
+  const char* envIp = ncclGetEnv("NET_OBSERV_LOCAL_IP");
+  if (envIp && strlen(envIp) > 0) {
+    return std::string(envIp);
+  }
+
+  // 通过hostname获取
+  std::array<char, 128> hostname;
+  if (gethostname(hostname.data(), hostname.size()) == 0) {
+    struct hostent* host = gethostbyname(hostname.data());
+    if (host) {
+      struct in_addr** addr_list = reinterpret_cast<struct in_addr**>(host->h_addr_list);
+      for (int i = 0; addr_list[i] != nullptr; i++) {
+        std::string ip = inet_ntoa(*addr_list[i]);
+        // 跳过回环地址
+        if (ip != "127.0.0.1") {
+          return ip;
+        }
+      }
+    }
+  }
+
+  // 回退：尝试从网络接口获取
+  std::array<char, 256> buffer;
+  FILE* fp = popen("hostname -I 2>/dev/null | awk '{print $1}'", "r");
+  if (fp) {
+    if (fgets(buffer.data(), buffer.size(), fp) != nullptr) {
+      std::string ip = trim(std::string(buffer.data()));
+      pclose(fp);
+      if (!ip.empty()) {
+        return ip;
+      }
+    } else {
+      pclose(fp);
+    }
+  }
+
+  INFO(NCCL_NET, "NET_OBSERV: Failed to get local IP address");
+  return "";
+}
+
+/**
+ * @brief 执行shell命令并获取输出
+ * @param cmd 要执行的命令
+ * @return 命令的标准输出，执行失败返回空字符串
+ */
+std::string NetworkObserver::executeCommand(const std::string& cmd) {
+  std::array<char, 256> buffer;
+  std::string result;
+
+  FILE* fp = popen(cmd.c_str(), "r");
+  if (!fp) {
+    return "";
+  }
+
+  while (fgets(buffer.data(), buffer.size(), fp) != nullptr) {
+    result += buffer.data();
+  }
+
+  pclose(fp);
+  return trim(result);
+}
+
+/**
+ * @brief 通过SSH远程查询节点的RDMA NIC名称
+ * @param remoteIp 远程节点IP地址
+ * @param netdev 网卡设备名（如"ens43f0np0"）
+ * @return RDMA NIC名称（如"mlx5_0"），查询失败返回空字符串
+ *
+ * 通过SSH连接到远程节点，读取/sys/class/net/<netdev>/device/infiniband获取mlx5设备名
+ * 需要预先配置SSH免密登录
+ */
+std::string NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev) {
+  // 构建SSH命令
+  std::string sshCmd = "ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no " + remoteIp +
+                       " 'ls /sys/class/net/" + netdev + "/device/infiniband/ 2>/dev/null | grep mlx5_'";
+
+  std::string result = executeCommand(sshCmd);
+
+  if (!result.empty() && result.find("mlx5_") != std::string::npos) {
+    // 提取mlx5_X部分
+    size_t pos = result.find("mlx5_");
+    size_t end = pos + 5;
+    while (end < result.length() && result[end] >= '0' && result[end] <= '9') end++;
+    return result.substr(pos, end - pos);
+  }
+
+  INFO(NCCL_NET, "NET_OBSERV: Failed to query remote RDMA NIC from %s for %s", remoteIp.c_str(), netdev.c_str());
+  return "";
+}
+
+/**
+ * @brief 从服务器网卡描述获取RDMA NIC名称（支持本地和远程查询）
+ * @param portDesc 服务器侧网卡描述（如"ens43f0np0"、"mlx5_0"）
+ * @param nodeIp 节点IP地址，用于判断是本地还是远程查询
+ * @return 获取到的RDMA NIC名称（如"mlx5_0"），无法获取返回空字符串
+ *
+ * 获取规则：
+ * 1. 如果描述中包含"mlx5_"，直接提取mlx5_X部分
+ * 2. 如果是本节点，通过本地sysfs获取mlx5_X
+ * 3. 如果是远程节点，通过SSH查询获取mlx5_X
+ * 4. 其他情况返回空字符串
+ */
+std::string NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp) {
+  // 如果描述中直接包含mlx5_，直接提取
+  if (portDesc.find("mlx5_") != std::string::npos) {
+    size_t pos = portDesc.find("mlx5_");
+    size_t end = pos + 5;
+    while (end < portDesc.length() && portDesc[end] >= '0' && portDesc[end] <= '9') end++;
+    return portDesc.substr(pos, end - pos);
+  }
+
+  // 如果是网卡名（ens/enp/eth开头）
+  if (portDesc.find("ens") != std::string::npos ||
+      portDesc.find("enp") != std::string::npos ||
+      portDesc.find("eth") != std::string::npos) {
+    
+    // 判断是本节点还是远程节点
+    std::string localIp = getLocalIpAddress();
+    bool isLocalNode = (nodeIp == localIp);
+    
+    if (isLocalNode) {
+      // 本节点：通过本地sysfs获取mlx5设备
+      std::string ibPath = "/sys/class/net/" + portDesc + "/device/infiniband";
+      DIR* dir = opendir(ibPath.c_str());
+      if (dir) {
+        struct dirent* entry;
+        while ((entry = readdir(dir)) != nullptr) {
+          // 跳过 . 和 ..
+          if (entry->d_name[0] == '.') continue;
+          // 查找 mlx5_X 格式的目录名
+          std::string name(entry->d_name);
+          if (name.find("mlx5_") != std::string::npos) {
+            closedir(dir);
+            return name;
+          }
+        }
+        closedir(dir);
+      }
+      // 如果sysfs读取失败，回退到默认的mlx5_0
+      INFO(NCCL_NET, "NET_OBSERV: Failed to read IB device from sysfs for %s, fallback to mlx5_0",
+           portDesc.c_str());
+      return "mlx5_0";
+    } else {
+      // 远程节点：通过SSH查询获取mlx5设备
+      INFO(NCCL_NET, "NET_OBSERV: Querying remote node %s for RDMA NIC of %s", nodeIp.c_str(), portDesc.c_str());
+      return queryRemoteRdmaNic(nodeIp, portDesc);
+    }
+  }
+
+  return "";
+}
+
+/**
+ * @brief 根据LLDP邻居信息更新网络拓扑映射
+ * @param lldpInfos LLDP邻居信息列表
+ * @param deviceModel 交换机设备型号
+ * 
+ * 构建交换机端口到服务器IP和RDMA NIC的映射关系，
+ * 并更新到topology_->portMapping中
+ */
+void NetworkObserver::updateTopologyFromLldp(const std::vector<LldpNeighborInfo>& lldpInfos,
+                                              const std::string& deviceModel) {
+  std::vector<LldpTopologyEntry> entries;
+
+  // Update switch name/model from LLDP context
+  if (!deviceModel.empty()) {
+    topology_->switchName = deviceModel;
+  }
+
+  for (const auto& info : lldpInfos) {
+    LldpTopologyEntry entry;
+    entry.switchPort = info.switchPort;
+    entry.nodeIp = info.nodeIp;
+    // 传递nodeIp以支持本地/远程查询判断
+    entry.rdmaNic = inferRdmaNicFromPortDesc(info.remotePortDesc, info.nodeIp);
+    entry.description = info.remoteSysName + " (" + info.remotePortDesc + ")";
+
+    if (!entry.rdmaNic.empty()) {
+      entries.push_back(entry);
+
+      PortMappingInfo pmInfo;
+      pmInfo.node = entry.nodeIp;
+      pmInfo.rdmaNic = entry.rdmaNic;
+      topology_->portMapping[entry.switchPort] = pmInfo;
+    }
+  }
+
+  if (!entries.empty()) {
+    INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Updated topology from LLDP with %zu entries", entries.size());
+    printLldpTopology(entries);
+  }
+}
+
+/**
+ * @brief 打印LLDP发现的拓扑信息表格
+ * @param entries LLDP拓扑条目列表
+ * 
+ * 输出格式化的表格，展示交换机端口、服务器IP和RDMA NIC的映射关系
+ */
+void NetworkObserver::printLldpTopology(const std::vector<LldpTopologyEntry>& entries) {
+  INFO(NCCL_NET, "NET_OBSERV: +----------------------------------------+");
+  INFO(NCCL_NET, "NET_OBSERV: | %-38s |", "LLDP Discovered Topology");
+  INFO(NCCL_NET, "NET_OBSERV: +------------------+---------------------+");
+  INFO(NCCL_NET, "NET_OBSERV: | %-16s | %-17s |", "Switch Port", "Node IP");
+  INFO(NCCL_NET, "NET_OBSERV: +------------------+---------------------+");
+
+  for (const auto& entry : entries) {
+    INFO(NCCL_NET, "NET_OBSERV: | %-16s | %-17s |",
+         entry.switchPort.c_str(), entry.nodeIp.c_str());
+    INFO(NCCL_NET, "NET_OBSERV: | %-16s | %-17s |",
+         "", ("NIC: " + entry.rdmaNic).c_str());
+  }
+
+  INFO(NCCL_NET, "NET_OBSERV: +------------------+---------------------+");
+}
+
+/**
+ * @brief 处理LLDP周期性订阅事件的主入口
+ * @param event gRPC请求中的JSON事件
+ *
+ * 处理流程：
+ * 1. 提取设备型号信息
+ * 2. 解析JSON字符串中的LLDP邻居数据
+ * 3. 更新网络拓扑映射
+ *
+ * 事件类型：json_event = 0x10080000 (GRPC_JSON_EVENT_SAMPLE_LLDP_INFO)
+ */
+void NetworkObserver::handleLldpEvent(const ruijie_json::JsonRequest& event) {
+  std::string deviceModel = "unknown";
+  if (event.has_device_info()) {
+    deviceModel = event.device_info().device_model();
+  }
+
+  std::string jsonString = event.json_string();
+  if (jsonString.empty()) {
+    INFO(NCCL_NET, "NET_OBSERV: LLDP event has empty json_string, skipping");
+    return;
+  }
+
+  auto lldpInfos = parseLldpJson(jsonString);
+  if (lldpInfos.empty()) {
+    INFO(NCCL_NET, "NET_OBSERV: No valid LLDP neighbors parsed from event");
+    return;
+  }
+
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Received LLDP event (0x%08x) from %s, %zu neighbors",
+       GRPC_JSON_EVENT_SAMPLE_LLDP_INFO, deviceModel.c_str(), lldpInfos.size());
+
+  updateTopologyFromLldp(lldpInfos, deviceModel);
+}
+
+// ---- Global singleton management ----
+
+static NetworkObserver* g_netObserver = nullptr;
+static TopologyConfig* g_netObservTopology = nullptr;
+static std::mutex g_netObservMutex;
+
+/**
+ * @brief 读取环境变量中的整数
+ * @param envName 环境变量名（不含NCCL_前缀）
+ * @param defaultValue 默认值
+ * @return 解析后的整数值，解析失败返回默认值
+ */
+static int readEnvInt(const char* envName, int defaultValue) {
+  const char* val = ncclGetEnv(envName);
+  if (!val) return defaultValue;
+  char* end;
+  long result = strtol(val, &end, 10);
+  if (end == val || *end != '\0') return defaultValue;
+  return static_cast<int>(result);
+}
+
+int ncclNetObservInit(void) {
+  const char* enable = ncclGetEnv("NCCL_NET_OBSERV_ENABLE");
+  if (!enable || strcmp(enable, "1") != 0) {
+    return 0;  // Disabled, treated as success
+  }
+
+  std::lock_guard<std::mutex> lock(g_netObservMutex);
+  if (g_netObserver) {
+    return 0;  // Already initialized
+  }
+
+  int mode = readEnvInt("NCCL_NET_OBSERV_MODE", 0);
+
+  double pollInterval = 1.0;
+  const char* envPoll = ncclGetEnv("NCCL_NET_OBSERV_POLL_INTERVAL");
+  if (envPoll) {
+    char* end;
+    double val = strtod(envPoll, &end);
+    if (end != envPoll && val > 0) {
+      pollInterval = val;
+    }
+  }
+
+  if (mode == 0) {
+    // Mode 0: LLDP mode - learn topology from switch events
+    int grpcPort = readEnvInt("NCCL_NET_OBSERV_GRPC_PORT", 50051);
+
+    g_netObservTopology = new TopologyConfig();
+    g_netObservTopology->grpcPort = grpcPort;
+
+    g_netObserver = new NetworkObserver(g_netObservTopology, /*rank*/0, pollInterval);
+    int ret = g_netObserver->start();
+    if (ret != 0) {
+      INFO(NCCL_NET, "NET_OBSERV: Failed to start NetworkObserver");
+      delete g_netObserver;
+      g_netObserver = nullptr;
+      delete g_netObservTopology;
+      g_netObservTopology = nullptr;
+      return ret;
+    }
+
+    INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: NetworkObserver started (LLDP mode, port=%d)", grpcPort);
+  } else {
+    // Mode 1: Config file mode
+    const char* configPath = ncclGetEnv("NCCL_NET_OBSERV_CONFIG");
+    if (!configPath) {
+      INFO(NCCL_NET, "NET_OBSERV: NCCL_NET_OBSERV_ENABLE=1 but NCCL_NET_OBSERV_CONFIG not set, disabling");
+      return 0;
+    }
+
+    struct stat st;
+    if (stat(configPath, &st) != 0) {
+      INFO(NCCL_NET, "NET_OBSERV: Topology config %s not found, disabling", configPath);
+      return 0;
+    }
+
+    g_netObservTopology = new TopologyConfig(TopologyConfig::loadFromFile(configPath));
+
+    g_netObserver = new NetworkObserver(g_netObservTopology, /*rank*/0, pollInterval);
+    int ret = g_netObserver->start();
+    if (ret != 0) {
+      INFO(NCCL_NET, "NET_OBSERV: Failed to start NetworkObserver");
+      delete g_netObserver;
+      g_netObserver = nullptr;
+      delete g_netObservTopology;
+      g_netObservTopology = nullptr;
+      return ret;
+    }
+
+    INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: NetworkObserver started (config=%s)", configPath);
+  }
+
+  return 0;
+}
+
+void ncclNetObservFinalize(void) {
+  std::lock_guard<std::mutex> lock(g_netObservMutex);
+  if (g_netObserver) {
+    g_netObserver->stop();
+    delete g_netObserver;
+    g_netObserver = nullptr;
+  }
+  if (g_netObservTopology) {
+    delete g_netObservTopology;
+    g_netObservTopology = nullptr;
+  }
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: NetworkObserver finalized");
+}
+
+/**
+ * @brief 更新rank拓扑映射（在ncclCommInitRank后调用）
+ * @param nodeRanks 每个节点包含的rank列表，按node ID索引
+ *
+ * 该函数在NCCL通信域建立后被调用，用于更新拓扑中的rank分布信息。
+ * 通过node ID（从LLDP事件中获取的节点顺序）匹配，而不是通过IP地址。
+ */
+void ncclNetObservUpdateRankTopology(const std::vector<std::vector<int>>& nodeRanks) {
+  std::lock_guard<std::mutex> lock(g_netObservMutex);
+  if (!g_netObservTopology) {
+    INFO(NCCL_NET, "NET_OBSERV: Cannot update rank topology, NetworkObserver not initialized");
+    return;
+  }
+
+  // 收集topology中所有唯一的节点IP，并按出现顺序分配node ID
+  std::vector<std::string> uniqueNodes;
+  for (const auto& entry : g_netObservTopology->portMapping) {
+    const std::string& nodeIp = entry.second.node;
+    // 检查是否已存在
+    bool found = false;
+    for (const auto& existing : uniqueNodes) {
+      if (existing == nodeIp) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      uniqueNodes.push_back(nodeIp);
+    }
+  }
+
+  // 按node ID顺序更新每个节点的ranks
+  for (size_t nodeId = 0; nodeId < nodeRanks.size() && nodeId < uniqueNodes.size(); nodeId++) {
+    const std::string& nodeIp = uniqueNodes[nodeId];
+    const std::vector<int>& ranks = nodeRanks[nodeId];
+
+    // 更新该节点IP对应的所有端口映射
+    for (auto& entry : g_netObservTopology->portMapping) {
+      if (entry.second.node == nodeIp) {
+        entry.second.ranks = ranks;
+        INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Updated port %s with %zu ranks for node %s",
+             entry.first.c_str(), ranks.size(), nodeIp.c_str());
+      }
+    }
+  }
+
+  // 打印更新后的拓扑信息
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Rank topology updated for %zu nodes", nodeRanks.size());
+  for (size_t i = 0; i < nodeRanks.size() && i < uniqueNodes.size(); i++) {
+    std::string ranksStr;
+    if (nodeRanks[i].size() <= 4) {
+      for (size_t j = 0; j < nodeRanks[i].size(); j++) {
+        if (j > 0) ranksStr += ",";
+        ranksStr += std::to_string(nodeRanks[i][j]);
+      }
+    } else {
+      ranksStr = std::to_string(nodeRanks[i].front()) + "-" + std::to_string(nodeRanks[i].back());
+    }
+    INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV:   Node %s: ranks [%s]", uniqueNodes[i].c_str(), ranksStr.c_str());
+  }
+}
+
+/**
+ * @brief NetworkObserver成员方法：处理IB传输层错误
+ * @param rdmaNic RDMA网卡设备名
+ * @param peerIp 对端节点IP地址（可选）
+ * @param wcStatus IB工作完成状态码
+ *
+ * 该函数在IB传输层检测到CQE错误时被调用，无需等待NCCL异常。
+ * 相比confirmFromException的文本解析方式，这种方式更直接、更及时。
+ */
+void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus) {
+  INFO(NCCL_NET, "NET_OBSERV: Direct IB error from %s, peer=%s, wc_status=%d",
+       rdmaNic.c_str(), peerIp.c_str(), wcStatus);
+
+  std::lock_guard<std::mutex> lock(incidentsMutex_);
+
+  // 查找匹配的未确认告警
+  std::vector<Incident*> matched;
+  for (auto& entry : activeIncidents_) {
+    if (entry.second.confirmed) continue;
+    if (entry.second.rdmaNic == rdmaNic) {
+      matched.push_back(&entry.second);
+    }
+  }
+
+  // 如果没有精确匹配，匹配所有未确认的告警
+  if (matched.empty()) {
+    for (auto& entry : activeIncidents_) {
+      if (!entry.second.confirmed) {
+        matched.push_back(&entry.second);
+      }
+    }
+  }
+
+  // 更新并确认告警
+  for (auto* incident : matched) {
+    // 获取最新的NIC计数器
+    std::pair<bool, std::map<std::string, int64_t>> ret =
+        nicReader_.checkNicRetrans(incident->rdmaNic);
+    if (!ret.second.empty()) {
+      incident->nicDelta = ret.second;
+    }
+
+    // 如果提供了peerIp，更新故障路径
+    if (!peerIp.empty()) {
+      std::string peerPort = topology_->getPortByNodeAndNic(peerIp, incident->rdmaNic);
+      if (!peerPort.empty()) {
+        incident->faultPaths = buildFaultPath(
+            {incident->portName}, incident->deviceModel, peerPort);
+      } else {
+        for (const auto& pmEntry : topology_->portMapping) {
+          if (pmEntry.second.node == peerIp) {
+            incident->faultPaths = buildFaultPath(
+                {incident->portName}, incident->deviceModel, pmEntry.first);
+            break;
+          }
+        }
+      }
+    }
+
+    // 确认告警
+    incident->confirmed = true;
+    incident->confirmTime = std::chrono::duration<double>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // 构建错误信息
+    char errorBuf[256];
+    snprintf(errorBuf, sizeof(errorBuf),
+             "IB CQE error: dev=%s, wc_status=%d, peer=%s",
+             rdmaNic.c_str(), wcStatus, peerIp.c_str());
+    incident->ncclError = errorBuf;
+
+    // 发送确认告警
+    emitConfirmedAlert(*incident);
+
+    INFO(NCCL_NET, "NET_OBSERV: Confirmed incident %d from direct IB error",
+         incident->incidentId);
+  }
+}
+
+/**
+ * @brief C接口：处理IB传输层错误（从p2p.cc直接调用）
+ * @param rdmaNic RDMA网卡设备名
+ * @param peerIp 对端节点IP地址（可选）
+ * @param wcStatus IB工作完成状态码
+ */
+void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus) {
+  if (!rdmaNic || !g_netObserver) {
+    return;
+  }
+
+  std::string nicName(rdmaNic);
+  std::string peerIpStr(peerIp ? peerIp : "");
+
+  std::lock_guard<std::mutex> lock(g_netObservMutex);
+  if (!g_netObservTopology) {
+    return;
+  }
+
+  g_netObserver->handleIbError(nicName, peerIpStr, wcStatus);
+}
+
+}  // namespace net_observ

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -750,7 +750,6 @@ void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& even
 
   auto affectedRanks = topology_->getRanksForPort(portName);
   std::string rdmaNic = topology_->getRdmaNicForPort(portName);
-  // auto pathLines = buildFaultPath({portName}, deviceModel);
 
   std::pair<bool, std::map<std::string, int64_t>> ret = nicReader_.checkNicRetrans(rdmaNic);
 
@@ -770,8 +769,6 @@ void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& even
   incident.deviceModel = deviceModel;
   incident.dropCount = dropCount;
   incident.timestamp = formattedTs;
-  incident.affectedRanks = affectedRanks;
-  // incident.faultPaths = pathLines;
   incident.rdmaNic = rdmaNic;
   incident.nicDelta = ret.second;
   incident.hasRetryGrowth = ret.first;
@@ -812,20 +809,20 @@ void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& even
  * 黄色告警，表示检测到交换机丢包，正在监控NIC计数器
  */
 void NetworkObserver::emitSwitchDropAlert(const Incident& incident) {
-  INFO(NCCL_NET, "%s%s%s", COLOR_YELLOW, COLOR_BOLD,
-       "========================================================================");
-  INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][WATCH] Switch Packet Drop Detected%s",
+  WARN("%s%s========================================================================%s", COLOR_YELLOW, COLOR_BOLD,
+       COLOR_RESET);
+  WARN("%s%s[NETWORK_ADVISOR][WATCH] Switch Packet Drop Detected%s",
        COLOR_YELLOW, COLOR_BOLD, COLOR_RESET);
-  INFO(NCCL_NET, "%s%s========================================================================",
-       COLOR_YELLOW, COLOR_RESET);
-  INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
-  INFO(NCCL_NET, "  %sTimestamp:%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
-  INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
-  INFO(NCCL_NET, "  %sDrop Count:%s     %ld", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
-  INFO(NCCL_NET, "  %sStatus:%s        %sWATCHING%s - Switch drop detected, checking NIC counters",
+  WARN("%s%s========================================================================%s",
+       COLOR_YELLOW, COLOR_BOLD, COLOR_RESET);
+  WARN("Incident ID:%s%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  WARN("Timestamp:%s%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  WARN("Affected Port:%s%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  WARN("Drop Count:%s%s     %ld", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  WARN("Status:%s%s        %sWATCHING%s - Switch drop detected, checking NIC counters",
        COLOR_CYAN, COLOR_RESET, COLOR_YELLOW, COLOR_RESET);
-  INFO(NCCL_NET, "%s%s========================================================================",
-       COLOR_YELLOW, COLOR_RESET);
+  WARN("%s%s========================================================================%s",
+       COLOR_YELLOW, COLOR_BOLD, COLOR_RESET);
 }
 
 /**
@@ -842,38 +839,34 @@ void NetworkObserver::emitPredictiveAlert(const Incident& incident) {
     rankStr += "Rank-" + std::to_string(incident.affectedRanks[i]);
   }
 
-  INFO(NCCL_NET, "%s%s%s", COLOR_MAGENTA, COLOR_BOLD,
-       "========================================================================");
-  INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][PREDICTIVE] RDMA Retransmission Detected - Fault Path Predicted%s",
+  WARN("%s%s========================================================================%s", COLOR_MAGENTA, COLOR_BOLD,
+       COLOR_RESET);
+  WARN("%s%s[NETWORK_ADVISOR][PREDICTIVE] RDMA Retransmission Detected - Fault Path Predicted%s",
        COLOR_MAGENTA, COLOR_BOLD, COLOR_RESET);
-  INFO(NCCL_NET, "%s%s========================================================================",
-       COLOR_MAGENTA, COLOR_RESET);
-  INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
-  INFO(NCCL_NET, "  %sTimestamp:%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
-  INFO(NCCL_NET, "  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
-  INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
-  INFO(NCCL_NET, "  %sSwitch Drop:%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
-  INFO(NCCL_NET, "  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
-  INFO(NCCL_NET, "  %sNIC Counter Delta:%s", COLOR_CYAN, COLOR_RESET);
+  WARN("%s%s========================================================================%s",
+       COLOR_MAGENTA, COLOR_BOLD, COLOR_RESET);
+  WARN("Incident ID:%s%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  WARN("Timestamp:%s%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  WARN("Affected Port:%s%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  WARN("Switch Drop:%s%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  WARN("RDMA NIC:%s%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  WARN("NIC Counter Delta:%s%s", COLOR_CYAN, COLOR_RESET);
   for (const auto& entry : incident.nicDelta) {
     std::string marker = (entry.first == "roce_adp_retrans") ? " <<<" : "";
-    INFO(NCCL_NET, "    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
+    WARN("    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
   }
-  for (const auto& pathLine : incident.faultPaths) {
-    INFO(NCCL_NET, "  %sPredicted Fault Path:%s %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
-  }
-  INFO(NCCL_NET, "  %sRoot Cause:%s     [Congestion/Link Issue] Switch drop + NIC retry growth",
+  WARN("Root Cause:%s%s     [Congestion/Link Issue] Switch drop + NIC retry growth",
        COLOR_CYAN, COLOR_RESET);
-  INFO(NCCL_NET, "  %sImpact:%s         RDMA retransmission in progress, training may degrade",
+  WARN("Impact:%s%s         RDMA retransmission in progress, training may degrade",
        COLOR_CYAN, COLOR_RESET);
-  INFO(NCCL_NET, "  %sStatus:%s        %sPREDICTIVE%s - RDMA is retrying, timeout not yet reached",
+  WARN("Status:%s%s        %sPREDICTIVE%s - RDMA is retrying, timeout not yet reached",
        COLOR_CYAN, COLOR_RESET, COLOR_MAGENTA, COLOR_RESET);
-  INFO(NCCL_NET, "  %sNext Step:%s      Waiting for NCCL IBV_WC_RETRY_EXC_ERR exception",
+  WARN("Next Step:%s%s      Waiting for NCCL IBV_WC_RETRY_EXC_ERR exception",
        COLOR_CYAN, COLOR_RESET);
-  INFO(NCCL_NET, "  %sSuggestion:%s     Pre-emptive: check cable/optical module at %s",
+  WARN("Suggestion:%s%s     Pre-emptive: check cable/optical module at %s",
        COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
-  INFO(NCCL_NET, "%s%s========================================================================",
-       COLOR_MAGENTA, COLOR_RESET);
+  WARN("%s%s========================================================================%s",
+       COLOR_MAGENTA, COLOR_BOLD, COLOR_RESET);
 }
 
 /**
@@ -905,42 +898,42 @@ void NetworkObserver::emitConfirmedAlert(const Incident& incident) {
     elapsedStr = elapsedBuf;
   }
 
-  INFO(NCCL_NET, "%s%s%s", COLOR_RED, COLOR_BOLD,
-       "========================================================================");
-  INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][CONFIRMED] RDMA Timeout - Fault Path Confirmed!%s",
+  WARN("%s%s========================================================================%s", COLOR_RED, COLOR_BOLD,
+       COLOR_RESET);
+  WARN("%s%s[NETWORK_ADVISOR][CONFIRMED] RDMA Timeout - Fault Path Confirmed!%s",
        COLOR_RED, COLOR_BOLD, COLOR_RESET);
-  INFO(NCCL_NET, "%s%s========================================================================",
-       COLOR_RED, COLOR_RESET);
-  INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
-  INFO(NCCL_NET, "  %sOriginal Time:%s  %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
-  INFO(NCCL_NET, "  %sConfirmed At:%s   %s", COLOR_CYAN, COLOR_RESET, confirmTs);
-  INFO(NCCL_NET, "  %sTime to Confirm:%s %s", COLOR_CYAN, COLOR_RESET, elapsedStr.c_str());
-  INFO(NCCL_NET, "  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
-  INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
-  INFO(NCCL_NET, "  %sSwitch Drop:%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
-  INFO(NCCL_NET, "  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
-  INFO(NCCL_NET, "  %sNIC Counter Delta (cumulative):%s", COLOR_CYAN, COLOR_RESET);
+  WARN("%s%s========================================================================%s",
+       COLOR_RED, COLOR_BOLD, COLOR_RESET);
+  WARN("  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  WARN("  %sOriginal Time:%s  %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  WARN("  %sConfirmed At:%s   %s", COLOR_CYAN, COLOR_RESET, confirmTs);
+  WARN("  %sTime to Confirm:%s %s", COLOR_CYAN, COLOR_RESET, elapsedStr.c_str());
+  WARN("  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
+  WARN("  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  WARN("  %sSwitch Drop:%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  WARN("  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  WARN("  %sNIC Counter Delta (cumulative):%s", COLOR_CYAN, COLOR_RESET);
   for (const auto& entry : incident.nicDelta) {
     std::string marker;
     if (entry.first == "roce_adp_retrans" || entry.first == "roce_adp_retrans_to") marker = " <<<";
-    INFO(NCCL_NET, "    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
+    WARN("    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
   }
   for (const auto& pathLine : incident.faultPaths) {
-    INFO(NCCL_NET, "  %sConfirmed Fault Path:%s %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
+    WARN("  %sConfirmed Fault Path:%s %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
   }
   if (!incident.ncclError.empty()) {
-    INFO(NCCL_NET, "  %sNCCL Error:%s    %s", COLOR_CYAN, COLOR_RESET, incident.ncclError.c_str());
+    WARN("  %sNCCL Error:%s    %s", COLOR_CYAN, COLOR_RESET, incident.ncclError.c_str());
   }
-  INFO(NCCL_NET, "  %sRoot Cause:%s     [Confirmed] Switch drop caused RDMA timeout on %s",
+  WARN("%sRoot Cause:%s     [Confirmed] Switch drop caused RDMA timeout on %s",
        COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
-  INFO(NCCL_NET, "  %sImpact:%s         Training stalled, NCCL timeout likely",
+  WARN("%sImpact:%s         Training stalled, NCCL timeout likely",
        COLOR_CYAN, COLOR_RESET);
-  INFO(NCCL_NET, "  %sStatus:%s        %s%sCONFIRMED%s - RDMA timeout reached",
+  WARN("%sStatus:%s        %s%sCONFIRMED%s - RDMA timeout reached",
        COLOR_CYAN, COLOR_RESET, COLOR_RED, COLOR_BOLD, COLOR_RESET);
-  INFO(NCCL_NET, "  %sSuggestion:%s     Immediate action required: check %s and %s",
+  WARN("%sSuggestion:%s     Immediate action required: check %s and %s",
        COLOR_CYAN, COLOR_RESET, incident.portName.c_str(), incident.rdmaNic.c_str());
-  INFO(NCCL_NET, "%s%s========================================================================",
-       COLOR_RED, COLOR_RESET);
+  WARN("%s%s========================================================================%s",
+       COLOR_RED, COLOR_BOLD, COLOR_RESET);
 }
 
 /**
@@ -994,17 +987,15 @@ std::vector<std::string> NetworkObserver::buildFaultPath(
   for (const auto& faultPort : affectedPorts) {
     INFO(NCCL_NET, "NET/OBSERV: Processing faultPort=%s", faultPort.c_str());
 
+    // Get source NIC for the fault port
     std::string srcNic = topology_->getRdmaNicForPort(faultPort);
+    // Get fault port Node IP
     std::string srcNode = topology_->getNodeForPort(faultPort);
-    auto srcRanks = topology_->getRanksForPort(faultPort);
 
-    INFO(NCCL_NET, "NET/OBSERV: faultPort=%s -> srcNic=%s, srcNode=%s, srcRanks.size=%zu",
-         faultPort.c_str(), srcNic.c_str(), srcNode.c_str(), srcRanks.size());
+    INFO(NCCL_NET, "NET/OBSERV: faultPort=%s -> srcNic=%s, srcNode=%s",
+         faultPort.c_str(), srcNic.c_str(), srcNode.c_str());
 
-    if (srcRanks.empty()) {
-      INFO(NCCL_NET, "NET/OBSERV: Skipping faultPort=%s, no ranks found", faultPort.c_str());
-      continue;
-    }
+    std::string srcRankStr = "Rank-" + std::to_string(tpRank);
 
     std::vector<std::string> otherPorts;
     if (!peerPort.empty()) {
@@ -1027,23 +1018,20 @@ std::vector<std::string> NetworkObserver::buildFaultPath(
         INFO(NCCL_NET, "NET/OBSERV: Skipping otherPort=%s (same as faultPort)", otherPort.c_str());
         continue;
       }
-      auto dstRanks = topology_->getRanksForPort(otherPort);
-      INFO(NCCL_NET, "NET/OBSERV: otherPort=%s -> dstRanks.size=%zu", otherPort.c_str(), dstRanks.size());
-      if (dstRanks.empty()) {
-        INFO(NCCL_NET, "NET/OBSERV: Skipping otherPort=%s, no ranks found", otherPort.c_str());
-        continue;
-      }
-      // Use tpRank and tpRemoteRank from transport layer for accurate rank identification
-      // If -1, fall back to topology-derived ranks
-      int srcRank = (tpRank >= 0) ? tpRank : srcRanks[0];
-      int dstRank = (tpRemoteRank >= 0) ? tpRemoteRank : dstRanks[0];
-      std::string srcRankStr = "Rank-" + std::to_string(srcRank);
-      std::string dstRankStr = "Rank-" + std::to_string(dstRank);
+
       // Get destination NIC for the other port
       std::string dstNic = topology_->getRdmaNicForPort(otherPort);
-      std::string path = srcRankStr + " -> " + srcNic + " -> "
+      // Get other port Node IP
+      std::string dstNode = topology_->getNodeForPort(otherPort);
+      
+      INFO(NCCL_NET, "NET/OBSERV: otherPort=%s -> dstNic=%s, dstNode=%s",
+           otherPort.c_str(), dstNic.c_str(), dstNode.c_str());
+      
+      std::string dstRankStr = "Rank-" + std::to_string(tpRemoteRank);
+
+      std::string path = srcRankStr + "(" + "srcNode:" + srcNode + ")" + " -> " + srcNic + " -> "
           + deviceModel + "(" + faultPort + ") -> " + deviceModel + "(" + otherPort + ") -> "
-          + dstNic + " -> " + dstRankStr;
+          + dstNic + " -> " + dstRankStr + "(" + "dstNode:" + dstNode + ")";
       INFO(NCCL_NET, "NET/OBSERV: Built fault path: %s", path.c_str());
       paths.push_back(path);
     }
@@ -1383,17 +1371,6 @@ static std::string getLocalRdmaNicIp(const std::string& mlx5Dev) {
 RdmaNicInfo NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp) {
   RdmaNicInfo result;
 
-  // 如果描述中直接包含mlx5_，直接提取
-  if (portDesc.find("mlx5_") != std::string::npos) {
-    size_t pos = portDesc.find("mlx5_");
-    size_t end = pos + 5;
-    while (end < portDesc.length() && portDesc[end] >= '0' && portDesc[end] <= '9') end++;
-    result.name = portDesc.substr(pos, end - pos);
-    // Also fetch the IP for the local machine
-    result.ip = getLocalRdmaNicIp(result.name);
-    return result;
-  }
-
   // 如果是网卡名（ens/enp/eth开头）
   if (portDesc.find("ens") != std::string::npos ||
       portDesc.find("enp") != std::string::npos ||
@@ -1419,7 +1396,6 @@ RdmaNicInfo NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDes
           std::string name(entry->d_name);
           if (name.find("mlx5_") != std::string::npos) {
             result.name = name;
-            closedir(dir);
             break;
           }
         }
@@ -1436,7 +1412,7 @@ RdmaNicInfo NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDes
       return result;
     } else {
       // 远程节点：通过SSH查询获取mlx5设备及其IP
-      INFO(NCCL_NET, "NET/OBSERV: Querying remote node %s for RDMA NIC of %s (requires SSH passwordless login)",
+      INFO(NCCL_NET, "NET/OBSERV: Querying remote node %s for RDMA NIC of %s",
            nodeIp.c_str(), portDesc.c_str());
       return queryRemoteRdmaNic(nodeIp, portDesc);
     }
@@ -1811,6 +1787,8 @@ void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::strin
 
   // 更新并确认告警
   for (auto* incident : matched) {
+    // 更新受到影响的rank信息
+    incident->affectedRanks = {tpRank, tpRemoteRank};
     // 获取最新的NIC计数器
     std::pair<bool, std::map<std::string, int64_t>> ret =
         nicReader_.checkNicRetrans(incident->rdmaNic);

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -594,7 +594,8 @@ NetworkObserver::NetworkObserver(TopologyConfig* topology, int rank, double poll
   , rank_(rank)
   , pollInterval_(pollInterval)
   , stopRequested_(false)
-  , incidentId_(0) {
+  , incidentId_(0)
+  , lldpHandled_(false) {
 }
 
 /**
@@ -700,7 +701,10 @@ void NetworkObserver::handleEvent(const ruijie_json::JsonRequest& event) {
   uint32_t eventId = event.json_event();
 
   if (eventId == GRPC_JSON_EVENT_SAMPLE_LLDP_INFO) {
-    handleLldpEvent(event);
+    if (!lldpHandled_) {
+      handleLldpEvent(event);
+      lldpHandled_ = true;
+    }
   } else if (eventId == GRPC_JSON_EVENT_SAMPLE_INGRESS_PORT_PKT_DROP) {
     handleSwitchDropEvent(event);
   } else {
@@ -898,41 +902,41 @@ void NetworkObserver::emitConfirmedAlert(const Incident& incident) {
     elapsedStr = elapsedBuf;
   }
 
-  WARN("%s%s========================================================================%s", COLOR_RED, COLOR_BOLD,
+  fprintf(stderr, "%s%s========================================================================%s\n", COLOR_RED, COLOR_BOLD,
        COLOR_RESET);
-  WARN("%s%s[NETWORK_ADVISOR][CONFIRMED] RDMA Timeout - Fault Path Confirmed!%s",
+  fprintf(stderr, "%s%s[NETWORK_ADVISOR][CONFIRMED] RDMA Timeout - Fault Path Confirmed!%s\n",
        COLOR_RED, COLOR_BOLD, COLOR_RESET);
-  WARN("%s%s========================================================================%s",
+  fprintf(stderr, "%s%s========================================================================%s\n",
        COLOR_RED, COLOR_BOLD, COLOR_RESET);
-  WARN("  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
-  WARN("  %sOriginal Time:%s  %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
-  WARN("  %sConfirmed At:%s   %s", COLOR_CYAN, COLOR_RESET, confirmTs);
-  WARN("  %sTime to Confirm:%s %s", COLOR_CYAN, COLOR_RESET, elapsedStr.c_str());
-  WARN("  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
-  WARN("  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
-  WARN("  %sSwitch Drop:%s    %ld packets", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
-  WARN("  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
-  WARN("  %sNIC Counter Delta (cumulative):%s", COLOR_CYAN, COLOR_RESET);
+  fprintf(stderr, "  %sIncident ID:%s    %s\n", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
+  fprintf(stderr, "  %sOriginal Time:%s  %s\n", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
+  fprintf(stderr, "  %sConfirmed At:%s   %s\n", COLOR_CYAN, COLOR_RESET, confirmTs);
+  fprintf(stderr, "  %sTime to Confirm:%s %s\n", COLOR_CYAN, COLOR_RESET, elapsedStr.c_str());
+  fprintf(stderr, "  %sAffected Ranks:%s %s\n", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
+  fprintf(stderr, "  %sAffected Port:%s  %s\n", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
+  fprintf(stderr, "  %sSwitch Drop:%s    %ld packets\n", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
+  fprintf(stderr, "  %sRDMA NIC:%s       %s\n", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
+  fprintf(stderr, "  %sNIC Counter Delta (cumulative):%s\n", COLOR_CYAN, COLOR_RESET);
   for (const auto& entry : incident.nicDelta) {
     std::string marker;
     if (entry.first == "roce_adp_retrans" || entry.first == "roce_adp_retrans_to") marker = " <<<";
-    WARN("    %s%s:%s +%ld%s", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
+    fprintf(stderr, "    %s%s:%s +%ld%s\n", COLOR_DIM, entry.first.c_str(), COLOR_RESET, (long)entry.second, marker.c_str());
   }
   for (const auto& pathLine : incident.faultPaths) {
-    WARN("  %sConfirmed Fault Path:%s %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
+    fprintf(stderr, "  %sConfirmed Fault Path:%s %s\n", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
   }
   if (!incident.ncclError.empty()) {
-    WARN("  %sNCCL Error:%s    %s", COLOR_CYAN, COLOR_RESET, incident.ncclError.c_str());
+    fprintf(stderr, "  %sNCCL Error:%s    %s\n", COLOR_CYAN, COLOR_RESET, incident.ncclError.c_str());
   }
-  WARN("%sRoot Cause:%s     [Confirmed] Switch drop caused RDMA timeout on %s",
+  fprintf(stderr, "  %sRoot Cause:%s     [Confirmed] Switch drop caused RDMA timeout on %s\n",
        COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
-  WARN("%sImpact:%s         Training stalled, NCCL timeout likely",
+  fprintf(stderr, "  %sImpact:%s         Training stalled, NCCL timeout likely\n",
        COLOR_CYAN, COLOR_RESET);
-  WARN("%sStatus:%s        %s%sCONFIRMED%s - RDMA timeout reached",
+  fprintf(stderr, "  %sStatus:%s        %s%sCONFIRMED%s - RDMA timeout reached\n",
        COLOR_CYAN, COLOR_RESET, COLOR_RED, COLOR_BOLD, COLOR_RESET);
-  WARN("%sSuggestion:%s     Immediate action required: check %s and %s",
+  fprintf(stderr, "  %sSuggestion:%s     Immediate action required: check %s and %s\n",
        COLOR_CYAN, COLOR_RESET, incident.portName.c_str(), incident.rdmaNic.c_str());
-  WARN("%s%s========================================================================%s",
+  fprintf(stderr, "%s%s========================================================================%s\n",
        COLOR_RED, COLOR_BOLD, COLOR_RESET);
 }
 
@@ -1460,7 +1464,7 @@ void NetworkObserver::updateTopologyFromLldp(const std::vector<LldpNeighborInfo>
   }
 
   if (!entries.empty()) {
-    INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Updated topology from LLDP with %zu entries", entries.size());
+    fprintf(stdout, "NET_OBSERV: Updated topology from LLDP with %zu entries\n", entries.size());
     printLldpTopology(entries);
   }
 }
@@ -1517,8 +1521,8 @@ void NetworkObserver::handleLldpEvent(const ruijie_json::JsonRequest& event) {
     return;
   }
 
-  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Received LLDP event (0x%08x) from %s, %zu neighbors",
-       GRPC_JSON_EVENT_SAMPLE_LLDP_INFO, deviceModel.c_str(), lldpInfos.size());
+  fprintf(stdout, "NET_OBSERV: Received LLDP event (0x%08x) from %s, %zu neighbors\n",
+          GRPC_JSON_EVENT_SAMPLE_LLDP_INFO, deviceModel.c_str(), lldpInfos.size());
 
   updateTopologyFromLldp(lldpInfos, deviceModel);
 }

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -1315,35 +1315,23 @@ std::string NetworkObserver::executeCommand(const std::string& cmd) {
  */
 RdmaNicInfo NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev) {
   RdmaNicInfo result;
-  // 构建SSH命令，使用BatchMode防止密码提示阻塞
-  // -o BatchMode=yes: 禁止交互式密码提示
-  // -o ConnectTimeout=3: 连接超时3秒
-  // -o StrictHostKeyChecking=no: 不检查主机密钥
-  std::string sshCmd = "ssh -o BatchMode=yes -o ConnectTimeout=3 -o StrictHostKeyChecking=no " + remoteIp +
-                       " 'mlx5_dev=$(ls /sys/class/net/" + netdev + "/device/infiniband/ 2>/dev/null | grep mlx5_); "
-                       "if [ -n \"$mlx5_dev\" ]; then "
-                       "  net_iface=$(ls /sys/class/infiniband/$mlx5_dev/device/net/ 2>/dev/null | head -1); "
-                       "  ip_addr=$(ip -o -4 addr show $net_iface 2>/dev/null | awk \"{print \\$4}\" | cut -d/ -f1); "
-                       "  echo \"$mlx5_dev $ip_addr\"; "
-                       "fi'";
 
-  std::string output = executeCommand(sshCmd);
-  output = trim(output);
-
-  if (!output.empty()) {
-    std::istringstream iss(output);
-    std::string namePart, ipPart;
-    iss >> namePart >> ipPart;
-    if (namePart.find("mlx5_") != std::string::npos) {
-      result.name = namePart;
-      result.ip = ipPart;
-    }
-  }
-
-  if (result.name.empty()) {
+  // Step 1: Get mlx5 device name from the network interface
+  std::string getMlx5Cmd = "ssh -o BatchMode=yes -o ConnectTimeout=3 -o StrictHostKeyChecking=no " + remoteIp +
+                           " ls /sys/class/net/" + netdev + "/device/infiniband/ 2>/dev/null | grep mlx5_ | head -1";
+  std::string mlx5Output = trim(executeCommand(getMlx5Cmd));
+  if (mlx5Output.empty()) {
     INFO(NCCL_NET, "NET/OBSERV: Failed to query remote RDMA NIC from %s for %s (SSH may not be configured)",
          remoteIp.c_str(), netdev.c_str());
+    return result;
   }
+  result.name = mlx5Output;
+
+  // Step 2: Get IP address using the netdev interface name directly
+  std::string getAddrCmd = "ssh -o BatchMode=yes -o ConnectTimeout=3 -o StrictHostKeyChecking=no " + remoteIp +
+                           " ip -o -4 addr show " + netdev + " 2>/dev/null | head -1 | awk '{print $4}' | cut -d/ -f1";
+  result.ip = trim(executeCommand(getAddrCmd));
+
   return result;
 }
 

--- a/src/plugin/net_observ/net_observ.cc
+++ b/src/plugin/net_observ/net_observ.cc
@@ -14,9 +14,15 @@
 #include <chrono>
 #include <ctime>
 #include <sys/stat.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <dirent.h>
 #include <array>
 #include <memory>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
 
 #include "checks.h"
 #include "param.h"
@@ -670,107 +676,6 @@ void NetworkObserver::monitorLoop() {
   }
 }
 
-/**
- * @brief 根据NCCL异常确认告警
- * @param errorText NCCL错误文本
- *
- * 解析异常信息中的RDMA网卡和对端IP，
- * 匹配activeIncidents_中的未确认告警并升级为CONFIRMED状态
- */
-void NetworkObserver::confirmFromException(const std::string& errorText) {
-  std::string rdmaNic;
-  std::string peerIp;
-  bool isNcclIbError = false;
-
-  std::smatch match;
-
-  // Check for NCCL IB error patterns
-  const std::regex ibErrorPatterns[] = {
-    std::regex("IBV_WC_RETRY_EXC_ERR"),
-    std::regex("Got CQE with error"),
-    std::regex("Got completion.*status=IBV_WC_RETRY_EXC_ERR"),
-  };
-
-  for (const auto& pattern : ibErrorPatterns) {
-    if (std::regex_search(errorText, match, pattern)) {
-      isNcclIbError = true;
-      break;
-    }
-  }
-
-  if (!isNcclIbError) {
-    std::string ncclKeywords[] = {"NCCL", "nccl", "Distributed", "dist_backend"};
-    bool hasNcclKeyword = false;
-    for (const auto& kw : ncclKeywords) {
-      if (errorText.find(kw) != std::string::npos) {
-        hasNcclKeyword = true;
-        break;
-      }
-    }
-    if (!hasNcclKeyword) return;
-  }
-
-  if (std::regex_search(errorText, match, NCCL_HCA_PATTERN)) {
-    rdmaNic = match[1].str();
-  }
-
-  if (std::regex_search(errorText, match, NCCL_PEER_IP_PATTERN)) {
-    peerIp = match[1].str();
-  }
-
-  INFO(NCCL_NET, "NET_OBSERV: Caught NCCL exception, rdma_nic=%s, peer_ip=%s, is_ib_error=%d",
-       rdmaNic.c_str(), peerIp.c_str(), isNcclIbError);
-
-  std::unordered_map<std::string, Incident> incidentsSnapshot;
-  {
-    std::lock_guard<std::mutex> lock(incidentsMutex_);
-    incidentsSnapshot = activeIncidents_;
-  }
-
-  std::vector<Incident*> matched;
-  for (auto& entry : incidentsSnapshot) {
-    if (entry.second.confirmed) continue;
-    if (!rdmaNic.empty() && entry.second.rdmaNic == rdmaNic) {
-      matched.push_back(&entry.second);
-    } else if (rdmaNic.empty()) {
-      matched.push_back(&entry.second);
-    }
-  }
-
-  if (matched.empty() && !incidentsSnapshot.empty()) {
-    for (auto& entry : incidentsSnapshot) {
-      if (!entry.second.confirmed) matched.push_back(&entry.second);
-    }
-  }
-
-  for (auto* incident : matched) {
-    std::pair<bool, std::map<std::string, int64_t>> ret = nicReader_.checkNicRetrans(incident->rdmaNic);
-    if (!ret.second.empty()) {
-      incident->nicDelta = ret.second;
-    }
-
-    if (!peerIp.empty()) {
-      std::string peerPort = topology_->getPortByNodeAndNic(peerIp, incident->rdmaNic);
-      if (!peerPort.empty()) {
-        incident->faultPaths = buildFaultPath({incident->portName}, incident->deviceModel, peerPort);
-      } else {
-        for (const auto& pmEntry : topology_->portMapping) {
-          if (pmEntry.second.node == peerIp) {
-            incident->faultPaths = buildFaultPath({incident->portName}, incident->deviceModel, pmEntry.first);
-            break;
-          }
-        }
-      }
-    }
-
-    incident->confirmed = true;
-    incident->confirmTime = std::chrono::duration<double>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
-    incident->ncclError = errorText.substr(0, 200);
-    emitConfirmedAlert(*incident);
-  }
-}
-
 // 事件类型常量定义
 constexpr uint32_t GRPC_JSON_EVENT_SAMPLE_INGRESS_PORT_PKT_DROP = 0x00020000;
 constexpr uint32_t GRPC_JSON_EVENT_SAMPLE_LLDP_INFO = 0x10080000;
@@ -837,7 +742,7 @@ void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& even
 
   auto affectedRanks = topology_->getRanksForPort(portName);
   std::string rdmaNic = topology_->getRdmaNicForPort(portName);
-  auto pathLines = buildFaultPath({portName}, deviceModel);
+  // auto pathLines = buildFaultPath({portName}, deviceModel);
 
   std::pair<bool, std::map<std::string, int64_t>> ret = nicReader_.checkNicRetrans(rdmaNic);
 
@@ -858,7 +763,7 @@ void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& even
   incident.dropCount = dropCount;
   incident.timestamp = formattedTs;
   incident.affectedRanks = affectedRanks;
-  incident.faultPaths = pathLines;
+  // incident.faultPaths = pathLines;
   incident.rdmaNic = rdmaNic;
   incident.nicDelta = ret.second;
   incident.hasRetryGrowth = ret.first;
@@ -899,15 +804,6 @@ void NetworkObserver::handleSwitchDropEvent(const ruijie_json::JsonRequest& even
  * 黄色告警，表示检测到交换机丢包，正在监控NIC计数器
  */
 void NetworkObserver::emitSwitchDropAlert(const Incident& incident) {
-  std::string rankStr;
-  for (size_t i = 0; i < incident.affectedRanks.size(); i++) {
-    if (i > 0) rankStr += ", ";
-    rankStr += "Rank-" + std::to_string(incident.affectedRanks[i]);
-  }
-  std::string nicRetryStr = incident.nicDelta.empty()
-    ? "Not yet detected (monitoring...)"
-    : formatCounterDelta(incident.nicDelta);
-
   INFO(NCCL_NET, "%s%s%s", COLOR_YELLOW, COLOR_BOLD,
        "========================================================================");
   INFO(NCCL_NET, "%s%s[NETWORK_ADVISOR][WATCH] Switch Packet Drop Detected%s",
@@ -916,14 +812,8 @@ void NetworkObserver::emitSwitchDropAlert(const Incident& incident) {
        COLOR_YELLOW, COLOR_RESET);
   INFO(NCCL_NET, "  %sIncident ID:%s    %s", COLOR_CYAN, COLOR_RESET, incident.incidentTag.c_str());
   INFO(NCCL_NET, "  %sTimestamp:%s     %s", COLOR_CYAN, COLOR_RESET, incident.timestamp.c_str());
-  INFO(NCCL_NET, "  %sAffected Ranks:%s %s", COLOR_CYAN, COLOR_RESET, rankStr.c_str());
   INFO(NCCL_NET, "  %sAffected Port:%s  %s", COLOR_CYAN, COLOR_RESET, incident.portName.c_str());
   INFO(NCCL_NET, "  %sDrop Count:%s     %ld", COLOR_CYAN, COLOR_RESET, (long)incident.dropCount);
-  INFO(NCCL_NET, "  %sRDMA NIC:%s       %s", COLOR_CYAN, COLOR_RESET, incident.rdmaNic.c_str());
-  INFO(NCCL_NET, "  %sNIC Retry:%s      %s", COLOR_CYAN, COLOR_RESET, nicRetryStr.c_str());
-  for (const auto& pathLine : incident.faultPaths) {
-    INFO(NCCL_NET, "  %sFault Path:%s     %s", COLOR_CYAN, COLOR_RESET, pathLine.c_str());
-  }
   INFO(NCCL_NET, "  %sStatus:%s        %sWATCHING%s - Switch drop detected, checking NIC counters",
        COLOR_CYAN, COLOR_RESET, COLOR_YELLOW, COLOR_RESET);
   INFO(NCCL_NET, "%s%s========================================================================",
@@ -1072,6 +962,8 @@ std::string NetworkObserver::formatCounterDelta(const std::map<std::string, int6
  * @param affectedPorts 受影响的交换机端口列表
  * @param deviceModel 交换机设备型号
  * @param peerPort 对端端口（可选，来自异常上下文）
+ * @param tpRank 本地Tensor Parallel rank
+ * @param tpRemoteRank 对端Tensor Parallel rank
  * @return 故障路径描述列表
  *
  * 构建端到端路径：Rank-X -> mlx5_X -> Switch(port) -> Switch(peerPort) -> mlx5_X -> Rank-Y
@@ -1079,41 +971,77 @@ std::string NetworkObserver::formatCounterDelta(const std::map<std::string, int6
 std::vector<std::string> NetworkObserver::buildFaultPath(
     const std::vector<std::string>& affectedPorts,
     const std::string& deviceModel,
-    const std::string& peerPort) {
+    const std::string& peerPort,
+    int tpRank,
+    int tpRemoteRank) {
+  INFO(NCCL_NET, "NET/OBSERV: buildFaultPath called with %zu affectedPorts, deviceModel=%s, peerPort=%s, tpRank=%d, tpRemoteRank=%d",
+       affectedPorts.size(), deviceModel.c_str(), peerPort.c_str(), tpRank, tpRemoteRank);
+
   if (affectedPorts.empty()) {
+    INFO(NCCL_NET, "NET/OBSERV: affectedPorts is empty, returning placeholder path");
     return {deviceModel + " (" + ")"};
   }
 
   std::vector<std::string> paths;
   for (const auto& faultPort : affectedPorts) {
+    INFO(NCCL_NET, "NET/OBSERV: Processing faultPort=%s", faultPort.c_str());
+
     std::string srcNic = topology_->getRdmaNicForPort(faultPort);
     std::string srcNode = topology_->getNodeForPort(faultPort);
     auto srcRanks = topology_->getRanksForPort(faultPort);
-    if (srcRanks.empty()) continue;
+
+    INFO(NCCL_NET, "NET/OBSERV: faultPort=%s -> srcNic=%s, srcNode=%s, srcRanks.size=%zu",
+         faultPort.c_str(), srcNic.c_str(), srcNode.c_str(), srcRanks.size());
+
+    if (srcRanks.empty()) {
+      INFO(NCCL_NET, "NET/OBSERV: Skipping faultPort=%s, no ranks found", faultPort.c_str());
+      continue;
+    }
 
     std::vector<std::string> otherPorts;
     if (!peerPort.empty()) {
+      INFO(NCCL_NET, "NET/OBSERV: Using provided peerPort=%s", peerPort.c_str());
       otherPorts.push_back(peerPort);
     } else {
+      INFO(NCCL_NET, "NET/OBSERV: No peerPort provided, searching portMapping for same NIC on different nodes...");
       for (const auto& pmEntry : topology_->portMapping) {
         if (pmEntry.second.node != srcNode && pmEntry.second.rdmaNic == srcNic) {
+          INFO(NCCL_NET, "NET/OBSERV: Found matching port in portMapping: port=%s, node=%s, rdmaNic=%s",
+               pmEntry.first.c_str(), pmEntry.second.node.c_str(), pmEntry.second.rdmaNic.c_str());
           otherPorts.push_back(pmEntry.first);
         }
       }
+      INFO(NCCL_NET, "NET/OBSERV: Found %zu otherPorts from portMapping", otherPorts.size());
     }
 
     for (const auto& otherPort : otherPorts) {
-      if (otherPort == faultPort) continue;
+      if (otherPort == faultPort) {
+        INFO(NCCL_NET, "NET/OBSERV: Skipping otherPort=%s (same as faultPort)", otherPort.c_str());
+        continue;
+      }
       auto dstRanks = topology_->getRanksForPort(otherPort);
-      if (dstRanks.empty()) continue;
-      std::string srcRankStr = "Rank-" + std::to_string(srcRanks[0]) + "~" + std::to_string(srcRanks.back());
-      std::string dstRankStr = "Rank-" + std::to_string(dstRanks[0]) + "~" + std::to_string(dstRanks.back());
+      INFO(NCCL_NET, "NET/OBSERV: otherPort=%s -> dstRanks.size=%zu", otherPort.c_str(), dstRanks.size());
+      if (dstRanks.empty()) {
+        INFO(NCCL_NET, "NET/OBSERV: Skipping otherPort=%s, no ranks found", otherPort.c_str());
+        continue;
+      }
+      // Use tpRank and tpRemoteRank from transport layer for accurate rank identification
+      // If -1, fall back to topology-derived ranks
+      int srcRank = (tpRank >= 0) ? tpRank : srcRanks[0];
+      int dstRank = (tpRemoteRank >= 0) ? tpRemoteRank : dstRanks[0];
+      std::string srcRankStr = "Rank-" + std::to_string(srcRank);
+      std::string dstRankStr = "Rank-" + std::to_string(dstRank);
+      // Get destination NIC for the other port
+      std::string dstNic = topology_->getRdmaNicForPort(otherPort);
       std::string path = srcRankStr + " -> " + srcNic + " -> "
           + deviceModel + "(" + faultPort + ") -> " + deviceModel + "(" + otherPort + ") -> "
-          + srcNic + " -> " + dstRankStr;
+          + dstNic + " -> " + dstRankStr;
+      INFO(NCCL_NET, "NET/OBSERV: Built fault path: %s", path.c_str());
       paths.push_back(path);
     }
   }
+
+  INFO(NCCL_NET, "NET/OBSERV: buildFaultPath returning %zu paths", paths.size());
   return paths;
 }
 
@@ -1293,7 +1221,9 @@ std::vector<LldpNeighborInfo> NetworkObserver::parseLldpJson(const std::string& 
  * @brief 获取本机IP地址
  * @return 本机IP地址字符串，获取失败返回空字符串
  *
- * 通过读取网络接口获取本机IP，优先返回非回环地址
+ * 优先级：
+ * 1. 环境变量 NET_OBSERV_LOCAL_IP
+ * 2. 从网络接口获取（使用socket，避免DNS阻塞）
  */
 std::string NetworkObserver::getLocalIpAddress() {
   // 首先尝试从环境变量获取
@@ -1302,39 +1232,43 @@ std::string NetworkObserver::getLocalIpAddress() {
     return std::string(envIp);
   }
 
-  // 通过hostname获取
-  std::array<char, 128> hostname;
-  if (gethostname(hostname.data(), hostname.size()) == 0) {
-    struct hostent* host = gethostbyname(hostname.data());
-    if (host) {
-      struct in_addr** addr_list = reinterpret_cast<struct in_addr**>(host->h_addr_list);
-      for (int i = 0; addr_list[i] != nullptr; i++) {
-        std::string ip = inet_ntoa(*addr_list[i]);
-        // 跳过回环地址
-        if (ip != "127.0.0.1") {
-          return ip;
-        }
-      }
-    }
+  // 使用socket获取本机IP，避免DNS解析阻塞
+  int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    INFO(NCCL_NET, "NET_OBSERV: Failed to create socket for IP detection");
+    return "";
   }
 
-  // 回退：尝试从网络接口获取
-  std::array<char, 256> buffer;
-  FILE* fp = popen("hostname -I 2>/dev/null | awk '{print $1}'", "r");
-  if (fp) {
-    if (fgets(buffer.data(), buffer.size(), fp) != nullptr) {
-      std::string ip = trim(std::string(buffer.data()));
-      pclose(fp);
-      if (!ip.empty()) {
-        return ip;
-      }
-    } else {
-      pclose(fp);
-    }
+  // 连接到一个公共DNS服务器（不会真正发送数据）
+  struct sockaddr_in serv;
+  memset(&serv, 0, sizeof(serv));
+  serv.sin_family = AF_INET;
+  serv.sin_addr.s_addr = inet_addr("8.8.8.8");  // Google DNS
+  serv.sin_port = htons(53);
+
+  if (connect(sock, (struct sockaddr*)&serv, sizeof(serv)) < 0) {
+    close(sock);
+    INFO(NCCL_NET, "NET_OBSERV: Failed to connect socket for IP detection");
+    return "";
   }
 
-  INFO(NCCL_NET, "NET_OBSERV: Failed to get local IP address");
-  return "";
+  struct sockaddr_in name;
+  socklen_t namelen = sizeof(name);
+  if (getsockname(sock, (struct sockaddr*)&name, &namelen) < 0) {
+    close(sock);
+    INFO(NCCL_NET, "NET_OBSERV: Failed to get socket name for IP detection");
+    return "";
+  }
+
+  std::string ip = inet_ntoa(name.sin_addr);
+  close(sock);
+
+  if (ip.empty() || ip == "0.0.0.0") {
+    INFO(NCCL_NET, "NET_OBSERV: Failed to get local IP address");
+    return "";
+  }
+
+  return ip;
 }
 
 /**
@@ -1367,10 +1301,15 @@ std::string NetworkObserver::executeCommand(const std::string& cmd) {
  *
  * 通过SSH连接到远程节点，读取/sys/class/net/<netdev>/device/infiniband获取mlx5设备名
  * 需要预先配置SSH免密登录
+ *
+ * 注意：使用BatchMode=yes防止密码提示阻塞
  */
 std::string NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, const std::string& netdev) {
-  // 构建SSH命令
-  std::string sshCmd = "ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no " + remoteIp +
+  // 构建SSH命令，使用BatchMode防止密码提示阻塞
+  // -o BatchMode=yes: 禁止交互式密码提示
+  // -o ConnectTimeout=3: 连接超时3秒
+  // -o StrictHostKeyChecking=no: 不检查主机密钥
+  std::string sshCmd = "ssh -o BatchMode=yes -o ConnectTimeout=3 -o StrictHostKeyChecking=no " + remoteIp +
                        " 'ls /sys/class/net/" + netdev + "/device/infiniband/ 2>/dev/null | grep mlx5_'";
 
   std::string result = executeCommand(sshCmd);
@@ -1383,7 +1322,8 @@ std::string NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, con
     return result.substr(pos, end - pos);
   }
 
-  INFO(NCCL_NET, "NET_OBSERV: Failed to query remote RDMA NIC from %s for %s", remoteIp.c_str(), netdev.c_str());
+  INFO(NCCL_NET, "NET_OBSERV: Failed to query remote RDMA NIC from %s for %s (SSH may not be configured)",
+       remoteIp.c_str(), netdev.c_str());
   return "";
 }
 
@@ -1396,8 +1336,10 @@ std::string NetworkObserver::queryRemoteRdmaNic(const std::string& remoteIp, con
  * 获取规则：
  * 1. 如果描述中包含"mlx5_"，直接提取mlx5_X部分
  * 2. 如果是本节点，通过本地sysfs获取mlx5_X
- * 3. 如果是远程节点，通过SSH查询获取mlx5_X
+ * 3. 如果是远程节点，通过SSH查询获取mlx5_X（需要配置免密登录）
  * 4. 其他情况返回空字符串
+ *
+ * 注意：SSH查询可能会失败，不影响主流程
  */
 std::string NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDesc, const std::string& nodeIp) {
   // 如果描述中直接包含mlx5_，直接提取
@@ -1415,7 +1357,12 @@ std::string NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDes
     
     // 判断是本节点还是远程节点
     std::string localIp = getLocalIpAddress();
-    bool isLocalNode = (nodeIp == localIp);
+    bool isLocalNode = (!localIp.empty() && nodeIp == localIp);
+    
+    // 如果nodeIp为空或无法确定本地IP，默认当作本地节点处理
+    if (nodeIp.empty() || localIp.empty()) {
+      isLocalNode = true;
+    }
     
     if (isLocalNode) {
       // 本节点：通过本地sysfs获取mlx5设备
@@ -1441,7 +1388,9 @@ std::string NetworkObserver::inferRdmaNicFromPortDesc(const std::string& portDes
       return "mlx5_0";
     } else {
       // 远程节点：通过SSH查询获取mlx5设备
-      INFO(NCCL_NET, "NET_OBSERV: Querying remote node %s for RDMA NIC of %s", nodeIp.c_str(), portDesc.c_str());
+      // 注意：这需要预先配置SSH免密登录，否则会失败
+      INFO(NCCL_NET, "NET_OBSERV: Querying remote node %s for RDMA NIC of %s (requires SSH passwordless login)",
+           nodeIp.c_str(), portDesc.c_str());
       return queryRemoteRdmaNic(nodeIp, portDesc);
     }
   }
@@ -1553,6 +1502,56 @@ void NetworkObserver::handleLldpEvent(const ruijie_json::JsonRequest& event) {
 static NetworkObserver* g_netObserver = nullptr;
 static TopologyConfig* g_netObservTopology = nullptr;
 static std::mutex g_netObservMutex;
+static int g_netObservLockFd = -1;  // File lock for single-instance per node
+
+/**
+ * @brief 尝试获取节点级别的单实例锁
+ * @return true 表示成功获取锁（应该启动），false 表示其他进程已持有锁
+ *
+ * 使用文件锁确保同一节点上只有一个 NetworkObserver 实例运行。
+ * 锁文件路径：/tmp/nccl_net_observ.lock
+ */
+static bool acquireNodeLock() {
+  const char* lockPath = "/tmp/nccl_net_observ.lock";
+  int fd = open(lockPath, O_RDWR | O_CREAT, 0666);
+  if (fd < 0) {
+    INFO(NCCL_NET, "NET_OBSERV: Failed to open lock file %s: %s", lockPath, strerror(errno));
+    return false;
+  }
+
+  struct flock fl;
+  memset(&fl, 0, sizeof(fl));
+  fl.l_type = F_WRLCK;
+  fl.l_whence = SEEK_SET;
+  fl.l_start = 0;
+  fl.l_len = 0;  // Lock entire file
+
+  if (fcntl(fd, F_SETLK, &fl) < 0) {
+    if (errno == EAGAIN || errno == EACCES) {
+      close(fd);
+      INFO(NCCL_NET, "NET_OBSERV: Another process already holds the lock, skipping init");
+      return false;
+    }
+    INFO(NCCL_NET, "NET_OBSERV: Failed to acquire lock: %s", strerror(errno));
+    close(fd);
+    return false;
+  }
+
+  g_netObservLockFd = fd;
+  INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: Acquired node-level lock (fd=%d)", fd);
+  return true;
+}
+
+/**
+ * @brief 释放节点级别的单实例锁
+ */
+static void releaseNodeLock() {
+  if (g_netObservLockFd >= 0) {
+    close(g_netObservLockFd);
+    g_netObservLockFd = -1;
+    INFO(NCCL_NET, "NET_OBSERV: Released node-level lock");
+  }
+}
 
 /**
  * @brief 读取环境变量中的整数
@@ -1577,7 +1576,13 @@ int ncclNetObservInit(void) {
 
   std::lock_guard<std::mutex> lock(g_netObservMutex);
   if (g_netObserver) {
-    return 0;  // Already initialized
+    return 0;  // Already initialized in this process
+  }
+
+  // Try to acquire node-level lock to ensure only one instance per node
+  if (!acquireNodeLock()) {
+    INFO(NCCL_NET, "NET_OBSERV: Another process on this node is already running NetworkObserver, skipping");
+    return 0;  // Another process is handling it, treat as success
   }
 
   int mode = readEnvInt("NCCL_NET_OBSERV_MODE", 0);
@@ -1655,6 +1660,7 @@ void ncclNetObservFinalize(void) {
     delete g_netObservTopology;
     g_netObservTopology = nullptr;
   }
+  releaseNodeLock();
   INFO(NCCL_INIT|NCCL_NET, "NET_OBSERV: NetworkObserver finalized");
 }
 
@@ -1729,9 +1735,9 @@ void ncclNetObservUpdateRankTopology(const std::vector<std::vector<int>>& nodeRa
  * 该函数在IB传输层检测到CQE错误时被调用，无需等待NCCL异常。
  * 相比confirmFromException的文本解析方式，这种方式更直接、更及时。
  */
-void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus) {
-  INFO(NCCL_NET, "NET_OBSERV: Direct IB error from %s, peer=%s, wc_status=%d",
-       rdmaNic.c_str(), peerIp.c_str(), wcStatus);
+void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::string& peerIp, int wcStatus, int tpRank, int tpRemoteRank) {
+  INFO(NCCL_NET, "NET_OBSERV: Direct IB error from %s, peer=%s, wc_status=%d, tpRank=%d, tpRemoteRank=%d",
+       rdmaNic.c_str(), peerIp.c_str(), wcStatus, tpRank, tpRemoteRank);
 
   std::lock_guard<std::mutex> lock(incidentsMutex_);
 
@@ -1764,19 +1770,32 @@ void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::strin
 
     // 如果提供了peerIp，更新故障路径
     if (!peerIp.empty()) {
+      INFO(NCCL_NET, "NET/OBSERV: Building fault path for peerIp=%s, rdmaNic=%s, localPort=%s",
+           peerIp.c_str(), incident->rdmaNic.c_str(), incident->portName.c_str());
       std::string peerPort = topology_->getPortByNodeAndNic(peerIp, incident->rdmaNic);
       if (!peerPort.empty()) {
+        INFO(NCCL_NET, "NET/OBSERV: Found peerPort via getPortByNodeAndNic: %s", peerPort.c_str());
         incident->faultPaths = buildFaultPath(
-            {incident->portName}, incident->deviceModel, peerPort);
+            {incident->portName}, incident->deviceModel, peerPort, tpRank, tpRemoteRank);
       } else {
+        INFO(NCCL_NET, "NET/OBSERV: peerPort not found via getPortByNodeAndNic, searching portMapping...");
+        bool foundInMapping = false;
         for (const auto& pmEntry : topology_->portMapping) {
           if (pmEntry.second.node == peerIp) {
+            INFO(NCCL_NET, "NET/OBSERV: Found peerIp in portMapping: port=%s, node=%s",
+                 pmEntry.first.c_str(), pmEntry.second.node.c_str());
             incident->faultPaths = buildFaultPath(
-                {incident->portName}, incident->deviceModel, pmEntry.first);
+                {incident->portName}, incident->deviceModel, pmEntry.first, tpRank, tpRemoteRank);
+            foundInMapping = true;
             break;
           }
         }
+        if (!foundInMapping) {
+          INFO(NCCL_NET, "NET/OBSERV: peerIp %s not found in portMapping, fault path unchanged", peerIp.c_str());
+        }
       }
+    } else {
+      INFO(NCCL_NET, "NET/OBSERV: peerIp is empty, skipping fault path update");
     }
 
     // 确认告警
@@ -1805,20 +1824,27 @@ void NetworkObserver::handleIbError(const std::string& rdmaNic, const std::strin
  * @param peerIp 对端节点IP地址（可选）
  * @param wcStatus IB工作完成状态码
  */
-void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus) {
+void ncclNetObservHandleIbError(const char* rdmaNic, const char* peerIp, int wcStatus, int tpRank, int tpRemoteRank) {
   if (!rdmaNic || !g_netObserver) {
+    INFO(NCCL_NET, "NET/OBSERV: %s: Skipping IB error handling (rdmaNic=%p, g_netObserver=%p)",
+         __func__, (void*)rdmaNic, (void*)g_netObserver);
     return;
   }
 
   std::string nicName(rdmaNic);
   std::string peerIpStr(peerIp ? peerIp : "");
 
+  INFO(NCCL_NET, "NET/OBSERV: %s: Handling IB error (rdmaNic=%s, peerIp=%s, wcStatus=%d, tpRank=%d, tpRemoteRank=%d)",
+       __func__, rdmaNic, peerIpStr.c_str(), wcStatus, tpRank, tpRemoteRank);
+
   std::lock_guard<std::mutex> lock(g_netObservMutex);
   if (!g_netObservTopology) {
+    INFO(NCCL_NET, "NET/OBSERV: %s: g_netObservTopology is null, skipping error handling", __func__);
     return;
   }
 
-  g_netObserver->handleIbError(nicName, peerIpStr, wcStatus);
+  g_netObserver->handleIbError(nicName, peerIpStr, wcStatus, tpRank, tpRemoteRank);
+  INFO(NCCL_NET, "NET/OBSERV: %s: IB error handled successfully", __func__);
 }
 
 }  // namespace net_observ

--- a/src/plugin/net_observ/ruijie-json.proto
+++ b/src/plugin/net_observ/ruijie-json.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package ruijie_json;
+
+service Json {
+  rpc JsonSend (JsonRequest) returns (JsonReply) {}
+  rpc JsonStreamSend (stream JsonRequest) returns (stream JsonReply) {}
+}
+
+message JsonDeviceMsg {
+  string producer_name = 1;
+  string device_name = 2;
+  string device_model = 3;
+  string device_ip = 4;
+  string device_vendor = 5;
+  string device_version = 6;
+}
+
+enum JsonExtensionID {
+  EID_UNSET = 0;
+  EID_SN = 1;
+  EID_EXPERIMENTAL = 999;
+}
+
+message JsonExtension {
+  JsonExtensionID id = 1;
+  bytes msg = 2;
+}
+
+message JsonRequest {
+  JsonDeviceMsg device_info = 1;
+  uint32 json_event = 2;
+  string json_string = 3;
+  int64 timestamp = 4;
+  string sensor_path = 5;
+  repeated JsonExtension extension = 6;
+}
+
+message JsonReply {
+  sint32 ret = 1;
+}

--- a/src/transport.cc
+++ b/src/transport.cc
@@ -33,6 +33,7 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
     NCCLCHECK(transport->canConnect(&ret, comm, graph, myInfo, peerInfo));
     if (ret) {
       connector->transportComm = transportComm;
+      INFO(NCCL_INIT|NCCL_NET, "Channel %02d/%d : select transport t=%d (%s)", channelId, connIndex, t, type == 1 ? "send" : "recv");
       NCCLCHECK(transportComm->setup(comm, graph, myInfo, peerInfo, connect, connector, channelId, connIndex));
       if (transportType) *transportType = t;
       return ncclSuccess;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include "register_inline.h"
 
-extern void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank);
+extern void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank, int channelId);
 
 static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too large");
 
@@ -881,7 +881,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   }
   printNetAttrs(&req->netAttr, "send connect");
   *done = 1;
-  ncclIbSetCommRanks(resources->netSendComm, resources->tpRank, resources->tpRemoteRank);
+  ncclIbSetCommRanks(resources->netSendComm, resources->tpRank, resources->tpRemoteRank, resources->channelId);
 
   if (resources->netDeviceHandle) {
     connection->netDeviceHandle = resources->netDeviceHandle;
@@ -1047,7 +1047,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   }
   printNetAttrs(&req->netAttr, "recv connect");
   *done = 1;
-  ncclIbSetCommRanks(resources->netRecvComm, resources->tpRank, resources->tpRemoteRank);
+  ncclIbSetCommRanks(resources->netRecvComm, resources->tpRank, resources->tpRemoteRank, resources->channelId);
 
   if (resources->netDeviceHandle) {
     connection->netDeviceHandle = resources->netDeviceHandle;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -20,6 +20,8 @@
 #include <assert.h>
 #include "register_inline.h"
 
+extern void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank);
+
 static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too large");
 
 #define NCCL_NET_MAP_HOSTMEM 0
@@ -314,6 +316,7 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.tpLocalRank = comm->topParentLocalRanks[comm->localRank];
   req.tpRank = comm->topParentRanks[myInfo->rank];
   req.tpRemoteRank = comm->topParentRanks[peerInfo->rank];
+  INFO(NCCL_INIT|NCCL_NET,"Channel %02d/%d : tpLocalRank=%d tpRank=%d tpRemoteRank=%d", channelId, connIndex, req.tpLocalRank, req.tpRank, req.tpRemoteRank);
   req.sameDevice = (comm->peerInfo[proxyRank].cudaDev == comm->cudaDev);
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), NULL, 0));
 
@@ -362,6 +365,7 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.tpLocalRank = comm->topParentLocalRanks[comm->localRank];
   req.tpRank = comm->topParentRanks[myInfo->rank];
   req.tpRemoteRank = comm->topParentRanks[peerInfo->rank];
+  INFO(NCCL_INIT|NCCL_NET,"Channel %02d/%d : tpLocalRank=%d tpRank=%d tpRemoteRank=%d", channelId, connIndex, req.tpLocalRank, req.tpRank, req.tpRemoteRank);
   req.sameDevice = (comm->peerInfo[proxyRank].cudaDev == comm->cudaDev);
   NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), connectInfo, sizeof(ncclNetHandle_t)));
   memcpy((uint8_t*)connectInfo + sizeof(ncclNetHandle_t), &req.useGdr, sizeof(int));
@@ -877,6 +881,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   }
   printNetAttrs(&req->netAttr, "send connect");
   *done = 1;
+  ncclIbSetCommRanks(resources->netSendComm, resources->tpRank, resources->tpRemoteRank);
 
   if (resources->netDeviceHandle) {
     connection->netDeviceHandle = resources->netDeviceHandle;
@@ -1042,6 +1047,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   }
   printNetAttrs(&req->netAttr, "recv connect");
   *done = 1;
+  ncclIbSetCommRanks(resources->netRecvComm, resources->tpRank, resources->tpRemoteRank);
 
   if (resources->netDeviceHandle) {
     connection->netDeviceHandle = resources->netDeviceHandle;

--- a/src/transport/net_ib/common.cc
+++ b/src/transport/net_ib/common.cc
@@ -80,11 +80,8 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank) {
   if (comm) {
     struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
-    // Sanity check: isSend should be 0 or 1 for a valid IB comm
-    if (base->isSend == 0 || base->isSend == 1) {
-      base->tpRank = tpRank;
-      base->tpRemoteRank = tpRemoteRank;
-    }
+    base->tpRank = tpRank;
+    base->tpRemoteRank = tpRemoteRank;
   }
 }
 

--- a/src/transport/net_ib/common.cc
+++ b/src/transport/net_ib/common.cc
@@ -77,11 +77,14 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   return ncclSuccess;
 }
 
-void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank) {
+void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank, int channelId) {
   if (comm) {
     struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
     base->tpRank = tpRank;
     base->tpRemoteRank = tpRemoteRank;
+    base->channelId = channelId;
+    INFO(NCCL_NET, "NET/IB: %s: Set comm ranks (tpRank=%d, tpRemoteRank=%d, channelId=%d)",
+         __func__, tpRank, tpRemoteRank, channelId);
   }
 }
 

--- a/src/transport/net_ib/common.cc
+++ b/src/transport/net_ib/common.cc
@@ -64,6 +64,8 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 
   NCCLCHECK(ncclIbResiliencyInit(baseComm, &baseComm->resiliency));
   baseComm->recvMatchingScheme = ncclParamIbReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbReceiverSideMatchingScheme();
+  baseComm->tpRank = -1;
+  baseComm->tpRemoteRank = -1;
 
   if (ncclParamIbOooRq() || (ncclParamIbResiliencyPortFailover() == 1)) {
     baseComm->recvMatchingScheme = BY_ID;
@@ -73,6 +75,17 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   }
 
   return ncclSuccess;
+}
+
+void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank) {
+  if (comm) {
+    struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+    // Sanity check: isSend should be 0 or 1 for a valid IB comm
+    if (base->isSend == 0 || base->isSend == 1) {
+      base->tpRank = tpRank;
+      base->tpRemoteRank = tpRemoteRank;
+    }
+  }
 }
 
 ncclResult_t ncclIbRecvCommInit(struct ncclIbRecvComm* recvComm) {

--- a/src/transport/net_ib/common.h
+++ b/src/transport/net_ib/common.h
@@ -355,6 +355,7 @@ struct alignas(32) ncclIbNetCommBase {
   struct ncclIbResiliency* resiliency;
   int tpRank;
   int tpRemoteRank;
+  int channelId;
 };
 
 struct ncclIbNetCommDevBase* ncclIbGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex);
@@ -545,7 +546,7 @@ static void ncclIbDevFatalError(struct ncclIbDev* dev) {
 }
 ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName);
 
-void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank);
+void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank, int channelId);
 
 extern ncclProfilerCallback_t ncclProfilerFunction;
 

--- a/src/transport/net_ib/common.h
+++ b/src/transport/net_ib/common.h
@@ -353,6 +353,8 @@ struct alignas(32) ncclIbNetCommBase {
   // statistics about the comm
   struct ncclIbStats stats;
   struct ncclIbResiliency* resiliency;
+  int tpRank;
+  int tpRemoteRank;
 };
 
 struct ncclIbNetCommDevBase* ncclIbGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex);
@@ -542,6 +544,8 @@ static void ncclIbDevFatalError(struct ncclIbDev* dev) {
   ncclIbStatsFatalError(&dev->stats);
 }
 ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName);
+
+void ncclIbSetCommRanks(void* comm, int tpRank, int tpRemoteRank);
 
 extern ncclProfilerCallback_t ncclProfilerFunction;
 

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -9,6 +9,7 @@
 #include "common.h"
 #include "compiler.h"
 #include "p2p_resiliency.h"
+#include "plugin/net_observ/net_observ.h"
 
 NCCL_PARAM(IbArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t ncclIbArThreshold = 8192;
@@ -783,6 +784,21 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
           if (r->base->resiliency == NULL) {
             WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__, i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             ncclIbLogCompletionWithError(r->base, wc, i);
+
+            // Notify NetworkObserver of the IB error for faster diagnosis
+            // Get device name from the device index
+            if (r->devBases[i]) {
+              int ibDevN = r->devBases[i]->ibDevN;
+              if (ibDevN >= 0 && ibDevN < ncclNIbDevs) {
+                const char* devName = ncclIbDevs[ibDevN].devName;
+                // Get peer IP from socket address
+                char peerIpStr[SOCKET_NAME_MAXLEN] = {0};
+                ncclSocketToString(&r->base->sock.addr, peerIpStr, 0);
+                // Call NetworkObserver to handle the error directly
+                net_observ::ncclNetObservHandleIbError(devName, peerIpStr, wc->status);
+              }
+            }
+
             // If resiliency is not enabled, we cannot recover from any error.
             return ncclRemoteError;
           }

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -646,10 +646,10 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
   char *hcaName = devBase->pd->context->device->name;
-  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u tpRank=%d tpRemoteRank=%d %s%s%s%s hca %s",
+  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u tpRank=%d tpRemoteRank=%d channelId=%d %s%s%s%s hca %s",
       sockStr, ibvWcStatusStr(wc->status), wc->status,
       ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
-      commBase->tpRank, commBase->tpRemoteRank,
+      commBase->tpRank, commBase->tpRemoteRank, commBase->channelId,
       localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
   return ncclSuccess;
 }
@@ -794,9 +794,22 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
                 // Get peer IP from socket address
                 char peerIpStr[SOCKET_NAME_MAXLEN] = {0};
                 ncclSocketToString(&r->base->sock.addr, peerIpStr, 0);
+                // ncclSocketToString returns format like "192.168.1.17<48310>",
+                // but NetworkObserver only needs the IP address without port
+                char* portStart = strchr(peerIpStr, '<');
+                if (portStart != NULL) {
+                  *portStart = '\0';
+                }
+                INFO(NCCL_NET, "NET/IB: %s: Notifying NetworkObserver of IB error (devIndex=%d, ibDevN=%d, devName=%s, peerIp=%s, wcStatus=%d, tpRank=%d, tpRemoteRank=%d)",
+                     __func__, i, ibDevN, devName, peerIpStr, wc->status, r->base->tpRank, r->base->tpRemoteRank);
                 // Call NetworkObserver to handle the error directly
-                net_observ::ncclNetObservHandleIbError(devName, peerIpStr, wc->status);
+                net_observ::ncclNetObservHandleIbError(devName, peerIpStr, wc->status, r->base->tpRank, r->base->tpRemoteRank);
+              } else {
+                WARN("NET/IB: %s: Invalid ibDevN for NetworkObserver notification (devIndex=%d, ibDevN=%d, ncclNIbDevs=%d)",
+                     __func__, i, ibDevN, ncclNIbDevs);
               }
+            } else {
+              WARN("NET/IB: %s: devBases[%d] is NULL, cannot notify NetworkObserver", __func__, i);
             }
 
             // If resiliency is not enabled, we cannot recover from any error.

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -645,9 +645,10 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
   char *hcaName = devBase->pd->context->device->name;
-  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s",
+  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u tpRank=%d tpRemoteRank=%d %s%s%s%s hca %s",
       sockStr, ibvWcStatusStr(wc->status), wc->status,
       ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
+      commBase->tpRank, commBase->tpRemoteRank,
       localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
   return ncclSuccess;
 }

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -631,14 +631,26 @@ static inline ncclResult_t ncclIbRequestComplete(struct ncclIbRequest* r, int* d
 
 // Log the details of a completion with error. The provided devIndex is the index
 // of the IB device on which the completion was received.
-static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commBase, struct ibv_wc* wc, int devIndex) {
+static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commBase, struct ibv_wc* wc, int devIndex, char* peerIpv4, size_t peerIpv4Len) {
   struct ncclIbNetCommDevBase* devBase = ncclIbGetNetCommDevBase(commBase, devIndex);
   char localGidString[INET6_ADDRSTRLEN] = "";
   char remoteGidString[INET6_ADDRSTRLEN] = "";
   const char* localGidStr = NULL, *remoteGidStr = NULL;
+  if (peerIpv4 && peerIpv4Len > 0) peerIpv4[0] = '\0';
   if (devBase->gidInfo.link_layer == IBV_LINK_LAYER_ETHERNET) {
     localGidStr = ibvGetGidStr(&devBase->gidInfo.localGid, localGidString, sizeof(localGidString));
     remoteGidStr = ibvGetGidStr(&commBase->remDevs[devIndex].remoteGid, remoteGidString, sizeof(remoteGidString));
+
+    if (peerIpv4 && peerIpv4Len > 0 && remoteGidStr) {
+      const struct in6_addr* a = (const struct in6_addr*)commBase->remDevs[devIndex].remoteGid.raw;
+      bool isIpV4Mapped = ((a->s6_addr32[0] | a->s6_addr32[1]) | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL;
+      if (isIpV4Mapped) {
+        struct in_addr ipv4;
+        ipv4.s_addr = a->s6_addr32[3];
+        const char* result = inet_ntop(AF_INET, &ipv4, peerIpv4, peerIpv4Len);
+        if (!result) peerIpv4[0] = '\0';
+      }
+    }
   }
 
   char sockStr[SOCKET_NAME_MAXLEN+1];
@@ -783,27 +795,24 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
         if (wc->status != IBV_WC_SUCCESS) {
           if (r->base->resiliency == NULL) {
             WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__, i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
-            ncclIbLogCompletionWithError(r->base, wc, i);
+            char peerIpv4[INET_ADDRSTRLEN] = "";
+            ncclIbLogCompletionWithError(r->base, wc, i, peerIpv4, sizeof(peerIpv4));
 
-            // Notify NetworkObserver of the IB error for faster diagnosis
-            // Get device name from the device index
             if (r->devBases[i]) {
               int ibDevN = r->devBases[i]->ibDevN;
               if (ibDevN >= 0 && ibDevN < ncclNIbDevs) {
                 const char* devName = ncclIbDevs[ibDevN].devName;
-                // Get peer IP from socket address
-                char peerIpStr[SOCKET_NAME_MAXLEN] = {0};
-                ncclSocketToString(&r->base->sock.addr, peerIpStr, 0);
-                // ncclSocketToString returns format like "192.168.1.17<48310>",
-                // but NetworkObserver only needs the IP address without port
-                char* portStart = strchr(peerIpStr, '<');
-                if (portStart != NULL) {
-                  *portStart = '\0';
+                char peerIpBuf[SOCKET_NAME_MAXLEN] = {0};
+                if (peerIpv4[0] != '\0') {
+                  strncpy(peerIpBuf, peerIpv4, sizeof(peerIpBuf) - 1);
+                } else {
+                  ncclSocketToString(&r->base->sock.addr, peerIpBuf, 0);
+                  char* portStart = strchr(peerIpBuf, '<');
+                  if (portStart != NULL) *portStart = '\0';
                 }
                 INFO(NCCL_NET, "NET/IB: %s: Notifying NetworkObserver of IB error (devIndex=%d, ibDevN=%d, devName=%s, peerIp=%s, wcStatus=%d, tpRank=%d, tpRemoteRank=%d)",
-                     __func__, i, ibDevN, devName, peerIpStr, wc->status, r->base->tpRank, r->base->tpRemoteRank);
-                // Call NetworkObserver to handle the error directly
-                net_observ::ncclNetObservHandleIbError(devName, peerIpStr, wc->status, r->base->tpRank, r->base->tpRemoteRank);
+                     __func__, i, ibDevN, devName, peerIpBuf, wc->status, r->base->tpRank, r->base->tpRemoteRank);
+                net_observ::ncclNetObservHandleIbError(devName, peerIpBuf, wc->status, r->base->tpRank, r->base->tpRemoteRank);
               } else {
                 WARN("NET/IB: %s: Invalid ibDevN for NetworkObserver notification (devIndex=%d, ibDevN=%d, ncclNIbDevs=%d)",
                      __func__, i, ibDevN, ncclNIbDevs);


### PR DESCRIPTION
1. add INFO log when selecting transport
2. add tpRank and tpRemoteRank fields to IB net comm base
3. implement ncclIbSetCommRanks to set peer ranks
4. add rank values to IB completion error logs
5. initialize rank fields in IB base comm init
6. call set ranks function in proxy connect handlers
7. add INFO logs for send/recv setup ranks

## Description

<!-- Clearly describe what the PR does and why -->

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

