### PR TITLE
Pin GIN proxy thread to NUMA-local CPU set

### DIFF
--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -42,6 +42,9 @@ ncclResult_t ncclGetRailedGinType(struct ncclComm* comm, ncclGinType_t* ginType)
 
 void* ncclGinProgress(struct ncclGinState* ginState_) {
   struct ncclGinState* ginState = (struct ncclGinState*)ginState_;
+  if (ncclOsCpuCount(ginState->cpuAffinity)) {
+    ncclOsSetAffinity(ginState->cpuAffinity);
+  }
   while (1) {
     std::unique_lock<std::mutex> lock(ginState->mutex);
     if (ginState->ginProgress == 1) {
@@ -293,6 +296,7 @@ ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequir
   }
 
   if (ginState->needsProxyProgress && ginState->ginProgress == 0) {
+    ginState->cpuAffinity = comm->cpuAffinity;
     ginState->ginProgress = 1;
     ginState->thread = std::thread(ncclGinProgress, ginState);
     ncclSetThreadName(ginState->thread, "NCCL GIN Progress%2d", comm->cudaDev);

--- a/src/include/gin/gin_host.h
+++ b/src/include/gin/gin_host.h
@@ -11,6 +11,7 @@
 #include "allocator.h"
 #include "nccl.h"
 #include "nccl_gin.h"
+#include "os.h"
 #include "nccl_device/gin/gin_device_host_common.h"
 #include <thread>
 #include <mutex>
@@ -24,6 +25,7 @@ struct ncclGinStateDevComm {
 };
 
 struct ncclGinState {
+  ncclAffinity cpuAffinity;
   ncclGin_t* ncclGin;
   void* ginInstance;
   bool connected;


### PR DESCRIPTION
The GIN proxy thread (ncclGinProgress) currently inherits its CPU affinity from
whatever thread calls ncclGinDevCommSetup. That happens after ncclCommInitRank
returns, so the temporary NUMA pin established during init has been restored,
and the GIN proxy ends up with the caller's affinity.

The traditional proxy thread (ncclProxyService) is spawned during init while
the calling thread is still NUMA-pinned, so it inherits the correct affinity
automatically.

This change saves comm->cpuAffinity on ginState before spawning the proxy
thread, and applies it at the top of ncclGinProgress to bring GIN parity with
the traditional proxy.