### PR TITLE
rma_proxy: fix MR registration type for host-NUMA cpuAccessSignals

### DIFF
--- a/src/rma/rma_proxy.cc
+++ b/src/rma/rma_proxy.cc
@@ -166,8 +166,9 @@ static ncclResult_t ncclRmaProxyCtxAllocGraph(struct ncclComm* comm, ncclRma_t* 
   // Allocate the CPU-accessible signal for graph capture and then register the memory region with the RMA plugin.
   NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->cpuAccessSignals, &rmaProxyCtx->cpuAccessSignalsDev,
                                   comm->nRanks + 1, 0, &rmaProxyCtx->cpuAccessSignalsGdrHandle, comm->memManager));
+  int cpuAccessSignalsType = (rmaProxyCtx->cpuAccessSignalsGdrHandle != NULL) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
   NCCLCHECK(ncclRmaProxyRegMrSym(rmaComm, rmaProxyCtx->rmaCollComm, rmaProxyCtx->props, rmaProxyCtx->cpuAccessSignalsDev, signalsBufSize,
-                                 NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
+                                 cpuAccessSignalsType, NCCL_NET_MR_FLAG_FORCE_SO,
                                  &rmaProxyCtx->cpuAccessSignalsMhandle));
   // Allocate the host buffer to track the expected values of the signals
   NCCLCHECK(ncclCalloc(&rmaProxyCtx->cpuAccessSignalsHost, signalsBufSize));


### PR DESCRIPTION
## Description

When GDRCopy is not enabled (`NCCL_GDRCOPY_ENABLE` defaults to 0), `allocMemCPUAccessible` allocates host-NUMA pinned memory instead of device memory. However, `ncclRmaProxyCtxAllocGraph` unconditionally passes NCCL_PTR_CUDA to `ncclRmaProxyRegMrSym` when registering `cpuAccessSignalsDev`, causing the net plugin to reject the registration due to wrong memory type.

## Changes & Impact

Use the GDR handle returned by `allocMemCPUAccessible` as a discriminator: non-NULL indicates GDRCopy-mapped device memory (`NCCL_PTR_CUDA`), NULL indicates host-NUMA pinned memory (`NCCL_PTR_HOST`).

This fixes RMA proxy connection failures when GDRCopy is not enabled.
