### PR TITLE
Fix RMA proxy path window-relative offset for sub-windows

### DIFF
--- a/src/dev_runtime.cc
+++ b/src/dev_runtime.cc
@@ -1795,6 +1795,14 @@ ncclGinWindow_t ncclDevrGetRmaDevWin(struct ncclDevrWindow* winHost, int ctx) {
   return winHost->memory->rmaDevWins[ctx];
 }
 
+// Get the byte offset of a window within the RMA registration backing memory
+size_t ncclDevrGetRmaOffset(struct ncclDevrWindow* winHost) {
+  if (winHost == nullptr || winHost->memory == nullptr) {
+    return 0;
+  }
+  return winHost->bigOffset - winHost->memory->bigOffset;
+}
+
 // Get the multicast address for a given team
 ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, struct ncclTeam lsaTeam, void** outPtr){
   if (winHost == nullptr || outPtr == nullptr) return ncclInternalError;

--- a/src/include/dev_runtime.h
+++ b/src/include/dev_runtime.h
@@ -119,6 +119,9 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
 // Get the RMA device window handle for a specific context
 ncclGinWindow_t ncclDevrGetRmaDevWin(struct ncclDevrWindow* winHost, int ctx);
 
+// Get the byte offset of a window within the RMA registration backing memory
+size_t ncclDevrGetRmaOffset(struct ncclDevrWindow* winHost);
+
 // Get the multicast address for a given team
 ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, struct ncclTeam lsaTeam, void** outPtr);
 

--- a/src/rma/rma_proxy_launch.cc
+++ b/src/rma/rma_proxy_launch.cc
@@ -28,9 +28,9 @@ static ncclResult_t ncclRmaProxyPutDescFromTask(struct ncclComm* comm, struct nc
 
   desc->rmaDescType = ncclRmaDescTypePutSignal;
   desc->rmaDescState = ncclRmaDescStateReady;
-  desc->putSignal.srcOff = task->srcWinOffset;
+  desc->putSignal.srcOff = ncclDevrGetRmaOffset(task->srcWinHost) + task->srcWinOffset;
   desc->putSignal.srcHandle = ncclDevrGetRmaDevWin(task->srcWinHost, task->ctx);
-  desc->putSignal.dstOff = task->peerWinOffset;
+  desc->putSignal.dstOff = ncclDevrGetRmaOffset(task->peerWinHost) + task->peerWinOffset;
   desc->putSignal.dstHandle = ncclDevrGetRmaDevWin(task->peerWinHost, task->ctx);
   desc->putSignal.size = task->count * ncclTypeSize(task->datatype);
   desc->putSignal.targetRank = task->peer;


### PR DESCRIPTION
## Problem

In the RMA proxy path, proxy descriptors were built with offsets relative to the user window but paired with RMA handles for the backing memory allocation (ncclDevrMemory). For sub-windows carved from a larger backing memory registration, this caused cross-node RMA operations to read/write from incorrect addresses within the registered memory, leading to data corruption.

## Root Cause

In `src/rma/rma_proxy_launch.cc`, the proxy descriptor builder used `task->srcWinOffset` / `task->peerWinOffset` which are window-relative offsets, but paired them with RMA handles from `ncclDevrGetRmaDevWin()` which return handles for the backing memory allocation (`winHost->memory->rmaDevWins[ctx]`).

For a sub-window, the window sits at a non-zero offset within the backing memory registration, so the proxy path effectively reads/writes from the wrong address in the registered memory.

## Fix

1. Add `ncclDevrGetRmaOffset()` helper in `dev_runtime.cc` that computes the byte offset of a window within its backing RMA registration: `winHost->bigOffset - winHost->memory->bigOffset`
2. Declare it in `src/include/dev_runtime.h`
3. Apply this offset when building proxy RMA descriptors in `rma_proxy_launch.cc`:
   - `desc->putSignal.srcOff = ncclDevrGetRmaOffset(task->srcWinHost) + task->srcWinOffset;`
   - `desc->putSignal.dstOff = ncclDevrGetRmaOffset(task->peerWinHost) + task->peerWinOffset;`

This matches the existing GIN path which already accounts for this offset via `ginOffset4K`.

Fixes: #2198