### PR TITLE
docs: fix window registration flag name

### DIFF
--- a/docs/userguide/source/api/device_gin.rst
+++ b/docs/userguide/source/api/device_gin.rst
@@ -100,7 +100,7 @@ These objects represent "VA signals": signals that are located at an arbitrary V
 of a pre-allocated signal index. Like the ``ncclGin_SignalInc`` and ``ncclGinSignalAdd`` objects,
 these objects  can be passed as the *remoteAction* arguments of methods such as :cpp:func:`ncclGin::put`
 and :cpp:func:`ncclGin::signal` to increment a signal on the peer. To use a VA signal, the window must be
-registered with flags :c:macro:`NCCL_WIN_COLL_STRICT_ORDERING`. When an address is used as a signal, all reads
+registered with flags :c:macro:`NCCL_WIN_STRICT_ORDERING`. When an address is used as a signal, all reads
 and writes to the address must be issued via GIN (i.e., a ``RemoteAction`` or GIN signal method).
 
 **Signal methods of ncclGin:**

--- a/docs/userguide/source/api/flags.rst
+++ b/docs/userguide/source/api/flags.rst
@@ -23,7 +23,7 @@ Window Registration Flags
  from all ranks must be equal when calling NCCL collective operations. It allows NCCL to operate
  buffer in a symmetric way and provide the best performance.
 
-.. c:macro:: NCCL_WIN_COLL_STRICT_ORDERING
+.. c:macro:: NCCL_WIN_STRICT_ORDERING
 
   Register buffer into NCCL window while ensuring strict ordering for window operations using the IB Verbs transport.
   This flag is mostly intended for buffers used for GIN VA Signals (see :ref:`devapi_signals`).


### PR DESCRIPTION
## Description

There is no defined `NCCL_WIN_COLL_STRICT_ORDERING` macro in the NCCL code.
Change `NCCL_WIN_COLL_STRICT_ORDERING` to `NCCL_WIN_STRICT_ORDERING` in the user guide doc.

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

