### PR TITLE
dev_runtime: preserve GIN resource requirements

### DIFF
--- a/src/dev_runtime.cc
+++ b/src/dev_runtime.cc
@@ -969,6 +969,10 @@ static ncclResult_t deepCopyDevCommRequirements(struct ncclDevCommRequirements c
     (*dstRes)->bufferSize = rr->bufferSize;
     (*dstRes)->bufferAlign = rr->bufferAlign;
     (*dstRes)->outBufferHandle = rr->outBufferHandle;
+    (*dstRes)->ginSignalCount = rr->ginSignalCount;
+    (*dstRes)->ginCounterCount = rr->ginCounterCount;
+    (*dstRes)->outGinSignalStart = rr->outGinSignalStart;
+    (*dstRes)->outGinCounterStart = rr->outGinCounterStart;
     dstRes = &(*dstRes)->next;
   }
 


### PR DESCRIPTION
## Description

<!-- Clearly describe what the PR does and why -->
## Summary

`deepCopyDevCommRequirements()` copies `ncclDevResourceRequirements` nodes before queuing device communicator creation work, but it only preserved the buffer fields.

This change also preserves the GIN resource fields:
- `ginSignalCount`
- `ginCounterCount`
- `outGinSignalStart`
- `outGinCounterStart`

These fields are later used to assign GIN signal/counter ranges and compute the total GIN resource counts.
This is consistent with outBufferHandle and outMultimemHandle, which are already preserved across the async task boundary.
## Testing

- Ran `git diff --check`
- Full build not run: `nvcc` is not available in this environment

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

