### PR TITLE
Replace reduce with allreduce in NCCL4Py allreduce test

### DIFF
--- a/bindings/nccl4py/examples/01_basic/01_allreduce.py
+++ b/bindings/nccl4py/examples/01_basic/01_allreduce.py
@@ -62,7 +62,7 @@ def main():
     data = torch.tensor([float(rank)], dtype=torch.float32, device=device)
 
     # [NCCL4Py] AllReduce: Sum all rank values
-    nccl_comm.reduce(data, data, nccl.SUM)
+    nccl_comm.allreduce(data, data, nccl.SUM)
 
     torch.cuda.synchronize()
 


### PR DESCRIPTION
## Description

The test is supposed to run allreduce, but was calling reduce. Without this change, the print statement produces incorrect output.

## Related Issues

None

## Changes & Impact

No impact

## Performance Impact

Correctness only