### PR TITLE
net/ib: Print qp_num in completion error log

### DIFF
--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -685,8 +685,8 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
   char* hcaName = devBase->pd->context->device->name;
-  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s", sockStr,
-       ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
+  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u qp_num=%u %s%s%s%s hca %s", sockStr,
+       ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err, wc->qp_num,
        localGidStr ? " localGid " : "", localGidString, remoteGidStr ? " remoteGids" : "", remoteGidString, hcaName);
   printIbWcStatusHint(wc->status);
   return ncclSuccess;

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -685,9 +685,10 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
   char* hcaName = devBase->pd->context->device->name;
-  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u qp_num=%u %s%s%s%s hca %s", sockStr,
-       ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err, wc->qp_num,
-       localGidStr ? " localGid " : "", localGidString, remoteGidStr ? " remoteGids" : "", remoteGidString, hcaName);
+  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u qp_num=%u %s%s%s%s hca %s",
+       sockStr, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
+       wc->qp_num, localGidStr ? " localGid " : "", localGidString, remoteGidStr ? " remoteGids" : "", remoteGidString,
+       hcaName);
   printIbWcStatusHint(wc->status);
   return ncclSuccess;
 }


### PR DESCRIPTION
## Description

This PR includes `wc.qp_num` in the detailed NET/IB completion error log.

NCCL already prints `qp_num` in the nearby CQE error log, but the detailed completion error line contains the peer, status, vendor error, local/remote GID, and HCA. Including `qp_num` in that same detailed line makes RoCE failures such as `IBV_WC_RETRY_EXC_ERR(12)` easier to correlate with earlier QP creation/connect logs.

## Related Issues

Closes #2219

## Changes & Impact

This is a logging-only change.

The detailed NET/IB completion error WARN now changes from:

```text
NET/IB: Got completion from peer ... status=... opcode=... vendor_err=... localGid ... remoteGid ... hca ...
```

to:

```text
NET/IB: Got completion from peer ... status=... opcode=... vendor_err=... qp_num=... localGid ... remoteGid ... hca ...
```

## Performance Impact

No expected performance impact.

