### PR TITLE
Fix KernelCh completion ordering in profiler proxy

### DIFF
--- a/src/transport/profiler.cc
+++ b/src/transport/profiler.cc
@@ -34,17 +34,18 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
       struct ncclProxySubArgs* sub = args->subs + s;
       struct ncclDevProfiler* workStarted = (struct ncclDevProfiler*)sub->sendbuff;
       struct ncclDevProfiler* workCompleted = (struct ncclDevProfiler*)sub->recvbuff;
+      int idx = sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL;
       if (sub->posted < sub->nsteps &&
-          sub->base <= workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
+          sub->base <= workStarted[sub->channelId].data[idx].counter) {
         ncclProfilerStartKernelChEvent(
-          args, s, workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
+          args, s, workStarted[sub->channelId].data[idx].timestamp);
         sub->posted = sub->nsteps;
         continue; // allow events on every channel to start
       }
-      if (sub->transmitted < sub->nsteps &&
-          sub->base <= workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
+      if (sub->posted == sub->nsteps && sub->transmitted < sub->nsteps &&
+          sub->base <= workCompleted[sub->channelId].data[idx].counter) {
         ncclProfilerStopKernelChEvent(
-          args, s, workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
+          args, s, workCompleted[sub->channelId].data[idx].timestamp);
         sub->transmitted = sub->nsteps;
         args->done++;
       }


### PR DESCRIPTION
## Description

This PR fixes a race in the NCCL profiler proxy where a KernelCh completion event could be processed before the corresponding start event was delivered.

The proxy now only stops/drains a KernelCh profiler sub-operation after StartKernelChEvent has been posted.

In stress testing with many small Ring+LL collectives, inspector logs showed missing coll_sn records across ranks, indicating dropped profiler records caused by this ordering race. Example gaps included:

<img width="859" height="659" alt="image" src="https://github.com/user-attachments/assets/8e76c01b-029a-41b8-9e5d-affcf1947763" />


## Related Issues

N/A

## Changes & Impact

1. Adds a guard so ncclProfilerStopKernelChEvent only runs after sub->posted == sub->nsteps.
2. Reuses the computed profiler ring index instead of recomputing it.
3. No API or ABI changes.

## Performance Impact

No expected impact on normal NCCL collective performance.
The change is limited to the profiler proxy path and only adds one CPU-side condition when profiler/inspector is enabled.

