### PR TITLE
dev_runtime: free requirements on DevCommCreate failure

### DIFF
--- a/src/dev_runtime.cc
+++ b/src/dev_runtime.cc
@@ -1547,7 +1547,10 @@ exit:
   cudaSetDevice(saveDev);
   return ret;
 fail:
-  free(task);
+  if (task) {
+    freeDevCommRequirements(task->reqs);
+    free(task);
+  }
   goto exit;
 }
 


### PR DESCRIPTION
## Description

<!-- Clearly describe what the PR does and why -->
When ncclDevCommCreate deep-copies the user-provided requirements into the async task, later failures before the task is enqueued only free the task wrapper.

Free the copied requirements on the failure path so the copied resourceRequirementsList/teamRequirementsList storage is released as well.

Validation:
- git diff --check
- source-level invariant check for the ncclDevCommCreate failure path

## Related Issues

<!-- Reference any related issues or PRs -->

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

