### PR TITLE
net_ib: free GIN barrier buffer on failure

### DIFF
--- a/src/transport/net_ib/gin.cc
+++ b/src/transport/net_ib/gin.cc
@@ -163,12 +163,14 @@ out:
 }
 
 ncclResult_t ncclGinIbP2PBarrier(struct ncclGinIbCollComm* cComm) {
+  ncclResult_t ret = ncclSuccess;
   // TODO: move allocation to init or use zero-byte allgather
-  int* dummy;
-  NCCLCHECK(ncclIbMalloc((void**)&dummy, cComm->nranks * sizeof(int)));
-  NCCLCHECK(ncclGinIbAllGather(cComm, dummy + cComm->rank, dummy, sizeof(int)));
-  free(dummy);
-  return ncclSuccess;
+  int* dummy = nullptr;
+  NCCLCHECKGOTO(ncclIbMalloc((void**)&dummy, cComm->nranks * sizeof(int)), ret, out);
+  NCCLCHECKGOTO(ncclGinIbAllGather(cComm, dummy + cComm->rank, dummy, sizeof(int)), ret, out);
+out:
+  if (dummy) free(dummy);
+  return ret;
 }
 
 ncclResult_t ncclGinIbConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm) {


### PR DESCRIPTION
## Description

<!-- Clearly describe what the PR does and why -->
ncclGinIbP2PBarrier allocates a temporary dummy buffer and then calls ncclGinIbAllGather. If the allgather fails, the existing NCCLCHECK path returns before freeing the buffer.

Use a local cleanup label so the dummy buffer is released on both success and failure paths.

Validation:
- git diff --check
- source-level invariant check for the ncclGinIbP2PBarrier cleanup path



