### PR TITLE
bound remote device count in ib connect and accept

### DIFF
--- a/src/transport/net_ib/connect.cc
+++ b/src/transport/net_ib/connect.cc
@@ -1025,6 +1025,11 @@ ib_connect:
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
 
+  if (remMeta.ndevs <= 0 || remMeta.ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+    WARN("NET/IB : remote peer reported an invalid device count %d (max %d)", remMeta.ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
+    return ncclInternalError;
+  }
+
   // ensure that the remote devices have the same link layer than the local devices used in the connection.
   if (comm->base.vProps.ndevs > 0) {
     int ibDev0 = comm->devs[0].base.ibDevN;
@@ -1458,6 +1463,11 @@ ib_recv:
 
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
+
+  if (remMeta.ndevs <= 0 || remMeta.ndevs > NCCL_IB_MAX_DEVS_PER_NIC) {
+    WARN("NET/IB : remote peer reported an invalid device count %d (max %d)", remMeta.ndevs, NCCL_IB_MAX_DEVS_PER_NIC);
+    return ncclInternalError;
+  }
 
   // Subnet-aware device selection: use the remote sender's GIDs to find a local
   // NIC on the same subnet. Override lComm->dev and update vProps if a


### PR DESCRIPTION
Peer-supplied ndevs in the IB connection metadata is used to index fixed-size arrays without a range check:
- ncclIbConnectImpl stores remMeta.devs[i] into remDevs[]/rkeys[] for i up to remMeta.ndevs
- ncclIbAcceptImpl does the same on the receiver side
- those arrays are sized NCCL_IB_MAX_DEVS_PER_NIC, so a peer reporting ndevs above that count reads and writes past the end
Validate the count is within range right after the metadata is received, on both sides.