### PR TITLE
dev_runtime: restore capture mode on GIN setup failure

### DIFF
--- a/src/dev_runtime.cc
+++ b/src/dev_runtime.cc
@@ -1241,7 +1241,7 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
   if (devr->ginEnabled) {
     reqs->ginSignalCount = ginSignalTotal;
     reqs->ginCounterCount = ginCounterTotal;
-    NCCLCHECK(ncclGinDevCommSetup(comm, reqs, outDevComm));
+    NCCLCHECKGOTO(ncclGinDevCommSetup(comm, reqs, outDevComm), ret, fail);
   }
 
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);


### PR DESCRIPTION
## Description

`ncclDevrCommCreateInternal()` switches the CUDA stream capture mode before setting up device communicator resources. Most failure paths after that point use `GOTO` cleanup labels so the original capture mode is restored.

The GIN setup path used `NCCLCHECK(ncclGinDevCommSetup(...))`, which returns directly on failure and skips the common `fail` path. This can leave the thread capture mode unrestored when GIN setup fails.

This change routes the failure through the existing `fail` label by using `NCCLCHECKGOTO`.

## Changes & Impact

- Restore the existing cleanup behavior on `ncclGinDevCommSetup()` failure.
- No change to the success path.
- No API or performance impact.

## Testing

- `git diff --check`
- Started `make -j$(nproc) src.build`; `src/dev_runtime.cc` compiled successfully. Full device kernel build was not completed due to long compile time.

