### PR TITLE
fix gin proxy load balance problem when nic is a lag port

### DIFF
--- a/src/transport/net_ib/gin.cc
+++ b/src/transport/net_ib/gin.cc
@@ -396,8 +396,11 @@ ncclResult_t ncclRmaIbProxyCreateContext(void* collComm, ncclRmaConfig_t* config
     NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullSendComm, sizeof(void*) * nranks), ret, end);
     NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullRecvComm, sizeof(void*) * nranks), ret, end);
     gc->rank = cComm->rank;
+  }
 
-    for (int i = 0; i < nranks; i += config->rankStride) {
+  for (int i = 0; i < nranks; i += config->rankStride) {
+    for (int c = 0; c < config->nContexts; c++) {
+      struct ncclRmaIbProxyCtx* gc = rmaProxyCtx + c;
       int connectPeer = (cComm->rank + i) % nranks;
       int acceptPeer = (cComm->rank - i + nranks) % nranks;
       do {


### PR DESCRIPTION
## Description

Fix  a QP load balance problem when using ROCE LAG (mode 4, 802.3 AD) with queue affinity policy by GIN proxy


## Related Issues

https://github.com/NVIDIA/nccl/issues/2136

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

## Performance Impact

make gin proxy qp can full use of the dual uplink port of bonding ib device
