### PR TITLE
bindings: Pass gin by pointers rather than values for barrier routines

### DIFF
--- a/bindings/ir/nccl_device_wrapper.h
+++ b/bindings/ir/nccl_device_wrapper.h
@@ -111,7 +111,7 @@ void ncclLsaBarrierSessionSync(ncclLsaBarrierSession_C* session, ncclCoopAny coo
 NCCL_IR_EXTERN_C __device__ void ncclGinBarrierSessionInit(
     ncclGinBarrierSession_C* session,
     ncclCoopAny coop,
-    ncclGin_C net,
+    ncclGin_C const* net,
     ncclTeam team,
     ncclGinBarrierHandle handle,
     uint32_t index);
@@ -138,7 +138,7 @@ NCCL_IR_EXTERN_C __device__ void ncclBarrierSessionInit(
     ncclCoopAny coop,
     ncclTeam innerTeam,
     ncclTeam outerTeam,
-    ncclGin_C net,
+    ncclGin_C const* net,
     ncclLsaBarrierHandle const innerBarHandle,
     ncclGinBarrierHandle const outerBarHandle,
     uint32_t index,

--- a/bindings/ir/nccl_device_wrapper__impl.h
+++ b/bindings/ir/nccl_device_wrapper__impl.h
@@ -96,11 +96,11 @@ void ncclLsaBarrierSessionSync(ncclLsaBarrierSession_C* session, ncclCoopAny coo
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinBarrierSessionInit(
     ncclGinBarrierSession_C* session,
     ncclCoopAny coop,
-    ncclGin_C net,
+    ncclGin_C const* net,
     ncclTeam team,
     ncclGinBarrierHandle handle,
     uint32_t index) {
-    ::new (&(session->bar)) ncclGinBarrierSession<ncclCoopAny>(coop, reinterpret_cast<ncclGin const&>(net), team, handle, index);
+    ::new (&(session->bar)) ncclGinBarrierSession<ncclCoopAny>(coop, reinterpret_cast<ncclGin const&>(*net), team, handle, index);
 }
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinBarrierSessionInitAllContexts(
@@ -127,12 +127,12 @@ NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclBarrierSessionInit(
     ncclCoopAny coop,
     ncclTeam innerTeam,
     ncclTeam outerTeam,
-    ncclGin_C net,
+    ncclGin_C const* net,
     ncclLsaBarrierHandle const innerBarHandle,
     ncclGinBarrierHandle const outerBarHandle,
     uint32_t index,
     bool multimem, ncclMultimemHandle const innerMmHandle) {
-    ::new (&(session->bar)) ncclBarrierSession<ncclCoopAny>(coop, innerTeam, outerTeam, reinterpret_cast<ncclGin const&>(net),
+    ::new (&(session->bar)) ncclBarrierSession<ncclCoopAny>(coop, innerTeam, outerTeam, reinterpret_cast<ncclGin const&>(*net),
            innerBarHandle, outerBarHandle, index, multimem, innerMmHandle);
 }
 

--- a/bindings/nccl4py/nccl/core/device/cute/_bindings.py
+++ b/bindings/nccl4py/nccl/core/device/cute/_bindings.py
@@ -24,7 +24,6 @@ from ._structs import (
     ncclGinBarrierHandle,
     ncclMultimemHandle,
     ncclCoopAny,
-    ncclGin_C,
 )
 
 
@@ -285,13 +284,13 @@ def ncclLsaBarrierSessionSync(session_ptr, coop, order):
 _raw_ncclGinBarrierSessionInit = _ffi(
     name="ncclGinBarrierSessionInit",
     params_types=[
-        _LLVMPtrType, ncclCoopAny, ncclGin_C, ncclTeam,
+        _LLVMPtrType, ncclCoopAny, _LLVMPtrType, ncclTeam,
         ncclGinBarrierHandle, cutlass.Uint32,
     ])
 
-def ncclGinBarrierSessionInit(session_ptr, coop, gin_value, team, handle, index):
+def ncclGinBarrierSessionInit(session_ptr, coop, gin_ptr, team, handle, index):
     _raw_ncclGinBarrierSessionInit(
-        _to_ptr(session_ptr), _to_coop_value(coop), gin_value, team, handle,
+        _to_ptr(session_ptr), _to_coop_value(coop), _to_ptr(gin_ptr), team, handle,
         cutlass.Uint32(index),
     )
 
@@ -312,17 +311,17 @@ def ncclGinBarrierSessionSync(session_ptr, coop, order, fence):
 _raw_ncclBarrierSessionInit = _ffi(
     name="ncclBarrierSessionInit",
     params_types=[
-        _LLVMPtrType, ncclCoopAny, ncclTeam, ncclTeam, ncclGin_C,
+        _LLVMPtrType, ncclCoopAny, ncclTeam, ncclTeam, _LLVMPtrType,
         ncclLsaBarrierHandle, ncclGinBarrierHandle, cutlass.Uint32,
         cutlass.Boolean, ncclMultimemHandle,
     ])
 
 def ncclBarrierSessionInit(session_ptr, coop, inner_team, outer_team,
-                            gin_value, inner_handle, outer_handle, index,
+                            gin_ptr, inner_handle, outer_handle, index,
                             multimem, inner_mm_handle):
     _raw_ncclBarrierSessionInit(
         _to_ptr(session_ptr), _to_coop_value(coop), inner_team, outer_team,
-        gin_value, inner_handle, outer_handle, cutlass.Uint32(index),
+        _to_ptr(gin_ptr), inner_handle, outer_handle, cutlass.Uint32(index),
         cutlass.Boolean(multimem), inner_mm_handle,
     )
 

--- a/bindings/nccl4py/nccl/core/device/cute/barrier.py
+++ b/bindings/nccl4py/nccl/core/device/cute/barrier.py
@@ -193,7 +193,7 @@ def gin_session(
     """
     storage = _alloca_session(raw.ncclGinBarrierSession_C_size())
     raw.ncclGinBarrierSessionInit(
-        storage, coop, gin.value(), team, handle, index,
+        storage, coop, gin.ptr, team, handle, index,
     )
     return GinBarrierSession(ptr=storage)
 
@@ -250,7 +250,7 @@ def hybrid_session(
     """
     storage = _alloca_session(raw.ncclBarrierSession_C_size())
     raw.ncclBarrierSessionInit(
-        storage, coop, inner_team, outer_team, gin.value(),
+        storage, coop, inner_team, outer_team, gin.ptr,
         inner_handle, outer_handle, index, multimem,
         inner_mm_handle if inner_mm_handle is not None else _zero_multimem_handle(),
     )


### PR DESCRIPTION
## Description

The barrier session init wrappers (ncclGinBarrierSessionInit and ncclBarrierSessionInit) took ncclGin_C by value. Under CuTeDSL, the by-value struct was spilled to an under-aligned (4-byte) local stack slot, so the C++ side's 8-byte read of its leading ncclDevComm reference faulted with cudaErrorMisalignedAddress. GIN put/get were unaffected because they already pass the struct by pointer.

Change both init wrappers to take ncclGin_C const* and have the Python bindings pass gin.ptr, mirroring the proven put/get path. Drop the now unused Gin.value() helper that produced the by-value load.

## Related Issues

Fixes: https://github.com/NVIDIA/nccl/issues/2242

## Changes & Impact

Modifies the NCCL device bindings IR (libnccl_device.bc)

## Performance Impact

N/A
