### PR TITLE
net/ib: deterministic sub-device order in fused vNICs (fix cross-plane QP pairing under SR-IOV multi-plane RoCE)

### DIFF
--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -218,6 +218,20 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
   mDev->planeId = (props->ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : ncclIbDevs[props->devs[0]].planeId;
 
+  // Order the sub-devices of a fused vNIC deterministically (by device name) so that every node
+  // builds the same sub-device ordering. QP-to-sub-device pairing inside a fused vNIC is positional
+  // (qpIndex % ndevs), so a stable, node-independent order is required to pair sub-devices
+  // consistently across endpoints. Without this, the sub-device order follows PCI/BDF enumeration,
+  // which is not stable across nodes for SR-IOV VFs of a multi-port/multi-plane NIC and leads to
+  // cross-plane QP pairing (mismatched GID subnets -> ibv_modify_qp 110 / degraded bandwidth).
+  for (int a = 0; a < props->ndevs - 1; a++) {
+    for (int b = 0; b < props->ndevs - 1 - a; b++) {
+      if (strcmp(ncclIbDevs[props->devs[b]].devName, ncclIbDevs[props->devs[b + 1]].devName) > 0) {
+        int tmp = props->devs[b]; props->devs[b] = props->devs[b + 1]; props->devs[b + 1] = tmp;
+      }
+    }
+  }
+
   for (int i = 0; i < props->ndevs; i++) {
     ncclIbDev* dev = ncclIbDevs + props->devs[i];
     if (mDev->vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;


### PR DESCRIPTION
## Problem

When two or more physical IB/RoCE devices are fused into one virtual NIC (`NCCL_IB_MERGE_NICS` /
`NCCL_NET_FORCE_MERGE`), `ncclIbMakeVDeviceInternal` stores the sub-devices in **PCI/BDF enumeration
order**. QP-to-sub-device pairing inside a fused vNIC is **positional** (`qpIndex % ndevs` locally,
and the remote's advertised `devIndex`), so both endpoints must agree on sub-device order.

For **SR-IOV VFs of a dual-port / multi-plane NIC** (e.g. a ConnectX-8 whose two 400G ports land on
two RoCE planes, exposed as VFs to Kubernetes pods), the relative BDF order of the plane-0 VF vs the
plane-1 VF is **not stable across nodes**. So `slot0<->slot0` positional pairing can connect
**plane 0 on one node to plane 1 on the peer**. Those VFs are on different GID subnets, so:

- the QP can't reach RTR → `ibv_modify_qp failed with 110 Connection timed out`, or
- when a route exists, traffic is cross-plane and bandwidth collapses.

This is independent of `NCCL_IB_HCA` `:rail:plane` tags (they fix cross-*rail* grouping, not
intra-vNIC sub-device order) and of `NCCL_IB_SUBNET_AWARE_ROUTING` (that selects which *merged
device* matches a remote subnet; it does not reorder sub-devices *within* a fused vNIC).

## Fix

Sort the sub-devices of each fused vNIC **by device name** before building the merged device. Device
names are stable and identical across nodes, so the order is node-independent and positional pairing
becomes plane-consistent. ~14 lines, no new env vars, default single-NIC behavior unchanged.

## Validation

8× **B300**, dual-port **ConnectX-8**, RoCEv2 with two planes, on **Kubernetes + NVIDIA Run:ai**;
RoCE exposed as **SR-IOV VFs** via the **NVIDIA Network Operator** (switchdev) + **NV-IPAM** +
**Multus** (one VF per rail × plane). 4-node `all_reduce_perf` (32 GPU, p0+p1):

| Config | busbw @16 GiB | QP timeouts |
|---|---|---|
| single-plane (8 rails) | ~382 GB/s | 0 (half fabric idle) |
| dual-plane, unsorted (stock) | fail / ~89 GB/s | many (110 cross-plane) |
| **dual-plane, this fix** | **763.9 GB/s** | **0** |

~2× single-plane, exceeding the 2-node single-plane figure (both planes fully utilized).

## Note for k8s / Run:ai users debugging this

Many stacks (NGC/HPC-X images) load an **external** net plugin
(`NET/Plugin: Loaded net plugin NCCL RDMA Plugin v11` from
`/opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so`) which carries its **own copy** of this
net_ib code — so an in-tree rebuild has no effect unless you set `NCCL_NET_PLUGIN=none` or apply the
same fix to the plugin. Check `NCCL_DEBUG=INFO ... | grep "NET/Plugin\|Initialized NET plugin"` to
see which backend is on the data path. The same deterministic-ordering fix is needed wherever the
net_ib code actually executes.

Refs #2035.