### PR TITLE
fix: close XML file on parse-error paths to avoid FILE* leak

### DIFF
--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -298,8 +298,9 @@ ncclResult_t ncclTopoDumpXmlToFile(const char* xmlTopoFile, struct ncclXml* xml)
     INFO(NCCL_GRAPH | NCCL_ENV, "Unable to open %s, not dumping topology.", xmlTopoFile);
     return ncclSuccess;
   }
-  NCCLCHECK(ncclTopoDumpXmlRec(0, file, xml->nodes));
+  ncclResult_t res = ncclTopoDumpXmlRec(0, file, xml->nodes);
   fclose(file);
+  NCCLCHECK(res);
   return ncclSuccess;
 }
 
@@ -418,8 +419,9 @@ ncclResult_t ncclTopoGetXmlFromFile(const char* xmlTopoFile, struct ncclXml* xml
   INFO(NCCL_GRAPH, "Loading topology file %s", xmlTopoFile);
   struct xmlHandler handlers[] = {{"system", ncclTopoXmlLoadSystem}};
   xml->maxIndex = 0;
-  NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
+  ncclResult_t res = xmlLoadSub(file, xml, NULL, handlers, 1);
   fclose(file);
+  NCCLCHECK(res);
 #elif NCCL_OS_WINDOWS
   (void)xmlTopoFile;
   (void)xml;
@@ -1259,8 +1261,9 @@ ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXm
   }
   struct xmlHandler handlers[] = {{"graphs", ncclTopoXmlGraphLoadGraphs}};
   xml->maxIndex = 0;
-  NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
+  ncclResult_t res = xmlLoadSub(file, xml, NULL, handlers, 1);
   fclose(file);
+  NCCLCHECK(res);
   return ncclSuccess;
 }
 


### PR DESCRIPTION
## Description

`ncclTopoGetXmlFromFile`, `ncclTopoGetXmlGraphFromFile`, and `ncclTopoDumpXmlToFile` (`src/graph/xml.cc`) only call `fclose()` on the success path. Because `NCCLCHECK(...)` returns immediately on a non-success result, an error from `xmlLoadSub()` / `ncclTopoDumpXmlRec()` returns from the function **before** the `fclose()`, leaking the `FILE*` (and its underlying file descriptor).

This triggers whenever `NCCL_TOPO_FILE` or `NCCL_GRAPH_FILE` points at a file that fails to parse — e.g. a wrong `version` attribute, an unterminated/mismatched tag, or an over-long value/name. Each affected `ncclCommInitRank` then leaks one descriptor.

**Fix:** capture the result, `fclose()` unconditionally, then propagate via `NCCLCHECK` — mirroring the `exit:`-label cleanup discipline already used elsewhere in this file (e.g. `ncclTopoGetXmlFromSys`).

## Related Issues

None.

## Changes & Impact

- `src/graph/xml.cc`: three call sites (two read paths + the dump path). The only behavioral change is that the file handle is released on the error path. No API change; non-breaking.

## Performance Impact

None — this is error-path-only resource cleanup.

### Testing

- Builds clean with `make src.build` (no new warnings).
- Before/after repro with a malformed topology file (`<system version="2"></system>` via `NCCL_TOPO_FILE`), looping `ncclCommInitRank` and counting open fds pointing at that file:
  - **Before:** open fds to the topo file grow `1, 2, 3, 4, 5, 6` across six failed inits (leak).
  - **After:** stays at `0` on every iteration (closed).
