### PR TITLE
fix: correct NVML P2P WRITE status warning to say INDEX_WRITE

### DIFF
--- a/src/misc/nvmlwrap.cc
+++ b/src/misc/nvmlwrap.cc
@@ -191,7 +191,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_WRITE, &ncclNvmlDevicePairs[a][b].p2pStatusWrite);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_WRITE) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }


### PR DESCRIPTION
## Description

In `ncclNvmlEnsureInitialized` (`src/misc/nvmlwrap.cc`), the P2P-status probe queries `NVML_P2P_CAPS_INDEX_READ` and then `NVML_P2P_CAPS_INDEX_WRITE`. The failure `WARN` for the **WRITE** query incorrectly prints `NVML_P2P_CAPS_INDEX_READ` — a copy-paste from the READ branch just above it.

The effect is purely diagnostic but misleading: an operator debugging a P2P **write**-capability failure is told the **read** query failed, pointing them at the wrong thing.

## Related Issues

None.

## Changes & Impact

- `src/misc/nvmlwrap.cc`: one diagnostic string literal corrected (`INDEX_READ` → `INDEX_WRITE`) in the WRITE branch's `WARN`. No change to the NVML call, control flow, stored status, or return value. Non-breaking.

## Performance Impact

None — diagnostic message text only.

### Testing

- Builds clean with `make src.build` (no new warnings).
- Verifiable by inspection: the READ branch's `WARN` correctly says READ; the WRITE branch's `WARN` previously also said READ, and now says WRITE to match its query.
