### PR TITLE
fix: stack buffer overflow in IPv6 address parsing

### DIFF
--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -296,12 +296,23 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     memset(ip_str, '\0', sizeof(ip_str));
     memset(port_str, '\0', sizeof(port_str));
     memset(if_name, '\0', sizeof(if_name));
-    strncpy(ip_str, ip_port_pair + 1, global_scope ? i - 1 : j - 1);
-    strncpy(port_str, ip_port_pair + i + 2, len - i - 1);
+    // Clamp each copy to its destination buffer. These lengths derive from
+    // operator-controlled input (e.g. NCCL_COMM_ID / NCCL_RAS_ADDR), so an
+    // over-long IPv6 address, port, or interface name would otherwise overflow
+    // these fixed stack buffers. The (size_t) cast plus clamp also makes any
+    // unexpected negative length safe (it becomes large, then clamps down).
+    size_t ipLen   = (size_t)(global_scope ? i - 1 : j - 1);
+    size_t portLen = (size_t)(len - i - 1);
+    if (ipLen   > sizeof(ip_str)   - 1) ipLen   = sizeof(ip_str)   - 1;
+    if (portLen > sizeof(port_str) - 1) portLen = sizeof(port_str) - 1;
+    strncpy(ip_str, ip_port_pair + 1, ipLen);
+    strncpy(port_str, ip_port_pair + i + 2, portLen);
     int port = atoi(port_str);
     if (!global_scope) {
       // If not global scope, we need the intf name
-      strncpy(if_name, ip_port_pair + j + 1, i - j - 1);
+      size_t ifLen = (size_t)(i - j - 1);
+      if (ifLen > sizeof(if_name) - 1) ifLen = sizeof(if_name) - 1;
+      strncpy(if_name, ip_port_pair + j + 1, ifLen);
     }
 
     struct sockaddr_in6& sin6 = ua->sin6;


### PR DESCRIPTION
## Description

`ncclSocketGetAddrFromString` parses an `[IPv6]:port` (optionally `[IPv6%iface]:port`) string into fixed-size stack buffers, but the `strncpy` lengths come straight from the input with no bound (`src/misc/socket.cc`):

- `port_str` is `NI_MAXSERV` (32) bytes, yet `strncpy(port_str, ip_port_pair + i + 2, len - i - 1)` copies the entire tail after `]:` — a port field longer than 31 chars overflows the stack buffer.
- `if_name` is 16 bytes, copied `i - j - 1` (the `%iface` portion) with no bound.
- `ip_str` is `NI_MAXHOST` (1025) and is likewise unbounded for a pathologically long address.

These lengths derive from operator-controlled configuration (`NCCL_COMM_ID`, and the RAS address path), so a malformed value such as `NCCL_COMM_ID` = `[::1]:` followed by 40+ digits triggers a stack out-of-bounds write (CWE-121). The IPv4/`getaddrinfo` branch is unaffected.

## Related Issues

None.

## Changes & Impact

- `src/misc/socket.cc`: clamp each `strncpy` length to its destination buffer size (minus one for the NUL already written by the preceding `memset`). The `(size_t)` cast plus the clamp also makes any unexpected negative length safe (it becomes large, then clamps down). Valid addresses — well under the buffer sizes — are unaffected; only malformed/over-long input is now truncated instead of overflowing. Non-breaking.

## Performance Impact

None — a few comparisons on the (rare) address-parse path.

### Testing

- Builds clean with `make src.build` (no new warnings).
- AddressSanitizer repro of the parsing logic (extracted verbatim) with `NCCL_COMM_ID`-style input `[::1]:` + 40 digits:
  - **Before:** `AddressSanitizer: stack-buffer-overflow ... WRITE of size 41 ... in strncpy` (41 bytes written into the 32-byte `port_str`).
  - **After:** parses without overflow (the over-long field is truncated to the buffer).
