### PR TITLE
fix: null comm->groupJob after abort to avoid use-after-free

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -424,6 +424,7 @@ ncclResult_t ncclCommEnsureReady(ncclComm_t comm) {
   ncclResult_t ret = ncclSuccess;
   if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
     ncclGroupJobAbort(comm->groupJob);
+    comm->groupJob = NULL;
   } else {
     NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
     if (ret == ncclInProgress) {


### PR DESCRIPTION
## Description

`ncclCommEnsureReady`'s abort branch (`src/init.cc`) calls `ncclGroupJobAbort(comm->groupJob)`, which decrements the group job's refcount and `delete`s it when the count reaches zero — but, unlike the success path in `ncclCommGetAsyncError` (which sets `comm->groupJob = NULL` after `ncclGroupJobComplete`), it leaves `comm->groupJob` pointing at the freed object.

A second abort on the same communicator then re-reads that dangling pointer. This occurs on a normal, supported sequence — `ncclCommRevoke` followed by `ncclCommDestroy`, both of which route through `ncclCommEnsureReady`'s abort branch: revoke frees the job, destroy re-enters the branch on the dangling `comm->groupJob` → **heap use-after-free**.

## Related Issues

None.

## Changes & Impact

- `src/init.cc`: set `comm->groupJob = NULL` immediately after `ncclGroupJobAbort(comm->groupJob)`, restoring the same invariant the success path already enforces. One line; no behavior change on any path that does not take the abort branch. Non-breaking.

## Performance Impact

None.

### Testing

Reproduced and verified with **AddressSanitizer** (`make src.build ASAN=1`), single rank, `blocking=0`, sequence `ncclCommInitRankConfig` → `ncclCommRevoke` → `ncclCommDestroy`:

**Before (use-after-free):**
```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 1 ... in ncclGroupJobAbort(ncclGroupJob*)   src/group.cc:903
  #1 ncclCommEnsureReady(ncclComm*)                      src/init.cc:426
  #2 ncclCommDestroy                                     src/init.cc:2901
freed by thread T0 here:
  #1 ncclGroupJobAbort(ncclGroupJob*)                    src/group.cc:909
  #2 ncclCommEnsureReady(ncclComm*)                      src/init.cc:426   (during ncclCommRevoke)
SUMMARY: AddressSanitizer: heap-use-after-free src/group.cc:903 in ncclGroupJobAbort
```

**After:** no use-after-free. Builds clean (`ASAN=1` and normal).
