### PR TITLE
Avoid RMA proxy when cuMem host is unavailable

### DIFF
--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -171,6 +171,11 @@ extern gdr_t ncclGdrCopy;
 
 #include "alloc.h"
 
+// CPU-accessible control memory can be backed by GDRCopy or cuMem host allocations.
+static inline bool ncclCpuAccessibleMemSupported(bool forceHost = false) {
+  return (ncclGdrCopy && !forceHost) || ncclCuMemHostEnable();
+}
+
 typedef struct gdr_mem_desc {
   void *gdrDevMem;
   void *gdrMap;
@@ -288,11 +293,14 @@ static ncclResult_t allocMemCPUAccessible(T **ptr, T **devPtr, size_t nelem, int
                                           void **gdrHandle, struct ncclMemManager* manager, bool forceHost = false) {
   if (ncclGdrCopy && !forceHost) {
     NCCLCHECK(ncclGdrCudaCalloc(ptr, devPtr, nelem, gdrHandle, manager));
-  } else {
+  } else if (ncclCuMemHostEnable()) {
     NCCLCHECK(ncclCuMemHostAlloc((void **)ptr, NULL, nelem * sizeof(T)));
     memset((void *)*ptr, 0, nelem * sizeof(T));
     *devPtr = *ptr;
     if (gdrHandle) *gdrHandle = NULL;  // Mark as host allocated by nulling GDR handle
+  } else {
+    WARN("CPU-accessible memory allocation requires GDRCopy or cuMem host allocations");
+    return ncclSystemError;
   }
   return ncclSuccess;
 }

--- a/src/init.cc
+++ b/src/init.cc
@@ -1669,8 +1669,12 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   if (globalGinSupport && globalCuMemGdrSupport && !comm->hasMloPart) {
     comm->globalGinSupport = globalCrossNicSupport ? NCCL_GIN_CONNECTION_FULL : NCCL_GIN_CONNECTION_RAIL;
   }
-  comm->globalRmaProxySupport = globalRmaPluginSupport && globalCrossNicSupport && globalCuMemGdrSupport;
   isOneLsaTeams = ncclDevrIsOneLsaTeam(comm);
+  comm->globalRmaProxySupport = globalRmaPluginSupport && globalCrossNicSupport && globalCuMemGdrSupport;
+  if (!isOneLsaTeams && comm->globalRmaProxySupport && !ncclCpuAccessibleMemSupported()) {
+    INFO(NCCL_INIT, "RMA proxy is not supported because neither GDRCopy nor cuMem host allocations are available");
+    comm->globalRmaProxySupport = false;
+  }
   comm->symmetricSupport = comm->isAllCudaP2p && ncclParamWinEnable() && ncclCuMemEnable() &&
                            (comm->globalGinSupport != NCCL_GIN_CONNECTION_NONE || isOneLsaTeams);
   comm->hostRmaSupport =


### PR DESCRIPTION
Guard CPU-accessible allocations with GDRCopy or cuMem host support.

## Description

RMA proxy control buffers are allocated through `allocMemCPUAccessible()`.
That helper uses GDRCopy when available, otherwise it falls back to
`ncclCuMemHostAlloc()`.

When cuMem host allocations fail the runtime self-test, the SHM path falls
back to `/dev/shm`, but the RMA proxy path could still call
`ncclCuMemHostAlloc()` and later fail in `cuMemCreate(HOST_NUMA)`.

This PR adds a shared CPU-accessible memory capability check and uses it to
avoid enabling multi-LSA RMA proxy when neither GDRCopy nor cuMem host
allocations are available. It also adds a defensive guard in
`allocMemCPUAccessible()`.

## Related Issues

none

## Changes & Impact

- Add `ncclCpuAccessibleMemSupported()` for GDRCopy/cuMem-host-backed
  CPU-accessible control memory.
- Disable multi-LSA RMA proxy support when CPU-accessible control memory is
  unavailable.
- Prevent `allocMemCPUAccessible()` from falling through to
  `ncclCuMemHostAlloc()` after cuMem host support has been disabled.
- No public API changes.
- No ABI changes.

In unsupported environments, host RMA proxy is now reported as unsupported
instead of failing later with CUDA `invalid argument`.

## Performance Impact

No performance impact is expected for supported paths.

Existing behavior is preserved when either GDRCopy or cuMem host allocations
are available. The change only gates unsupported RMA proxy configurations and
adds a defensive allocation check.


