### PR TITLE
Adding FI_MORE to the Gin Proxy Path

### DIFF
--- a/src/gin/gin_host_proxy.cc
+++ b/src/gin/gin_host_proxy.cc
@@ -246,7 +246,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
     signalOp = mapGfdOpToSignalOp(gfd);
     NCCLCHECK(rmaBackend->iputSignal(ctx->rmaCtx, hostGpuCtx->contextId, 0, nullptr, 0, 0, nullptr, targetRank,
                                      signalOff, signalHandle, signalVal, signalOp, extractIsStrongSignal(gfd),
-                                     &state->request));
+                                     /*optFlags*/ 0, &state->request));
     return ncclSuccess;
   }
 
@@ -261,7 +261,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
       return ncclInvalidUsage;
     }
     NCCLCHECK(rmaBackend->iget(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                               targetRank, &state->request));
+                               targetRank, /*optFlags*/ 0, &state->request));
     return ncclSuccess;
   }
 
@@ -303,7 +303,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
     if (signalOp == -1) {
       // First cast from 63 bits to 64 bits and then to void * to avoid warnings
       NCCLCHECK(rmaBackend->iput(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                                 targetRank, &state->request));
+                                 targetRank, /*optFlags*/ 0, &state->request));
     } else {
       // Reconstruct the signal value
       signalVal = extractSignalVal(gfd);
@@ -312,7 +312,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
         sizeof(uint64_t);
       NCCLCHECK(rmaBackend->iputSignal(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
                                        targetRank, signalOff, ctx->signalsGinHandle, signalVal, signalOp,
-                                       extractIsStrongSignal(gfd), &state->request));
+                                       extractIsStrongSignal(gfd), /*optFlags*/ 0, &state->request));
     }
     break;
   default:

--- a/src/gin/gin_host_proxy.cc
+++ b/src/gin/gin_host_proxy.cc
@@ -13,6 +13,7 @@
 #include "checks.h"
 #include "gdrwrap.h"
 #include "nccl_device/gin/proxy/gin_proxy_device_host_common.h"
+#include "nccl_device/gin/gin_device_common.h"
 #include "compiler.h"
 #include "comm.h"
 #include "proxy_gpucontext/gpucontext.h"
@@ -171,15 +172,24 @@ static bool extractIsStrongSignal(ncclGinProxyGfd_t* gfd) {
   return gfd->qword[ncclGinProxyGfdSignalVal].signalVal.isStrongSignal != 0;
 }
 
+// True if the queue slot at sis[targetRank] holds a GFD (its header flag is set by the producer).
+static bool isGfdAvailable(struct ginProxyHostGpuCtx* hostGpuCtx, int targetRank) {
+  ncclGinProxyGfd_t* q = hostGpuCtx->queues + targetRank * hostGpuCtx->queueSize;
+  uint32_t idx = hostGpuCtx->sis[targetRank] & (hostGpuCtx->queueSize - 1);
+  ncclGinProxyQword_t header;
+  COMPILER_ATOMIC_LOAD_DEST(&q[idx].qword[ncclGinProxyGfdHeader].raw, &header.raw, std::memory_order_relaxed);
+  return header.flag.v != 0;
+}
+
 static int proxyGinPollGfd(struct ginProxyCtx* ctx, ginProxyHostGpuCtx* hostGpuCtx, int targetRank,
                            ncclGinProxyGfd_t* gfd, struct ginProxyGfdState** state) {
+  if (!isGfdAvailable(hostGpuCtx, targetRank)) {
+    return 0;
+  }
+
   ncclGinProxyGfd_t* q = hostGpuCtx->queues + targetRank * hostGpuCtx->queueSize;
   uint32_t idx = hostGpuCtx->sis[targetRank] & (hostGpuCtx->queueSize - 1);
   ncclGinProxyQword_t qword;
-  COMPILER_ATOMIC_LOAD_DEST(&q[idx].qword[ncclGinProxyGfdHeader].raw, &qword.raw, std::memory_order_relaxed);
-  if (qword.flag.v == 0) {
-    return 0;
-  }
 
   // We know for sure that the first qword is there, copy it.
   gfd->qword[ncclGinProxyGfdHeader] = q[idx].qword[ncclGinProxyGfdHeader];
@@ -234,9 +244,13 @@ static int mapGfdOpToSignalOp(ncclGinProxyGfd_t* gfd) {
 }
 
 static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyHostGpuCtx* hostGpuCtx, int targetRank,
-                                       ncclGinProxyGfd_t* gfd, struct ginProxyGfdState* state) {
+                                       ncclGinProxyGfd_t* gfd, struct ginProxyGfdState* state, bool isLastInBatch) {
   int signalOp;
   uint64_t signalVal;
+  // Defer the doorbell only when this peer's next GFD is already queued (so it is guaranteed pollable next
+  // iteration and the doorbell is rung before we leave Progress) and this isn't the last op in the batch.
+  bool aggregate = isGfdAvailable(hostGpuCtx, targetRank) && !isLastInBatch;
+  uint32_t optFlags = aggregate ? ncclGinOptFlagsAggregateRequests : ncclGinOptFlagsDefault;
 
   // Handle VA Signal operations (signal-only, no PUT)
   if (extractOp(gfd) & ncclGinProxyOpVASignal) {
@@ -246,7 +260,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
     signalOp = mapGfdOpToSignalOp(gfd);
     NCCLCHECK(rmaBackend->iputSignal(ctx->rmaCtx, hostGpuCtx->contextId, 0, nullptr, 0, 0, nullptr, targetRank,
                                      signalOff, signalHandle, signalVal, signalOp, extractIsStrongSignal(gfd),
-                                     /*optFlags*/ 0, &state->request));
+                                     optFlags, &state->request));
     return ncclSuccess;
   }
 
@@ -261,7 +275,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
       return ncclInvalidUsage;
     }
     NCCLCHECK(rmaBackend->iget(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                               targetRank, /*optFlags*/ 0, &state->request));
+                               targetRank, optFlags, &state->request));
     return ncclSuccess;
   }
 
@@ -303,7 +317,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
     if (signalOp == -1) {
       // First cast from 63 bits to 64 bits and then to void * to avoid warnings
       NCCLCHECK(rmaBackend->iput(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                                 targetRank, /*optFlags*/ 0, &state->request));
+                                 targetRank, optFlags, &state->request));
     } else {
       // Reconstruct the signal value
       signalVal = extractSignalVal(gfd);
@@ -312,7 +326,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
         sizeof(uint64_t);
       NCCLCHECK(rmaBackend->iputSignal(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
                                        targetRank, signalOff, ctx->signalsGinHandle, signalVal, signalOp,
-                                       extractIsStrongSignal(gfd), /*optFlags*/ 0, &state->request));
+                                       extractIsStrongSignal(gfd), optFlags, &state->request));
     }
     break;
   default:
@@ -630,7 +644,8 @@ static ncclResult_t ncclGinProxyProgress(void* ginCtx) {
         ncclGinProxyGfd_t gfd;
         struct ginProxyGfdState* state = NULL;
         if (!proxyGinPollGfd(ctx, hostGpuCtx, targetRank, &gfd, &state)) break;
-        ncclResult_t ret = proxyGinProcessGfd(ctx, hostGpuCtx, targetRank, &gfd, state);
+        bool isLastInBatch = (p == ctx->pollBatch - 1);
+        ncclResult_t ret = proxyGinProcessGfd(ctx, hostGpuCtx, targetRank, &gfd, state, isLastInBatch);
         if (ret) ctx->hasError = ret;
         NCCLCHECK(ret);
       }

--- a/src/include/plugin/nccl_rma.h
+++ b/src/include/plugin/nccl_rma.h
@@ -19,10 +19,11 @@
 #define NCCL_RMA_MAX_PLUGINS 16
 #endif
 
+#include "rma/rma_v15.h"
 #include "rma/rma_v14.h"
 #include "rma/rma_v13.h"
 
-typedef ncclRma_v14_t ncclRma_t;
-typedef ncclRmaConfig_v14_t ncclRmaConfig_t;
+typedef ncclRma_v15_t ncclRma_t;
+typedef ncclRmaConfig_v15_t ncclRmaConfig_t;
 
 #endif // end include guard

--- a/src/include/plugin/rma/rma_v15.h
+++ b/src/include/plugin/rma/rma_v15.h
@@ -1,0 +1,48 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef RMA_V15_H_
+#define RMA_V15_H_
+#include "nccl_net.h"
+#include "rma/rma_v14.h"
+
+typedef ncclRmaConfig_v14_t ncclRmaConfig_v15_t;
+
+typedef struct {
+  const char* name;
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction);
+  ncclResult_t (*devices)(int* ndev);
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm);
+  ncclResult_t (*createContext)(void* collComm, ncclRmaConfig_v15_t* config, void** rmaCtx);
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                 uint64_t mrFlags, void** mhandle);
+  ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
+  ncclResult_t (*destroyContext)(void* rmaCtx);
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // optFlags carries ncclGinOptFlags. With ncclGinOptFlagsAggregateRequests the backend may
+  // defer the doorbell; the default flushes.
+  ncclResult_t (*iput)(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                       void* dstMhandle, uint32_t rank, uint32_t optFlags, void** request);
+  ncclResult_t (*iputSignal)(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                             void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                             uint64_t signalValue, uint32_t signalOp, bool isStrongSignal, uint32_t optFlags,
+                             void** request);
+  ncclResult_t (*iget)(void* rmaCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
+                       uint64_t localOff, void* localMhandle, uint32_t rank, uint32_t optFlags, void** request);
+
+  ncclResult_t (*iflush)(void* rmaCtx, int context, void* mhandle, uint32_t rank, void** request);
+  ncclResult_t (*test)(void* collComm, void* request, int* done);
+  ncclResult_t (*rmaProgress)(void* rmaCtx);
+  ncclResult_t (*queryLastError)(void* rmaCtx, bool* hasError);
+  ncclResult_t (*finalize)(void* ctx);
+} ncclRma_v15_t;
+#endif

--- a/src/plugin/rma.cc
+++ b/src/plugin/rma.cc
@@ -18,12 +18,13 @@
 
 typedef ncclRma_t* getNcclRma_t(void* rmaPluginLib);
 
+extern getNcclRma_t getNcclRma_v15;
 extern getNcclRma_t getNcclRma_v14;
 extern getNcclRma_t getNcclRma_v13;
 NCCL_PARAM(RmaPluginRefCount, "RMA_PLUGIN_REF_COUNT", 0);
-#define NCCL_RMA_VERSION_COUNT 2
-int ncclRmaVersion[NCCL_RMA_VERSION_COUNT] = {14, 13};
-getNcclRma_t* getNcclRma[NCCL_RMA_VERSION_COUNT] = {getNcclRma_v14, getNcclRma_v13};
+#define NCCL_RMA_VERSION_COUNT 3
+int ncclRmaVersion[NCCL_RMA_VERSION_COUNT] = {15, 14, 13};
+getNcclRma_t* getNcclRma[NCCL_RMA_VERSION_COUNT] = {getNcclRma_v15, getNcclRma_v14, getNcclRma_v13};
 
 #define NCCL_RMA_NUM_RESERVED_PLUGINS 3
 #define NCCL_RMA_NUM_INTERNAL_PLUGINS 1

--- a/src/plugin/rma/CMakeLists.txt
+++ b/src/plugin/rma/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Plugin sources
 set(PLUGIN_RMA_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/rma_v15.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/rma_v14.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/rma_v13.cc
 )

--- a/src/plugin/rma/rma_v13.cc
+++ b/src/plugin/rma/rma_v13.cc
@@ -27,7 +27,7 @@ static ncclResult_t ncclRma_init(void** ctx, uint64_t commId, ncclDebugLogger_t 
   return ncclSuccess;
 }
 
-static ncclResult_t ncclRma_createContext(void* collComm, ncclRmaConfig_v14_t* config, void** rmaCtx) {
+static ncclResult_t ncclRma_createContext(void* collComm, ncclRmaConfig_v15_t* config, void** rmaCtx) {
   ncclNetDeviceHandle_v11_t* devHandle;
   ncclGinConfig_v13_t config_v13;
   memset(&config_v13, 0, sizeof(config_v13));
@@ -56,10 +56,25 @@ static ncclResult_t ncclRma_regMrSymDmaBuf(void* collComm, void* data, size_t si
 static ncclResult_t ncclRma_iputSignal(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
                                        uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
                                        void* signalMhandle, uint64_t signalValue, uint32_t signalOp,
-                                       bool isStrongSignal, void** request) {
+                                       bool isStrongSignal, uint32_t optFlags, void** request) {
   (void)isStrongSignal;
+  (void)optFlags;
   return ncclRma_v13->iputSignal(rmaCtx, context, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff,
                                  signalMhandle, signalValue, signalOp, request);
+}
+
+static ncclResult_t ncclRma_iput(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                 uint64_t dstOff, void* dstMhandle, uint32_t rank, uint32_t optFlags,
+                                 void** request) {
+  (void)optFlags;
+  return ncclRma_v13->iput(rmaCtx, context, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, request);
+}
+
+static ncclResult_t ncclRma_iget(void* rmaCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
+                                 uint64_t localOff, void* localMhandle, uint32_t rank, uint32_t optFlags,
+                                 void** request) {
+  (void)optFlags;
+  return ncclRma_v13->iget(rmaCtx, context, remoteOff, remoteMhandle, size, localOff, localMhandle, rank, request);
 }
 
 ncclRma_t* getNcclRma_v13(void* lib) {
@@ -83,9 +98,9 @@ ncclRma_t* getNcclRma_v13(void* lib) {
     ncclRma.destroyContext = ncclRma_v13->destroyContext;
     ncclRma.closeColl = ncclRma_v13->closeColl;
     ncclRma.closeListen = ncclRma_v13->closeListen;
-    ncclRma.iput = ncclRma_v13->iput;
+    ncclRma.iput = ncclRma_iput;
     ncclRma.iputSignal = ncclRma_iputSignal;
-    ncclRma.iget = ncclRma_v13->iget;
+    ncclRma.iget = ncclRma_iget;
     ncclRma.iflush = ncclRma_v13->iflush;
     ncclRma.test = ncclRma_v13->test;
     ncclRma.rmaProgress = ncclRma_v13->ginProgress;

--- a/src/plugin/rma/rma_v14.cc
+++ b/src/plugin/rma/rma_v14.cc
@@ -6,16 +6,67 @@
  *************************************************************************/
 
 #include "nccl_rma.h"
-#include "proxy.h"
+#include "checks.h"
+#include "os.h"
 #include <dlfcn.h>
 
 static ncclRma_v14_t* ncclRma_v14;
+static ncclRma_t ncclRma;
+
+static ncclResult_t ncclRma_v14_init(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction) {
+  return ncclRma_v14->init(ctx, commId, logFunction);
+}
+
+static ncclResult_t ncclRma_v14_iput(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                     uint64_t dstOff, void* dstMhandle, uint32_t rank, uint32_t optFlags,
+                                     void** request) {
+  (void)optFlags;
+  return ncclRma_v14->iput(rmaCtx, context, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, request);
+}
+
+// Drop optFlags (v14 has no aggregate hint); isStrongSignal is passed through.
+static ncclResult_t ncclRma_v14_iputSignal(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                           uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
+                                           void* signalMhandle, uint64_t signalValue, uint32_t signalOp,
+                                           bool isStrongSignal, uint32_t optFlags, void** request) {
+  (void)optFlags;
+  return ncclRma_v14->iputSignal(rmaCtx, context, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff,
+                                 signalMhandle, signalValue, signalOp, isStrongSignal, request);
+}
+
+static ncclResult_t ncclRma_v14_iget(void* rmaCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
+                                     uint64_t localOff, void* localMhandle, uint32_t rank, uint32_t optFlags,
+                                     void** request) {
+  (void)optFlags;
+  return ncclRma_v14->iget(rmaCtx, context, remoteOff, remoteMhandle, size, localOff, localMhandle, rank, request);
+}
 
 ncclRma_t* getNcclRma_v14(void* lib) {
   ncclRma_v14 = (ncclRma_v14_t*)dlsym(lib, "ncclRmaPlugin_v14");
   if (ncclRma_v14) {
     INFO(NCCL_INIT | NCCL_NET, "RMA/Plugin: Loaded rma plugin %s (v14)", ncclRma_v14->name);
-    return ncclRma_v14;
+    ncclRma.name = ncclRma_v14->name;
+    ncclRma.init = ncclRma_v14_init;
+    ncclRma.devices = ncclRma_v14->devices;
+    ncclRma.getProperties = ncclRma_v14->getProperties;
+    ncclRma.listen = ncclRma_v14->listen;
+    ncclRma.connect = ncclRma_v14->connect;
+    ncclRma.createContext = ncclRma_v14->createContext;
+    ncclRma.regMrSym = ncclRma_v14->regMrSym;
+    ncclRma.regMrSymDmaBuf = ncclRma_v14->regMrSymDmaBuf;
+    ncclRma.deregMrSym = ncclRma_v14->deregMrSym;
+    ncclRma.destroyContext = ncclRma_v14->destroyContext;
+    ncclRma.closeColl = ncclRma_v14->closeColl;
+    ncclRma.closeListen = ncclRma_v14->closeListen;
+    ncclRma.iput = ncclRma_v14_iput;
+    ncclRma.iputSignal = ncclRma_v14_iputSignal;
+    ncclRma.iget = ncclRma_v14_iget;
+    ncclRma.iflush = ncclRma_v14->iflush;
+    ncclRma.test = ncclRma_v14->test;
+    ncclRma.rmaProgress = ncclRma_v14->rmaProgress;
+    ncclRma.queryLastError = ncclRma_v14->queryLastError;
+    ncclRma.finalize = ncclRma_v14->finalize;
+    return &ncclRma;
   }
   return nullptr;
 }

--- a/src/plugin/rma/rma_v15.cc
+++ b/src/plugin/rma/rma_v15.cc
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "nccl_rma.h"
+#include "proxy.h"
+#include <dlfcn.h>
+
+static ncclRma_v15_t* ncclRma_v15;
+
+ncclRma_t* getNcclRma_v15(void* lib) {
+  ncclRma_v15 = (ncclRma_v15_t*)dlsym(lib, "ncclRmaPlugin_v15");
+  if (ncclRma_v15) {
+    INFO(NCCL_INIT | NCCL_NET, "RMA/Plugin: Loaded rma plugin %s (v15)", ncclRma_v15->name);
+    return ncclRma_v15;
+  }
+  return nullptr;
+}

--- a/src/rma/rma_proxy_progress.cc
+++ b/src/rma/rma_proxy_progress.cc
@@ -21,11 +21,11 @@ static ncclResult_t ncclRmaProxyIssuePutSignal(ncclRma_t* ncclRma, struct ncclRm
                                                struct ncclRmaPutSignalOp* ps) {
   if (ps->signal.op == 0) {
     NCCLCHECK(ncclRma->iput(ctx->rmaCtx, 0, ps->srcOff, ps->srcHandle, ps->size, ps->dstOff, ps->dstHandle,
-                            ps->targetRank, &ps->request));
+                            ps->targetRank, /*optFlags*/ 0, &ps->request));
   } else {
     NCCLCHECK(ncclRma->iputSignal(ctx->rmaCtx, 0, ps->srcOff, ps->srcHandle, ps->size, ps->dstOff, ps->dstHandle,
                                   ps->targetRank, ps->signal.offset, ps->signal.signalMhandle, ps->signal.val,
-                                  ps->signal.op, /*isStrongSignal*/ true, &ps->request));
+                                  ps->signal.op, /*isStrongSignal*/ true, /*optFlags*/ 0, &ps->request));
   }
   // Defensive: RMA proxy iput/iputSignal should return a non-NULL request with inflightReqeusts checked.
   if (ps->request == nullptr) {
@@ -155,7 +155,7 @@ static ncclResult_t ncclRmaProxyFlushNicGpuPath(ncclRma_t* ncclRma, struct ncclR
   void* request = nullptr;
   size_t flushOff = (size_t)ctx->comm->rank * sizeof(uint64_t);
   NCCLCHECK(ncclRma->iput(ctx->rmaCtx, 0, flushOff, ctx->flushBufMhandle, sizeof(uint64_t), flushOff,
-                          ctx->flushBufMhandle, ctx->comm->rank, &request));
+                          ctx->flushBufMhandle, ctx->comm->rank, /*optFlags*/ 0, &request));
   int done = 0;
   while (!done) {
     NCCLCHECK(ncclRma->test(ctx->rmaCollComm, request, &done));

--- a/src/transport/net_ib/gin.cc
+++ b/src/transport/net_ib/gin.cc
@@ -519,7 +519,9 @@ static ncclResult_t ncclRmaIbProxyGetRecvComm(struct ncclRmaIbProxyCtx* rmaProxy
 }
 
 ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
-                                uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
+                                uint64_t dstOff, void* dstMhandle, uint32_t rank, uint32_t optFlags,
+                                void** request) {
+  (void)optFlags;
   struct ncclRmaIbProxyCtx* rmaProxyCtx = &((struct ncclRmaIbProxyCtx*)rmaCtx)[context];
 
   struct ncclRmaIbProxyMrHandle* srcMrHandle = (struct ncclRmaIbProxyMrHandle*)srcMhandle;
@@ -571,7 +573,9 @@ ncclResult_t ncclRmaIbProxyIPut(void* rmaCtx, int context, uint64_t srcOff, void
 }
 
 ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset, void* remoteMhandle, size_t size,
-                                uint64_t localOffset, void* localMhandle, uint32_t rank, void** request) {
+                                uint64_t localOffset, void* localMhandle, uint32_t rank, uint32_t optFlags,
+                                void** request) {
+  (void)optFlags;
   struct ncclRmaIbProxyCtx* rmaProxyCtx = &((struct ncclRmaIbProxyCtx*)rmaCtx)[context];
 
   struct ncclRmaIbProxyMrHandle* remoteMrHandle = (struct ncclRmaIbProxyMrHandle*)remoteMhandle;
@@ -625,8 +629,9 @@ ncclResult_t ncclRmaIbProxyIGet(void* rmaCtx, int context, uint64_t remoteOffset
 ncclResult_t ncclRmaIbProxyIPutSignal(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
                                       uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
                                       void* signalMhandle, uint64_t signalValue, uint32_t signalOp, bool isStrongSignal,
-                                      void** request) {
+                                      uint32_t optFlags, void** request) {
   (void)isStrongSignal;
+  (void)optFlags;
   if (signalOp != NCCL_NET_SIGNAL_OP_INC && signalOp != NCCL_NET_SIGNAL_OP_ADD) {
     WARN("ncclRmaIbProxyIPutSignal: Unsupported signalOp %u", signalOp);
     return ncclInvalidArgument;


### PR DESCRIPTION
## Description

Plugins in the RMA/GIN Host Proxy path would benefit from being able to batch sends at the network level. This change bumps the RMA version and adds in logic for passing `optFlags` from the proxy through NCCL into the plugin, so the plugin can hold off on ringing the NIC doorbell when it knows more ops are coming. i.e. In Libfabric, an `FI_MORE` flag can be set to let the NIC know that more data is coming and to hold off on ringing the doorbell meaning a batch of ops rings one doorbell instead of one per op.

The proxy sets the hint by looking checking if the next slot on the GFD queue is already filled. If so then, more ops are in flight. It falls back to an aggregate bit the kernel can stamp in the GFD, which covers the terminal op of a batch where look-ahead can't see the next op yet.

Note the `FI_MORE` handling itself lives in the plugin (e.g. aws-ofi-nccl), not in this change — NCCL just plumbs the optFlags hint down to it.


## Changes & Impact

- Bumping up the RMA version from v14 -> v15 to add support for passing optFlags to the plugin. Older v14 plugins don't get the param and behave as before.
- Carved out an aggregation bit in the GFD header for aggregating writes via FI_MORE (guarded by a static_assert on the GFD version).
- Added look-ahead logic in the proxy to set the flag when it sees more data coming on the GFD queue.