### PR TITLE
init: do not reject a config that sets only minCTAs or only maxCTAs

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -2324,7 +2324,8 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
 
   if ((internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->minCTAs <= 0) ||
       (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs <= 0) ||
-      (internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
+      (internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT &&
+       internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
     WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs,
          internalConfigPtr->maxCTAs);
     ret = ncclInvalidArgument;


### PR DESCRIPTION
## Description

`parseCommConfig` validates the `minCTAs`/`maxCTAs` config fields with three clauses. The first two guard the unset sentinel `NCCL_CONFIG_UNDEF_INT` before their `<= 0` checks, but the third clause — `internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs` — does not. Unset config fields are `NCCL_CONFIG_UNDEF_INT` (`INT_MIN`), so a config that sets only `minCTAs` (leaving `maxCTAs` unset) makes `minCTAs > INT_MIN` true, and `ncclCommInitRankConfig` / `ncclCommSplit` reject an otherwise-valid configuration with `ncclInvalidArgument`. `minCTAs` and `maxCTAs` are documented as independently settable, so setting just one should be allowed.

## Related Issues

None.

## Changes & Impact

- `src/init.cc` (`parseCommConfig`): guard the `minCTAs > maxCTAs` comparison with the same `NCCL_CONFIG_UNDEF_INT` checks the two sibling clauses already use, so it only fires when both bounds are actually set. A genuinely inverted pair (e.g. `minCTAs=16, maxCTAs=4`) is still rejected. Non-breaking.

## Performance Impact

None.

### Testing

- Builds clean with `make src.build`.
- Single-GPU before/after with `ncclCommInitRankConfig` (1 rank), `config.minCTAs=4`, `maxCTAs` left unset:
  - **Before:** `init.cc NCCL WARN Invalid config min/max channels attribute value 4/-2147483648` → returns `ncclInvalidArgument` (`-2147483648` is the unset `maxCTAs` sentinel).
  - **After:** init returns `ncclSuccess`.
