### PR TITLE
register: restore caller CUDA device on all deregister exit paths

### DIFF
--- a/src/register/register.cc
+++ b/src/register/register.cc
@@ -177,26 +177,30 @@ ncclResult_t ncclCommGraphRegister(const ncclComm_t comm, void* buff, size_t siz
 static ncclResult_t commDeregister(struct ncclComm* comm, bool isGraph, struct ncclReg* reg) {
   NCCLCHECK(CommCheck(comm, "ncclCommRegister", "comm"));
   struct ncclRegCache* cache = &comm->regCache;
+  ncclResult_t ret = ncclSuccess;
   int slot;
-  int saveDev;
+  int saveDev = -1;
   if (reg == NULL) goto exit;
   CUDACHECK(cudaGetDevice(&saveDev));
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   for (slot = 0; slot < cache->population && cache->slots[slot] != reg; slot++);
   if (slot == cache->population) {
     WARN("Deregister: Could not find handle");
-    return ncclInvalidUsage;
+    ret = ncclInvalidUsage;
+    goto exit;
   }
   if (isGraph) --reg->graphRefs;
   else --reg->localRefs;
-  if (reg->localRefs || reg->graphRefs) return ncclSuccess;
-  NCCLCHECK(regCleanup(comm, reg));
+  if (reg->localRefs || reg->graphRefs) goto exit;
+  NCCLCHECKGOTO(regCleanup(comm, reg), ret, exit);
   free(reg);
   memmove(cache->slots + slot, cache->slots + slot + 1, (cache->population - slot - 1) * sizeof(struct ncclReg*));
   cache->population -= 1;
-  CUDACHECK(cudaSetDevice(saveDev));
 exit:
-  return ncclSuccess;
+  // Restore the caller's device on every path that switched it (saveDev stays
+  // -1 on the reg==NULL early-out, where no switch happened).
+  if (saveDev != -1) CUDACHECK(cudaSetDevice(saveDev));
+  return ret;
 }
 
 NCCL_API(ncclResult_t, ncclCommDeregister, const ncclComm_t comm, void* handle);


### PR DESCRIPTION
## Description

`commDeregister` (the implementation behind the public `ncclCommDeregister` and `ncclCommGraphDeregister`) saves the caller's current CUDA device and switches to the communicator's device:

```c
CUDACHECK(cudaGetDevice(&saveDev));
CUDACHECK(cudaSetDevice(comm->cudaDev));
```

but only restores it on the success fall-through. Three paths between the switch and the restore return without restoring:

- handle not found — `return ncclInvalidUsage`;
- refs still held — `if (reg->localRefs || reg->graphRefs) return ncclSuccess` — the case where a buffer was registered more than once (or both locally and for a graph);
- `regCleanup` failure — `NCCLCHECK(regCleanup(...))`.

On those paths the calling host thread is left on `comm->cudaDev`. A subsequent `cudaMalloc` / `cudaMemcpy` / kernel launch the user issues on that thread without an explicit `cudaSetDevice` then targets the wrong GPU — silent wrong-device allocation/execution, not a crash. The public deregister API is expected to be neutral with respect to the caller's current device.

## Related Issues

None.

## Changes & Impact

- `src/register/register.cc` (`commDeregister`): route every post-switch exit through a single `exit:` label that restores the saved device — guarded by `saveDev`, which stays `-1` on the `reg == NULL` early-out where no switch happened — and return an accumulated `ret`. This mirrors the established save/switch/restore idiom used elsewhere (e.g. `ncclMemFree` in `src/allocator.cc`). The success path is unchanged; the not-found / refs-remaining / cleanup-failure paths now also restore the device. Non-breaking.

## Performance Impact

None.

### Testing

- Builds clean with `make src.build`; `all_reduce_perf` regression: `Out of bounds values : 0 OK`.
- The defect is evident against the codebase's own idiom (`ncclMemFree`): the original restore sat before the `exit:` label, so the early returns bypassed it. Observing the wrong-device effect at runtime requires ≥2 GPUs (so `comm->cudaDev` differs from the caller's device); the change is behavior-preserving on the success path and on single-device setups.
