### PR TITLE
collnet: size shared collNet comm arrays by NCCL_MAX_NETDEVS

### DIFF
--- a/src/transport/coll_net.cc
+++ b/src/transport/coll_net.cc
@@ -355,8 +355,10 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
 }
 
 struct sharedResources {
-  void* collNetListenComms[MAXCHANNELS];
-  void* collNetComms[MAXCHANNELS];
+  // These are all indexed by netDev (in [0, NCCL_MAX_NETDEVS)), like commRefCount
+  // below and the sibling proxyAppend / regular-net netComms arrays.
+  void* collNetListenComms[NCCL_MAX_NETDEVS];
+  void* collNetComms[NCCL_MAX_NETDEVS];
   int commRefCount[NCCL_MAX_NETDEVS];
 };
 


### PR DESCRIPTION
## Description

In the collnet transport, `struct sharedResources` sizes `collNetListenComms` and `collNetComms` by `MAXCHANNELS` (64), but indexes them by `netDev`, which ranges over `[0, NCCL_MAX_NETDEVS)` (128). The same `netDev` indexes the adjacent `commRefCount[NCCL_MAX_NETDEVS]` in the very same struct, the sibling `ncclCollNetSharedRes::proxyAppend[2*NCCL_MAX_NETDEVS]`, and the regular-net `ncclProxyProgressState::netComms[NCCL_MAX_NETDEVS]` — all sized by `NCCL_MAX_NETDEVS`. So on a host where the selected collnet `netDev` index is `>= 64`, `sharedListen` / `sharedConnect` / `sharedFree` read and write `collNetComms[netDev]` / `collNetListenComms[netDev]` past the end of the 64-element arrays, into the neighbouring `commRefCount` field and beyond — a heap out-of-bounds access, not a clean assert.

## Related Issues

None.

## Changes & Impact

- `src/transport/coll_net.cc` (`struct sharedResources`): size `collNetListenComms` and `collNetComms` by `NCCL_MAX_NETDEVS`, matching their `netDev` index domain (and `commRefCount` / `proxyAppend` / `netComms`). The `ncclCalloc`-allocated struct grows by ~1 KB; indices 0–63 are byte-identical, only the previously-out-of-bounds 64–127 range is now valid storage. Non-breaking.

## Performance Impact

None.

### Testing

- Builds clean with `make src.build`; `all_reduce_perf` regression: `Out of bounds values : 0 OK`.
- The mismatch is provable statically (a `static_assert(NCCL_MAX_NETDEVS <= MAXCHANNELS)` would fail to compile) and from the three sibling arrays keyed on the same `netDev`. The overrun only triggers with >64 collnet-capable NICs on one host, which cannot be reproduced on a single-GPU machine.
