### PR TITLE
ras: include ncclTimeout in the client error breakdown

### DIFF
--- a/src/ras/client_support.cc
+++ b/src/ras/client_support.cc
@@ -1687,7 +1687,8 @@ static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollCom
   for (;;) {
     int maxCount = 0;
     ncclResult_t maxCountIdx = ncclSuccess;
-    for (int i = ncclUnhandledCudaError; i < ncclInProgress; i++) {
+    for (int i = ncclUnhandledCudaError; i < ncclNumResults; i++) {
+      if (i == ncclInProgress) continue; // not an error; loop now reaches ncclTimeout (enum value after ncclInProgress)
       if (maxCount < ncclErrors[i]) {
         maxCount = ncclErrors[i];
         maxCountIdx = (ncclResult_t)i;
@@ -2074,6 +2075,8 @@ static const char* ncclErrorToString(ncclResult_t err) {
     return "Remote process error";
   case ncclInProgress:
     return "NCCL operation in progress";
+  case ncclTimeout:
+    return "Timeout";
   default:
     return "Unexpected error";
   }


### PR DESCRIPTION
## Description

`rasClientBreakDownErrors` enumerates the most-frequent NCCL error codes among a communicator's ranks with `for (int i = ncclUnhandledCudaError; i < ncclInProgress; i++)`. That bound stops at `ncclRemoteError` (6) and never visits `ncclTimeout` (8), which sorts *after* `ncclInProgress` (7) in `ncclResult_t`. But the headline count is computed as `nRanks - (ncclErrors[ncclSuccess] + ncclErrors[ncclInProgress])`, which *does* include timeout ranks. So when one or more ranks report `ncclTimeout`, the RAS report states "Asynchronous error on N ranks" while the per-rank breakdown lists fewer than N — the timeout ranks are attributed to no rank/GPU/node. Separately, `ncclErrorToString` has no `ncclTimeout` case and falls through to "Unexpected error".

## Related Issues

None.

## Changes & Impact

- `src/ras/client_support.cc`: loop to `ncclNumResults` while skipping `ncclInProgress`, so `ncclTimeout` is included in the breakdown; and add the missing `ncclTimeout` case to `ncclErrorToString`. Diagnostic / serviceability output only; no data-path effect. Non-breaking.

## Performance Impact

None.

### Testing

- Builds clean with `make src.build`; `all_reduce_perf` regression: `Out of bounds values : 0 OK`.
- The omission is evident from the enum order (`ncclTimeout = 8 > ncclInProgress = 7`) versus the loop bound; the header/breakdown disagreement appears only when a rank reports `ncclTimeout`.
