### PR TITLE
net_ib: use uint32 truncation (not % UINT32_MAX) for BY_ID imm-data request id

### DIFF
--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -125,7 +125,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   // - nreqs > 1
   //      Send size is still sent but receiver ignores it since the sizes are
   //      written to directly to remote completion records array
-  uint32_t immData = comm->base.recvMatchingScheme == BY_ID ? (uint32_t)(reqs[0]->id % UINT32_MAX) : reqs[0]->send.size;
+  uint32_t immData = comm->base.recvMatchingScheme == BY_ID ? (uint32_t)reqs[0]->id : reqs[0]->send.size;
 
   struct ibv_send_wr* lastWr = comm->wrs + nreqs - 1;
   if (nreqs > 1 ||


### PR DESCRIPTION
## Description

In `ncclIbMultiSend`, the BY_ID matching scheme packs the request id into the 32-bit RDMA imm-data as `reqs[0]->id % UINT32_MAX` — i.e. modulo 2^32−1 — rather than natural `uint32_t` truncation (modulo 2^32). The two agree for every id in `[0, 2^32−2]`, but diverge at the wrap: `id == 2^32−1` yields 0 under the modulus versus `0xFFFFFFFF` under truncation, and they stay out of step beyond that. The receiver matches completions using the id as a `uint32_t`, so after 2^32−1 send operations on a communicator the transmitted imm-data no longer matches the receiver's expected request id, and a completion is matched to the wrong request.

## Related Issues

None.

## Changes & Impact

- `src/transport/net_ib/p2p.cc` (`ncclIbMultiSend`): use the plain `(uint32_t)` cast (natural 2^32 truncation), matching the receiver-side id handling. The value is identical for all ids below 2^32−1, so normal operation is unaffected; only the counter-wrap case is corrected. Non-breaking.

## Performance Impact

None.

### Testing

- Builds clean with `make src.build`; `all_reduce_perf` regression: `Out of bounds values : 0 OK`.
- The divergence is provable arithmetically (256 divides 2^32 but not 2^32−1). Triggering it requires ~4.3 billion ops on a single communicator, so it cannot be exercised quickly on one GPU; the change is a no-op for every id below the wrap.
