### PR TITLE
net_ib: add missing break in printIbWcStatusHint switch

### DIFF
--- a/src/transport/net_ib/common.h
+++ b/src/transport/net_ib/common.h
@@ -616,14 +616,17 @@ static inline void printIbWcStatusHint(int status) {
          "HINT: In many cases this error occurs when ACS is enabled which would break GPU Direct RDMA protocol.");
     INFO(NCCL_NET, "HINT: To confirm and fix the problem, you can set NCCL_NET_GDR_LEVEL=0 to disable ACS following "
                    "vendor documentation.");
+    break;
   case IBV_WC_WR_FLUSH_ERR:
     INFO(NCCL_NET, "HINT: In many cases this error occurs when NIC on the same instance cannot talk to each other.");
+    break;
   case IBV_WC_RETRY_EXC_ERR:
     INFO(NCCL_NET, "HINT: In many cases this error occurs when the NCCL_IB_TIMEOUT is set too short.");
     INFO(NCCL_NET, "HINT: Default value is 20, which is ~30 seconds before error.");
     INFO(NCCL_NET, "HINT: To confirm, try increasing the value of NCCL_IB_TIMEOUT and see if the error persists.");
     INFO(NCCL_NET, "HINT: See https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-ib-timeout for "
                    "more information.");
+    break;
   default:
     break;
   }


### PR DESCRIPTION
## Description

`printIbWcStatusHint` is a `switch` on the IB work-completion status whose `IBV_WC_LOC_PROT_ERR`, `IBV_WC_WR_FLUSH_ERR` and `IBV_WC_RETRY_EXC_ERR` cases lack a `break`. Because they fall through, a single completion error prints its own hint plus the hints of every case below it — e.g. a local protection error (`IBV_WC_LOC_PROT_ERR`) also advises that "NCCL_IB_TIMEOUT is set too short", which is unrelated and misleading when debugging.

## Related Issues

None.

## Changes & Impact

- `src/transport/net_ib/common.h` (`printIbWcStatusHint`): add `break;` to each of the three cases so only the hint matching the actual completion status is printed. Diagnostic output only; no behavior change beyond the log text. Non-breaking.

## Performance Impact

None.

### Testing

- Builds clean with `make src.build`; `all_reduce_perf` regression: `Out of bounds values : 0 OK`.
- The fall-through is evident from the missing `break;`; the fix limits each completion status to its own hint.
