### PR TITLE
nccl4py/cute: Add CuTe DSL support for several GIN APIs

### DIFF
--- a/bindings/nccl4py/nccl/core/device/cute/_bindings.py
+++ b/bindings/nccl4py/nccl/core/device/cute/_bindings.py
@@ -220,6 +220,126 @@ def ncclGinPut(gin_ptr, team, peer, dst_win, dst_offset, src_win, src_offset,
     )
 
 
+_raw_ncclGinPutValue = _ffi(
+    name="ncclGinPutValue",
+    params_types=[
+        _LLVMPtrType,        # ncclGin_C* gin
+        ncclTeam,            # team
+        cutlass.Int32,       # peer
+        _LLVMPtrType,        # dst window
+        cutlass.Int64,       # dst offset
+        cutlass.Int64,       # value
+        cutlass.Int64,       # size
+        cutlass.Boolean,     # is_signal
+        cutlass.Int32,       # signal_id
+        cutlass.Int32,       # signal_op
+        cutlass.Int64,       # signal_op_arg
+        ncclCoopAny,         # coop
+        cutlass.Boolean,     # is_descriptor
+        _LLVMPtrType,        # descriptor_ptr
+        cutlass.Int32,       # given_release
+        cutlass.Int32,       # required_release
+    ])
+
+def ncclGinPutValue(gin_ptr, team, peer, dst_win, dst_offset, value, size,
+                    is_signal, signal_id, signal_op, signal_op_arg, coop,
+                    is_descriptor, descriptor_ptr,
+                    given_release, required_release):
+    _raw_ncclGinPutValue(
+        _to_ptr(gin_ptr), team, cutlass.Int32(peer),
+        _to_ptr(dst_win), cutlass.Int64(dst_offset),
+        cutlass.Int64(value), cutlass.Int64(size),
+        cutlass.Boolean(is_signal), cutlass.Int32(signal_id),
+        cutlass.Int32(signal_op), cutlass.Int64(signal_op_arg),
+        _to_coop_value(coop),
+        cutlass.Boolean(is_descriptor), _to_ptr(descriptor_ptr),
+        cutlass.Int32(given_release), cutlass.Int32(required_release),
+    )
+
+
+_raw_ncclGinGet = _ffi(
+    name="ncclGinGet",
+    params_types=[
+        _LLVMPtrType,        # ncclGin_C* gin
+        ncclTeam,            # team
+        cutlass.Int32,       # peer
+        _LLVMPtrType,        # remote window
+        cutlass.Int64,       # remote offset
+        _LLVMPtrType,        # local window
+        cutlass.Int64,       # local offset
+        cutlass.Int64,       # size
+        ncclCoopAny,         # coop
+        cutlass.Boolean,     # is_descriptor
+        _LLVMPtrType,        # descriptor_ptr
+        cutlass.Int32,       # opt_flags
+    ])
+
+def ncclGinGet(gin_ptr, team, peer, remote_win, remote_offset, local_win,
+               local_offset, size, coop, is_descriptor, descriptor_ptr,
+               opt_flags):
+    _raw_ncclGinGet(
+        _to_ptr(gin_ptr), team, cutlass.Int32(peer),
+        _to_ptr(remote_win), cutlass.Int64(remote_offset),
+        _to_ptr(local_win), cutlass.Int64(local_offset),
+        cutlass.Int64(size),
+        _to_coop_value(coop),
+        cutlass.Boolean(is_descriptor), _to_ptr(descriptor_ptr),
+        cutlass.Int32(opt_flags),
+    )
+
+
+_raw_ncclGinFlush = _ffi(
+    name="ncclGinFlush",
+    params_types=[_LLVMPtrType, ncclCoopAny, cutlass.Int32])
+
+def ncclGinFlush(gin_ptr, coop, ord):
+    _raw_ncclGinFlush(
+        _to_ptr(gin_ptr), _to_coop_value(coop), cutlass.Int32(ord),
+    )
+
+
+_raw_ncclGinSignal = _ffi(
+    name="ncclGinSignal",
+    params_types=[
+        _LLVMPtrType,        # ncclGin_C* gin
+        ncclTeam,            # team
+        cutlass.Int32,       # peer
+        cutlass.Boolean,     # is_signal
+        cutlass.Int32,       # signal_id
+        cutlass.Int32,       # signal_op
+        cutlass.Int64,       # signal_op_arg
+        ncclCoopAny,         # coop
+        cutlass.Boolean,     # is_descriptor
+        _LLVMPtrType,        # descriptor_ptr
+        cutlass.Int32,       # given_release
+        cutlass.Int32,       # required_release
+    ])
+
+def ncclGinSignal(gin_ptr, team, peer, is_signal, signal_id, signal_op, signal_op_arg,
+                  coop, is_descriptor, descriptor_ptr, given_release, required_release):
+    _raw_ncclGinSignal(
+        _to_ptr(gin_ptr), team, cutlass.Int32(peer),
+        cutlass.Boolean(is_signal), cutlass.Int32(signal_id),
+        cutlass.Int32(signal_op), cutlass.Int64(signal_op_arg),
+        _to_coop_value(coop),
+        cutlass.Boolean(is_descriptor), _to_ptr(descriptor_ptr),
+        cutlass.Int32(given_release), cutlass.Int32(required_release),
+    )
+
+
+_raw_ncclGinReadSignal = _ffi(
+    name="ncclGinReadSignal",
+    params_types=[_LLVMPtrType, cutlass.Int32, cutlass.Int32, cutlass.Int32],
+    return_type=cutlass.Int64,
+)
+
+def ncclGinReadSignal(gin_ptr, signal_id, bits, ord):
+    return cutlass.Int64(_raw_ncclGinReadSignal(
+        _to_ptr(gin_ptr), cutlass.Int32(signal_id),
+        cutlass.Int32(bits), cutlass.Int32(ord),
+    ))
+
+
 _raw_ncclGinWaitSignal = _ffi(
     name="ncclGinWaitSignal",
     params_types=[

--- a/bindings/nccl4py/nccl/core/device/cute/gin.py
+++ b/bindings/nccl4py/nccl/core/device/cute/gin.py
@@ -63,8 +63,8 @@ class Gin:
         counter_id: int = 0,
         is_descriptor: bool = False,
         descriptor_ptr=0,
-        given_release: int = 0,
-        required_release: int = 3,
+        given_release: int = 3,
+        required_release: int = 1,
     ) -> None:
         """Put ``src`` to ``dst`` on ``peer`` of ``team``.
 

--- a/bindings/nccl4py/nccl/core/device/cute/gin.py
+++ b/bindings/nccl4py/nccl/core/device/cute/gin.py
@@ -107,6 +107,160 @@ class Gin:
             given_release, required_release,
         )
 
+    def put_value(
+        self,
+        team: ncclTeam,
+        peer: int,
+        dst_win,
+        dst,
+        value: int,
+        coop: ncclCoopAny,
+        *,
+        is_signal: bool = False,
+        signal_id: int = 0,
+        signal_op: int = 0,
+        signal_op_arg: int = 0,
+        is_descriptor: bool = False,
+        descriptor_ptr=0,
+        given_release: int = 3,
+        required_release: int = 1,
+    ) -> None:
+        """Put scalar ``value`` to ``dst`` on ``peer`` of ``team``.
+
+        ``dst`` is a ``cute.Tensor`` instance from :meth:`Window.tensor`;
+        its byte offset and element size are derived from it.
+
+        Args:
+            team: addressing domain.
+            peer: destination rank within ``team``.
+            dst_win: destination :class:`Window`.
+            dst: destination ``cute.Tensor`` inside ``dst_win``.
+            value: scalar value to transfer using ``dst``'s element size.
+            coop: cooperative group issuing the put.
+            is_signal: write ``signal_id`` after the transfer completes.
+            signal_id: signal slot id (when ``is_signal``).
+            signal_op: signal op code per the C ABI (when ``is_signal``).
+            signal_op_arg: argument to ``signal_op`` (when ``is_signal``).
+            is_descriptor: ``descriptor_ptr`` carries an external descriptor.
+            descriptor_ptr: descriptor pointer (when ``is_descriptor``).
+            given_release: release-fence flags from the caller.
+            required_release: release-fence flags required by the op.
+        """
+        # Window.local_pointer returns a raw !llvm.ptr; wrap it via cute.make_ptr
+        # so both sides expose .toint() and we can subtract uniformly. dtype is
+        # Int8 to make the resulting subtraction a byte offset.
+        dst_base = cute.make_ptr(cutlass.Int8, dst_win.local_pointer(0))
+        dst_offset = dst.iterator.toint() - dst_base.toint()
+        size = dst.element_type.width // 8
+        raw.ncclGinPutValue(
+            self.ptr, team, peer, dst_win, dst_offset, value, size,
+            is_signal, signal_id, signal_op, signal_op_arg,
+            coop, is_descriptor, descriptor_ptr,
+            given_release, required_release,
+        )
+
+    def get(
+        self,
+        team: ncclTeam,
+        peer: int,
+        remote_win,
+        remote,
+        local_win,
+        local,
+        coop: ncclCoopAny,
+        *,
+        is_descriptor: bool = False,
+        descriptor_ptr=0,
+        opt_flags: int = 0,
+    ) -> None:
+        """Get ``remote`` to ``local`` from ``peer`` of ``team``.
+
+        ``remote`` / ``local`` are ``cute.Tensor`` instances from
+        :meth:`Window.tensor`; byte offsets and transfer size are derived
+        from them. ``remote`` and ``remote_win`` must have the same byte size.
+
+        Args:
+            team: addressing domain.
+            peer: source rank within ``team``.
+            remote_win: source :class:`Window` (remote).
+            remote: source ``cute.Tensor`` inside ``remote_win``.
+            local_win: destination :class:`Window` (local).
+            local: destination ``cute.Tensor`` inside ``local_win``.
+            coop: cooperative group issuing the get.
+            is_descriptor: ``descriptor_ptr`` carries an external descriptor.
+            descriptor_ptr: descriptor pointer (when ``is_descriptor``).
+            opt_flags: GIN operation flags. Default 0.
+        """
+        # Window.local_pointer returns a raw !llvm.ptr; wrap it via cute.make_ptr
+        # so both sides expose .toint() and we can subtract uniformly. dtype is
+        # Int8 to make the resulting subtraction a byte offset.
+        remote_base = cute.make_ptr(cutlass.Int8, remote_win.local_pointer(0))
+        local_base = cute.make_ptr(cutlass.Int8, local_win.local_pointer(0))
+        remote_offset = remote.iterator.toint() - remote_base.toint()
+        local_offset = local.iterator.toint() - local_base.toint()
+        size = (local.element_type.width // 8) * cute.size(local)
+        raw.ncclGinGet(
+            self.ptr, team, peer, remote_win, remote_offset, local_win, local_offset, size,
+            coop, is_descriptor, descriptor_ptr,
+            opt_flags,
+        )
+
+    def signal(
+        self,
+        team: ncclTeam,
+        peer: int,
+        is_signal: bool,
+        signal_id: int,
+        signal_op: int,
+        signal_op_arg: int,
+        coop: ncclCoopAny,
+        *,
+        is_descriptor: bool = False,
+        descriptor_ptr=0,
+        given_release: int = 3,
+        required_release: int = 1,
+    ) -> None:
+        """Signal a GIN operation.
+
+        Args:
+            team: addressing domain.
+            peer: destination rank within ``team``.
+            is_signal: write ``signal_id`` after the transfer completes.
+            signal_id: signal slot id (when ``is_signal``).
+            signal_op: signal op code per the C ABI (when ``is_signal``).
+            signal_op_arg: argument to ``signal_op`` (when ``is_signal``).
+            coop: cooperative group issuing the signal.
+            is_descriptor: ``descriptor_ptr`` carries an external descriptor.
+            descriptor_ptr: descriptor pointer (when ``is_descriptor``).
+            given_release: release-fence flags from the caller.
+            required_release: release-fence flags required by the op.
+        """
+        raw.ncclGinSignal(
+            self.ptr, team, peer, is_signal, signal_id, signal_op, signal_op_arg,
+            coop, is_descriptor, descriptor_ptr, given_release, required_release,
+    )
+
+    def read_signal(
+        self,
+        *,
+        signal: int = 0,
+        bits: int = 64,
+        ord: int = 2,
+    ) -> cutlass.Int64:
+        """Read the value of a GIN signal slot.
+
+        Args:
+            signal: signal slot id (matches ``signal_id`` of the producing
+                :meth:`put`). Default 0.
+            bits: signal slot width in bits (currently 64).
+            ord: ``cuda::memory_order`` integer; default 2 = ``ACQUIRE``.
+                See :class:`~nccl.core.device.cute.types.MemoryOrder`.
+
+        Returns:
+            value of the signal slot.
+        """
+        return raw.ncclGinReadSignal(self.ptr, signal, bits, ord)
+
     def wait_signal(
         self,
         coop: ncclCoopAny,
@@ -128,6 +282,16 @@ class Gin:
                 See :class:`~nccl.core.device.cute.types.MemoryOrder`.
         """
         raw.ncclGinWaitSignal(self.ptr, coop, signal, least, bits, ord)
+
+    def flush(self, coop: ncclCoopAny, ord: int = 2) -> None:
+        """Flush pending GIN operations.
+
+        Args:
+            coop: cooperative group issuing the flush.
+            ord: ``cuda::memory_order`` integer; default 2 = ``ACQUIRE``.
+                See :class:`~nccl.core.device.cute.types.MemoryOrder`.
+        """
+        raw.ncclGinFlush(self.ptr, coop, ord)
 
     @dsl_user_op
     def value(self, *, loc=None, ip=None) -> ncclGin_C:


### PR DESCRIPTION
## Description

This pull request adds support for several GIN APIs missing in the initial release. They can be supported by (trivially) adding FFI entries and wrappers to existing APIs available in IR bindings. New APIs supported in this PR includes `get`, `flush`, `signal`, `read_signal` and `put_value`. A small fix is also included to match the `gin.get` default semantics to CUDA C++ API so that the new `put_value` API would be consistent with it.

## Related Issues

N/A

## Changes & Impact

* The default release semantics of CuTe DSL `Gin.put` is modified to match CUDA C++ API
* Several other APIs are introduced to CuTe DSL `Gin` class, including `get`, `flush`, `signal`, `read_signal` and `put_value`.

## Performance Impact

We conducted several internal demos and benchmarks using the new API and have been successful so far.

