### PR TITLE
Add GIN GPU/NIC peer affinity mapping

### DIFF
--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -321,6 +321,12 @@ static int ginRankToWorldRank(struct ncclComm* comm, ncclGinConnectionType_t con
   return ncclTeamRankToWorld(comm, railTeam, ginRank);
 }
 
+static bool ginPeerOnSameNode(struct ncclComm* comm, int peerWorldRank) {
+  if (peerWorldRank == comm->rank) return true;
+  if (comm->rankToNode != NULL) return comm->rankToNode[peerWorldRank] == comm->node;
+  return comm->peerInfo[peerWorldRank].hostHash == comm->peerInfo[comm->rank].hostHash;
+}
+
 static int findConnByName(ncclGinRankInfo const* info, char const* name, int connCount) {
   for (int c = 0; c < connCount; c++) {
     if (strcmp(info->conns[c].name, name) == 0) return c;
@@ -445,7 +451,7 @@ static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, 
         return ncclInternalError;
       }
       for (int lc = 0; lc < ginState->ginCommCount; lc++) {
-        if (peer == myGinRank) {
+        if (ginPeerOnSameNode(comm, peerWorld)) {
           ginState->remoteConnByPeer[lc * nGinRanks + peer] = lc;
           continue;
         }

--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -328,8 +328,17 @@ static int findConnByName(ncclGinRankInfo const* info, char const* name, int con
   return -1;
 }
 
-static ncclResult_t getPeerAffinityTarget(std::vector<std::pair<std::string, std::string>> const& entries,
-                                          char const* localName, std::string* target) {
+static std::string joinNicList(std::vector<std::string> const& names) {
+  std::string joined;
+  for (size_t i = 0; i < names.size(); i++) {
+    if (i != 0) joined += ",";
+    joined += names[i];
+  }
+  return joined;
+}
+
+static ncclResult_t getPeerAffinityTargets(std::vector<std::pair<std::string, std::string>> const& entries,
+                                           char const* localName, std::vector<std::string>* targets) {
   bool found = false;
   for (size_t i = 0; i < entries.size(); i++) {
     if (entries[i].first == localName) {
@@ -337,7 +346,7 @@ static ncclResult_t getPeerAffinityTarget(std::vector<std::pair<std::string, std
         WARN("NCCL_NIC_PEER_AFFINITY has multiple entries for NIC '%s'", localName);
         return ncclInvalidUsage;
       }
-      *target = entries[i].second;
+      NCCLCHECK(splitNicList("NCCL_NIC_PEER_AFFINITY", entries[i].second, *targets));
       found = true;
     }
   }
@@ -346,6 +355,26 @@ static ncclResult_t getPeerAffinityTarget(std::vector<std::pair<std::string, std
     return ncclInvalidUsage;
   }
   return ncclSuccess;
+}
+
+static ncclResult_t selectPeerAffinityConn(std::vector<std::pair<std::string, std::string>> const& entries,
+                                           char const* localName, ncclGinRankInfo const* peerInfo, int connCount,
+                                           int peerWorld, int* remoteConn, std::string* targetName) {
+  std::vector<std::string> targets;
+  NCCLCHECK(getPeerAffinityTargets(entries, localName, &targets));
+  for (size_t i = 0; i < targets.size(); i++) {
+    int conn = findConnByName(peerInfo, targets[i].c_str(), connCount);
+    if (conn >= 0) {
+      *remoteConn = conn;
+      *targetName = targets[i];
+      return ncclSuccess;
+    }
+  }
+  std::string targetList = joinNicList(targets);
+  WARN("NCCL_NIC_PEER_AFFINITY maps local NIC '%s' to peer NIC candidates '%s', but peer world rank %d did not select "
+       "any of them.",
+       localName, targetList.c_str(), peerWorld);
+  return ncclInvalidUsage;
 }
 
 static ncclResult_t validatePeerAffinitySelectedGinNames(
@@ -370,8 +399,8 @@ static ncclResult_t validatePeerAffinitySelectedGinNames(
       }
     }
     for (int c = 0; c < ginState->ginCommCount; c++) {
-      std::string unusedTarget;
-      NCCLCHECK(getPeerAffinityTarget(peerEntries, peerInfo->conns[c].name, &unusedTarget));
+      std::vector<std::string> unusedTargets;
+      NCCLCHECK(getPeerAffinityTargets(peerEntries, peerInfo->conns[c].name, &unusedTargets));
     }
   }
   return ncclSuccess;
@@ -421,18 +450,17 @@ static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, 
           continue;
         }
         std::string targetName;
-        NCCLCHECK(getPeerAffinityTarget(peerEntries, ginState->localGinNames[lc], &targetName));
-        int remoteConn = findConnByName(peerInfo, targetName.c_str(), ginState->ginCommCount);
-        if (remoteConn < 0) {
-          WARN("NCCL_NIC_PEER_AFFINITY maps local NIC '%s' to peer NIC '%s', but peer world rank %d did not select it.",
-               ginState->localGinNames[lc], targetName.c_str(), peerWorld);
-          return ncclInvalidUsage;
-        }
+        int remoteConn = -1;
+        NCCLCHECK(selectPeerAffinityConn(peerEntries, ginState->localGinNames[lc], peerInfo, ginState->ginCommCount,
+                                         peerWorld, &remoteConn, &targetName));
 
         std::string reciprocalTarget;
-        NCCLCHECK(getPeerAffinityTarget(peerEntries, peerInfo->conns[remoteConn].name, &reciprocalTarget));
-        if (reciprocalTarget != ginState->localGinNames[lc]) {
-          WARN("NCCL_NIC_PEER_AFFINITY must be reciprocal: local '%s' -> peer '%s', but peer '%s' -> '%s'",
+        int reciprocalConn = -1;
+        ncclGinRankInfo* localInfo = allRankInfo + comm->rank;
+        NCCLCHECK(selectPeerAffinityConn(peerEntries, peerInfo->conns[remoteConn].name, localInfo,
+                                         ginState->ginCommCount, comm->rank, &reciprocalConn, &reciprocalTarget));
+        if (reciprocalConn != lc) {
+          WARN("NCCL_NIC_PEER_AFFINITY must be reciprocal: local '%s' -> peer '%s', but peer '%s' selects local '%s'",
                ginState->localGinNames[lc], targetName.c_str(), peerInfo->conns[remoteConn].name,
                reciprocalTarget.c_str());
           return ncclInvalidUsage;

--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -445,6 +445,10 @@ static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, 
         return ncclInternalError;
       }
       for (int lc = 0; lc < ginState->ginCommCount; lc++) {
+        if (peer == myGinRank) {
+          ginState->remoteConnByPeer[lc * nGinRanks + peer] = lc;
+          continue;
+        }
         std::string targetName;
         int remoteConn = -1;
         NCCLCHECK(selectPeerAffinityConn(peerEntries, ginState->localGinNames[lc], peerInfo, ginState->ginCommCount,

--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -440,7 +440,7 @@ static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, 
     NCCLCHECK(parseAffinityPairs("NCCL_NIC_PEER_AFFINITY", peerEntries));
     NCCLCHECK(validateUniqueAffinityKeys("NCCL_NIC_PEER_AFFINITY", peerEntries));
     NCCLCHECK(validatePeerAffinitySelectedGinNames(comm, ginState, nGinRanks, allRankInfo, peerEntries));
-    ginState->nicPeerAffinityEnabled = true;
+    bool hasNonIdentityRemoteConn = false;
 
     for (int peer = 0; peer < nGinRanks; peer++) {
       int peerWorld = ginRankToWorldRank(comm, ginState->ginConnectionType, peer);
@@ -472,7 +472,14 @@ static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, 
           return ncclInvalidUsage;
         }
         ginState->remoteConnByPeer[lc * nGinRanks + peer] = remoteConn;
+        if (remoteConn != lc) hasNonIdentityRemoteConn = true;
       }
+    }
+    ginState->nicPeerAffinityEnabled = hasNonIdentityRemoteConn;
+    if (!ginState->nicPeerAffinityEnabled) {
+      INFO(NCCL_INIT | NCCL_NET,
+           "GIN affinity: NCCL_NIC_PEER_AFFINITY resolved to identity remote connections; using per-connection GDAKI "
+           "context setup");
     }
   }
 

--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -14,7 +14,15 @@
 #include "gin/gin_host.h"
 #include "gin/gin_host_proxy.h"
 #include "compiler.h"
+#include <algorithm>
+#include <cctype>
+#include <climits>
+#include <cstring>
 #include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+#include <cuda_runtime_api.h>
 
 NCCL_PARAM(GinEnable, "GIN_ENABLE", 1);
 NCCL_PARAM(DevApiJit, "DEV_API_JIT", 0);
@@ -77,6 +85,381 @@ void* ncclGinProgress(struct ncclGinState* ginState_) {
 
 NCCL_PARAM(GinNconnections, "GIN_NCONNECTIONS", -2);
 
+static bool envIsSet(const char* envName) {
+  const char* env = ncclGetEnv(envName);
+  return env != NULL && env[0] != '\0';
+}
+
+struct ncclGinConnInfo {
+  int ginDev;
+  uint64_t guid;
+  int16_t planeId;
+  char name[NCCL_GIN_NIC_NAME_MAX];
+};
+
+struct ncclGinRankInfo {
+  int connCount;
+  ncclGinConnInfo conns[NCCL_GIN_MAX_CONNECTIONS];
+};
+
+struct ncclGinDevName {
+  int dev;
+  char name[NCCL_GIN_NIC_NAME_MAX];
+};
+
+static std::string trimString(std::string const& s) {
+  size_t b = 0;
+  while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b]))) b++;
+  size_t e = s.size();
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1]))) e--;
+  return s.substr(b, e - b);
+}
+
+static ncclResult_t parseAffinityPairs(const char* envName, std::vector<std::pair<std::string, std::string>>& pairs) {
+  const char* env = ncclGetEnv(envName);
+  if (env == NULL || env[0] == '\0') return ncclSuccess;
+
+  std::string text(env);
+  size_t pos = 0;
+  while (pos <= text.size()) {
+    size_t end = text.find(';', pos);
+    std::string entry = trimString(text.substr(pos, end == std::string::npos ? std::string::npos : end - pos));
+    if (!entry.empty()) {
+      size_t eq = entry.find('=');
+      if (eq == std::string::npos) {
+        WARN("%s entry '%s' is missing '='", envName, entry.c_str());
+        return ncclInvalidUsage;
+      }
+      std::string key = trimString(entry.substr(0, eq));
+      std::string value = trimString(entry.substr(eq + 1));
+      if (key.empty() || value.empty()) {
+        WARN("%s entry '%s' has empty key or value", envName, entry.c_str());
+        return ncclInvalidUsage;
+      }
+      pairs.push_back(std::make_pair(key, value));
+    }
+    if (end == std::string::npos) break;
+    pos = end + 1;
+  }
+  if (pairs.empty()) {
+    WARN("%s is set but contains no entries", envName);
+    return ncclInvalidUsage;
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t validateUniqueAffinityKeys(const char* envName,
+                                               std::vector<std::pair<std::string, std::string>> const& pairs) {
+  for (size_t i = 0; i < pairs.size(); i++) {
+    for (size_t j = i + 1; j < pairs.size(); j++) {
+      if (pairs[i].first == pairs[j].first) {
+        WARN("%s has multiple entries for key '%s'", envName, pairs[i].first.c_str());
+        return ncclInvalidUsage;
+      }
+    }
+  }
+  return ncclSuccess;
+}
+
+static bool parseCudaAffinityKey(std::string const& key, int* cudaDev) {
+  const std::string prefix = "cuda:";
+  if (key.compare(0, prefix.size(), prefix) != 0 || key.size() == prefix.size()) return false;
+
+  long value = 0;
+  for (size_t i = prefix.size(); i < key.size(); i++) {
+    if (!std::isdigit(static_cast<unsigned char>(key[i]))) return false;
+    value = value * 10 + (key[i] - '0');
+    if (value > INT_MAX) return false;
+  }
+  *cudaDev = (int)value;
+  return true;
+}
+
+static ncclResult_t validateGpuAffinityEntries(std::vector<std::pair<std::string, std::string>> const& entries) {
+  int cudaDevCount = 0;
+  CUDACHECK(cudaGetDeviceCount(&cudaDevCount));
+  for (size_t i = 0; i < entries.size(); i++) {
+    int cudaDev = -1;
+    if (!parseCudaAffinityKey(entries[i].first, &cudaDev)) {
+      WARN("NCCL_GPU_NIC_AFFINITY has invalid key '%s'; expected cuda:<logical-device-id>",
+           entries[i].first.c_str());
+      return ncclInvalidUsage;
+    }
+    if (cudaDev < 0 || cudaDev >= cudaDevCount) {
+      WARN("NCCL_GPU_NIC_AFFINITY references unknown CUDA logical device cuda:%d; visible device count is %d",
+           cudaDev, cudaDevCount);
+      return ncclInvalidUsage;
+    }
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t splitNicList(const char* envName, std::string const& list, std::vector<std::string>& names) {
+  size_t pos = 0;
+  while (pos <= list.size()) {
+    size_t end = list.find(',', pos);
+    std::string name = trimString(list.substr(pos, end == std::string::npos ? std::string::npos : end - pos));
+    if (name.empty()) {
+      WARN("%s contains an empty NIC name in '%s'", envName, list.c_str());
+      return ncclInvalidUsage;
+    }
+    if (std::find(names.begin(), names.end(), name) != names.end()) {
+      WARN("%s contains duplicate NIC name '%s'", envName, name.c_str());
+      return ncclInvalidUsage;
+    }
+    names.push_back(name);
+    if (end == std::string::npos) break;
+    pos = end + 1;
+  }
+  return names.empty() ? ncclInvalidUsage : ncclSuccess;
+}
+
+static ncclResult_t getGinDevNames(struct ncclGinState* ginState, int ndev, std::vector<ncclGinDevName>& ginDevNames) {
+  for (int d = 0; d < ndev; d++) {
+    ncclNetProperties_t props;
+    NCCLCHECK(ginState->ncclGin->getProperties(d, &props));
+    if (props.name == NULL || props.name[0] == '\0') {
+      WARN("GIN device %d did not report a valid name", d);
+      return ncclInvalidUsage;
+    }
+    ncclGinDevName devName;
+    devName.dev = d;
+    snprintf(devName.name, sizeof(devName.name), "%s", props.name);
+    ginDevNames.push_back(devName);
+  }
+  return ncclSuccess;
+}
+
+static int findGinDevByName(std::vector<ncclGinDevName> const& ginDevNames, std::string const& name) {
+  for (size_t i = 0; i < ginDevNames.size(); i++) {
+    if (name == ginDevNames[i].name) return ginDevNames[i].dev;
+  }
+  return -1;
+}
+
+static ncclResult_t validateGpuAffinityNicLists(
+  std::vector<std::pair<std::string, std::string>> const& entries,
+  std::vector<ncclGinDevName> const& ginDevNames) {
+  for (size_t e = 0; e < entries.size(); e++) {
+    std::vector<std::string> nicNames;
+    NCCLCHECK(splitNicList("NCCL_GPU_NIC_AFFINITY", entries[e].second, nicNames));
+    if (nicNames.size() > NCCL_TOPO_MAX_NODES) {
+      WARN("NCCL_GPU_NIC_AFFINITY selects too many NICs for %s", entries[e].first.c_str());
+      return ncclInvalidUsage;
+    }
+    for (size_t i = 0; i < nicNames.size(); i++) {
+      if (findGinDevByName(ginDevNames, nicNames[i]) < 0) {
+        WARN("NCCL_GPU_NIC_AFFINITY selects unknown or non-GIN NIC '%s' for %s", nicNames[i].c_str(),
+             entries[e].first.c_str());
+        return ncclInvalidUsage;
+      }
+    }
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t applyGpuNicAffinity(struct ncclComm* comm, int ndev, int* localGinDevs, int* nLocalGinDevs) {
+  struct ncclGinState* ginState = &comm->sharedRes->ginState;
+  ginState->gpuNicAffinityEnabled = false;
+
+  const char* env = ncclGetEnv("NCCL_GPU_NIC_AFFINITY");
+  if (env == NULL || env[0] == '\0') return ncclSuccess;
+
+  std::vector<std::pair<std::string, std::string>> entries;
+  std::vector<ncclGinDevName> ginDevNames;
+  std::string cudaKey = "cuda:" + std::to_string(comm->cudaDev);
+  std::string selectedList;
+
+  NCCLCHECK(parseAffinityPairs("NCCL_GPU_NIC_AFFINITY", entries));
+  NCCLCHECK(validateUniqueAffinityKeys("NCCL_GPU_NIC_AFFINITY", entries));
+  NCCLCHECK(validateGpuAffinityEntries(entries));
+  NCCLCHECK(getGinDevNames(ginState, ndev, ginDevNames));
+  NCCLCHECK(validateGpuAffinityNicLists(entries, ginDevNames));
+
+  for (size_t i = 0; i < entries.size(); i++) {
+    if (entries[i].first == cudaKey) {
+      selectedList = entries[i].second;
+    }
+  }
+  if (selectedList.empty()) return ncclSuccess;
+
+  std::vector<std::string> nicNames;
+  NCCLCHECK(splitNicList("NCCL_GPU_NIC_AFFINITY", selectedList, nicNames));
+  if (nicNames.size() > NCCL_TOPO_MAX_NODES) {
+    WARN("NCCL_GPU_NIC_AFFINITY selects too many NICs for %s", cudaKey.c_str());
+    return ncclInvalidUsage;
+  }
+  for (size_t i = 0; i < nicNames.size(); i++) {
+    int dev = findGinDevByName(ginDevNames, nicNames[i]);
+    if (dev < 0) {
+      WARN("NCCL_GPU_NIC_AFFINITY selects unknown or non-GIN NIC '%s' for %s", nicNames[i].c_str(), cudaKey.c_str());
+      return ncclInvalidUsage;
+    }
+    localGinDevs[i] = dev;
+  }
+  *nLocalGinDevs = nicNames.size();
+  ginState->gpuNicAffinityEnabled = true;
+  INFO(NCCL_INIT | NCCL_NET, "GIN affinity: %s selected %d NICs from NCCL_GPU_NIC_AFFINITY", cudaKey.c_str(),
+       *nLocalGinDevs);
+  return ncclSuccess;
+}
+
+static void fillLocalGinRankInfo(struct ncclGinState* ginState, ncclGinRankInfo* info) {
+  memset(info, 0, sizeof(*info));
+  info->connCount = ginState->ginCommCount;
+  for (int n = 0; n < ginState->ginCommCount; n++) {
+    info->conns[n].ginDev = ginState->localGinDevs[n];
+    info->conns[n].guid = ginState->ginProps[n].guid;
+    info->conns[n].planeId = ginState->ginProps[n].planeId;
+    snprintf(info->conns[n].name, sizeof(info->conns[n].name), "%s", ginState->localGinNames[n]);
+  }
+}
+
+static int ginRankToWorldRank(struct ncclComm* comm, ncclGinConnectionType_t connectionType, int ginRank) {
+  if (connectionType == NCCL_GIN_CONNECTION_FULL) return ginRank;
+  ncclTeam_t railTeam = ncclTeamRail(comm);
+  return ncclTeamRankToWorld(comm, railTeam, ginRank);
+}
+
+static int findConnByName(ncclGinRankInfo const* info, char const* name, int connCount) {
+  for (int c = 0; c < connCount; c++) {
+    if (strcmp(info->conns[c].name, name) == 0) return c;
+  }
+  return -1;
+}
+
+static ncclResult_t getPeerAffinityTarget(std::vector<std::pair<std::string, std::string>> const& entries,
+                                          char const* localName, std::string* target) {
+  bool found = false;
+  for (size_t i = 0; i < entries.size(); i++) {
+    if (entries[i].first == localName) {
+      if (found) {
+        WARN("NCCL_NIC_PEER_AFFINITY has multiple entries for NIC '%s'", localName);
+        return ncclInvalidUsage;
+      }
+      *target = entries[i].second;
+      found = true;
+    }
+  }
+  if (!found) {
+    WARN("NCCL_NIC_PEER_AFFINITY is missing an entry for selected NIC '%s'", localName);
+    return ncclInvalidUsage;
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t validatePeerAffinitySelectedGinNames(
+  struct ncclComm* comm, struct ncclGinState* ginState, int nGinRanks, ncclGinRankInfo* allRankInfo,
+  std::vector<std::pair<std::string, std::string>> const& peerEntries) {
+  for (int peer = 0; peer < nGinRanks; peer++) {
+    int peerWorld = ginRankToWorldRank(comm, ginState->ginConnectionType, peer);
+    ncclGinRankInfo* peerInfo = allRankInfo + peerWorld;
+    if (peerInfo->connCount < ginState->ginCommCount) {
+      WARN("GIN affinity metadata mismatch for peer world rank %d: peer connCount=%d local connCount=%d", peerWorld,
+           peerInfo->connCount, ginState->ginCommCount);
+      return ncclInternalError;
+    }
+    for (int a = 0; a < ginState->ginCommCount; a++) {
+      for (int b = a + 1; b < ginState->ginCommCount; b++) {
+        if (strcmp(peerInfo->conns[a].name, peerInfo->conns[b].name) == 0) {
+          WARN("NCCL_NIC_PEER_AFFINITY requires unique selected GIN NICs, but peer world rank %d connection %d and %d "
+               "both use '%s'",
+               peerWorld, a, b, peerInfo->conns[a].name);
+          return ncclInvalidUsage;
+        }
+      }
+    }
+    for (int c = 0; c < ginState->ginCommCount; c++) {
+      std::string unusedTarget;
+      NCCLCHECK(getPeerAffinityTarget(peerEntries, peerInfo->conns[c].name, &unusedTarget));
+    }
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, int myGinRank,
+                                          ncclGinRankInfo* allRankInfo) {
+  struct ncclGinState* ginState = &comm->sharedRes->ginState;
+  const char* peerEnv = ncclGetEnv("NCCL_NIC_PEER_AFFINITY");
+  const bool peerAffinityEnabled = (peerEnv != NULL && peerEnv[0] != '\0');
+  std::vector<std::pair<std::string, std::string>> peerEntries;
+
+  if (ginState->remoteConnByPeer) {
+    free(ginState->remoteConnByPeer);
+    ginState->remoteConnByPeer = NULL;
+  }
+  ginState->nicPeerAffinityEnabled = false;
+  ginState->ginRankCount = nGinRanks;
+  NCCLCHECK(ncclCalloc(&ginState->remoteConnByPeer, ginState->ginCommCount * nGinRanks));
+  for (int lc = 0; lc < ginState->ginCommCount; lc++) {
+    for (int peer = 0; peer < nGinRanks; peer++) {
+      ginState->remoteConnByPeer[lc * nGinRanks + peer] = lc;
+    }
+  }
+
+  if (peerAffinityEnabled) {
+    if (ginState->ncclGin != &ncclGinIbGdaki) {
+      WARN("NCCL_NIC_PEER_AFFINITY is supported only by the internal GIN_IB_GDAKI backend.");
+      return ncclInvalidUsage;
+    }
+    NCCLCHECK(parseAffinityPairs("NCCL_NIC_PEER_AFFINITY", peerEntries));
+    NCCLCHECK(validateUniqueAffinityKeys("NCCL_NIC_PEER_AFFINITY", peerEntries));
+    NCCLCHECK(validatePeerAffinitySelectedGinNames(comm, ginState, nGinRanks, allRankInfo, peerEntries));
+    ginState->nicPeerAffinityEnabled = true;
+
+    for (int peer = 0; peer < nGinRanks; peer++) {
+      int peerWorld = ginRankToWorldRank(comm, ginState->ginConnectionType, peer);
+      ncclGinRankInfo* peerInfo = allRankInfo + peerWorld;
+      if (peerInfo->connCount < ginState->ginCommCount) {
+        WARN("GIN affinity metadata mismatch for peer world rank %d: peer connCount=%d local connCount=%d", peerWorld,
+             peerInfo->connCount, ginState->ginCommCount);
+        return ncclInternalError;
+      }
+      for (int lc = 0; lc < ginState->ginCommCount; lc++) {
+        if (peer == myGinRank) {
+          ginState->remoteConnByPeer[lc * nGinRanks + peer] = lc;
+          continue;
+        }
+        std::string targetName;
+        NCCLCHECK(getPeerAffinityTarget(peerEntries, ginState->localGinNames[lc], &targetName));
+        int remoteConn = findConnByName(peerInfo, targetName.c_str(), ginState->ginCommCount);
+        if (remoteConn < 0) {
+          WARN("NCCL_NIC_PEER_AFFINITY maps local NIC '%s' to peer NIC '%s', but peer world rank %d did not select it.",
+               ginState->localGinNames[lc], targetName.c_str(), peerWorld);
+          return ncclInvalidUsage;
+        }
+
+        std::string reciprocalTarget;
+        NCCLCHECK(getPeerAffinityTarget(peerEntries, peerInfo->conns[remoteConn].name, &reciprocalTarget));
+        if (reciprocalTarget != ginState->localGinNames[lc]) {
+          WARN("NCCL_NIC_PEER_AFFINITY must be reciprocal: local '%s' -> peer '%s', but peer '%s' -> '%s'",
+               ginState->localGinNames[lc], targetName.c_str(), peerInfo->conns[remoteConn].name,
+               reciprocalTarget.c_str());
+          return ncclInvalidUsage;
+        }
+        ginState->remoteConnByPeer[lc * nGinRanks + peer] = remoteConn;
+      }
+    }
+  }
+
+  if (ginState->gpuNicAffinityEnabled || ginState->nicPeerAffinityEnabled) {
+    for (int lc = 0; lc < ginState->ginCommCount; lc++) {
+      INFO(NCCL_INIT | NCCL_NET, "GIN affinity: rank %d ginRank %d localConn %d localNic %s dev %d plane %d",
+           comm->rank, myGinRank, lc, ginState->localGinNames[lc], ginState->localGinDevs[lc],
+           ginState->ginProps[lc].planeId);
+      for (int peer = 0; peer < nGinRanks; peer++) {
+        int peerWorld = ginRankToWorldRank(comm, ginState->ginConnectionType, peer);
+        int remoteConn = ginState->remoteConnByPeer[lc * nGinRanks + peer];
+        INFO(NCCL_INIT | NCCL_NET,
+             "GIN affinity: rank %d localConn %d localNic %s -> peerWorld %d peerGinRank %d remoteConn %d remoteNic %s",
+             comm->rank, lc, ginState->localGinNames[lc], peerWorld, peer, remoteConn,
+             allRankInfo[peerWorld].conns[remoteConn].name);
+      }
+    }
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   struct ncclGinState* ginState = &comm->sharedRes->ginState;
   if (ginState->connected) return ncclSuccess;
@@ -111,9 +494,13 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   int nLocalGinDevs;
   int localGinDevs[NCCL_TOPO_MAX_NODES];
   NCCLCHECK(ncclTopoGetLocalGinDevs(comm, localGinDevs, &nLocalGinDevs));
+  NCCLCHECK(applyGpuNicAffinity(comm, ndev, localGinDevs, &nLocalGinDevs));
+  ginState->nicPeerAffinityEnabled = false;
+  ginState->ginRankCount = 0;
 
   void** handles = NULL;
   char* allHandles = NULL;
+  ncclGinRankInfo* allRankInfo = NULL;
 
   int* ginCommCountHandles = NULL;
   NCCLCHECKGOTO(ncclCalloc(&ginCommCountHandles, comm->nRanks), ret, fail);
@@ -131,6 +518,11 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, ginCommCountHandles, sizeof(int)), ret, fail);
   for (int r = 0; r < comm->nRanks; r++) {
     ginState->ginCommCount = std::min(ginState->ginCommCount, ginCommCountHandles[r]);
+  }
+  if (ginState->ginCommCount <= 0) {
+    WARN("No GIN connections can be created.");
+    ret = ncclInternalError;
+    goto fail;
   }
 
   NCCLCHECKGOTO(ncclCalloc(&allHandles, (size_t)comm->nRanks * NCCL_NET_HANDLE_MAXSIZE), ret, fail);
@@ -155,12 +547,29 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   }
 
   for (int n = 0; n < ginState->ginCommCount; n++) {
+    int localDev = localGinDevs[n % nLocalGinDevs];
+    ginState->localGinDevs[n] = localDev;
+    NCCLCHECKGOTO(ginState->ncclGin->getProperties(localDev, ginState->ginProps + n), ret, fail);
+    if (ginState->ginProps[n].name == NULL || ginState->ginProps[n].name[0] == '\0') {
+      WARN("GIN device %d did not report a valid name", localDev);
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    snprintf(ginState->localGinNames[n], sizeof(ginState->localGinNames[n]), "%s", ginState->ginProps[n].name);
+  }
+
+  if (envIsSet("NCCL_GPU_NIC_AFFINITY") || envIsSet("NCCL_NIC_PEER_AFFINITY")) {
+    NCCLCHECKGOTO(ncclCalloc(&allRankInfo, comm->nRanks), ret, fail);
+    fillLocalGinRankInfo(ginState, allRankInfo + comm->rank);
+    NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allRankInfo, sizeof(ncclGinRankInfo)), ret, fail);
+    NCCLCHECKGOTO(buildRemoteConnByPeer(comm, nGinRanks, myGinRank, allRankInfo), ret, fail);
+  }
+
+  for (int n = 0; n < ginState->ginCommCount; n++) {
     void* listenComm;
-    NCCLCHECKGOTO(ginState->ncclGin->listen(ginState->ginInstance, localGinDevs[n % nLocalGinDevs],
+    NCCLCHECKGOTO(ginState->ncclGin->listen(ginState->ginInstance, ginState->localGinDevs[n],
                                             allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
                   ret, fail);
-
-    NCCLCHECKGOTO(ginState->ncclGin->getProperties(localGinDevs[n % nLocalGinDevs], ginState->ginProps + n), ret, fail);
 
     NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allHandles, NCCL_NET_HANDLE_MAXSIZE), ret, fail);
 
@@ -176,6 +585,8 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   allHandles = NULL;
   free(ginCommCountHandles);
   ginCommCountHandles = NULL;
+  free(allRankInfo);
+  allRankInfo = NULL;
 
 exit:
   if (ret == ncclSuccess) ginState->connected = true;
@@ -184,6 +595,11 @@ fail:
   if (allHandles) free(allHandles);
   if (handles) free(handles);
   if (ginCommCountHandles) free(ginCommCountHandles);
+  if (allRankInfo) free(allRankInfo);
+  if (ginState->remoteConnByPeer) {
+    free(ginState->remoteConnByPeer);
+    ginState->remoteConnByPeer = NULL;
+  }
   goto exit;
 }
 
@@ -274,10 +690,25 @@ ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequir
       1
   };
 
-  for (int n = 0; n < ginState->ginCommCount; n++) {
-    NCCLCHECKGOTO(ginState->ncclGin->createContext(ginState->ginComms[n], &ginConfig, &ginStateDevComm->ginCtx[n],
-                                                   &ginStateDevComm->devHandles[n]),
+  if (ginState->nicPeerAffinityEnabled) {
+    if (ginState->ncclGin != &ncclGinIbGdaki) {
+      WARN("NCCL_NIC_PEER_AFFINITY is supported only by the internal GIN_IB_GDAKI backend.");
+      ret = ncclInvalidUsage;
+      goto end;
+    }
+    NCCLCHECKGOTO(ncclGinIbGdakiCreateContextGroup(ginState->ginComms, ginState->ginCommCount, &ginConfig,
+                                                   ginState->remoteConnByPeer, ginStateDevComm->ginCtx,
+                                                   ginStateDevComm->devHandles),
                   ret, end);
+  } else {
+    for (int n = 0; n < ginState->ginCommCount; n++) {
+      NCCLCHECKGOTO(ginState->ncclGin->createContext(ginState->ginComms[n], &ginConfig, &ginStateDevComm->ginCtx[n],
+                                                     &ginStateDevComm->devHandles[n]),
+                    ret, end);
+    }
+  }
+
+  for (int n = 0; n < ginState->ginCommCount; n++) {
     if (ginStateDevComm->ginCtx[n] == NULL || ginStateDevComm->devHandles[n] == NULL ||
         ginStateDevComm->devHandles[n]->handle == NULL) {
       WARN("GIN plugin %s returned invalid context for connection %d: ginCtx=%p devHandle=%p handle=%p",
@@ -367,6 +798,10 @@ ncclResult_t ncclGinHostFinalize(struct ncclComm* comm) {
       ginState->ginComms[n] = NULL;
     }
   }
+  if (ginState->remoteConnByPeer) {
+    free(ginState->remoteConnByPeer);
+    ginState->remoteConnByPeer = NULL;
+  }
   memset((void*)ginState, 0, sizeof(*ginState));
   return ncclSuccess;
 }
@@ -386,6 +821,22 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
     }
   }
   int mrFlags = (winFlags & NCCL_WIN_STRICT_ORDERING) ? NCCL_NET_MR_FLAG_FORCE_SO : 0;
+  if (ginState->nicPeerAffinityEnabled) {
+    if (ginState->ncclGin != &ncclGinIbGdaki) {
+      WARN("NCCL_NIC_PEER_AFFINITY is supported only by the internal GIN_IB_GDAKI backend.");
+      return ncclInvalidUsage;
+    }
+    NCCLCHECK(ncclGinIbGdakiRegMrSymGroup(ginState->ginComms, ginState->ginCommCount, ginState->remoteConnByPeer,
+                                          address, size, memType, mrFlags, ginHostWins, (void**)ginDevWins));
+    for (int n = 0; n < ginState->ginCommCount; n++) {
+      if (ginHostWins[n] == NULL) {
+        WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
+        return ncclSystemError;
+      }
+    }
+    return ncclSuccess;
+  }
+
   for (int n = 0; n < ginState->ginCommCount; n++) {
     NCCLCHECK(ginState->ncclGin->regMrSym(ginState->ginComms[n], address, size, memType, mrFlags, &ginHostWins[n],
                                           &ginDevWins[n]));

--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -321,12 +321,6 @@ static int ginRankToWorldRank(struct ncclComm* comm, ncclGinConnectionType_t con
   return ncclTeamRankToWorld(comm, railTeam, ginRank);
 }
 
-static bool ginPeerOnSameNode(struct ncclComm* comm, int peerWorldRank) {
-  if (peerWorldRank == comm->rank) return true;
-  if (comm->rankToNode != NULL) return comm->rankToNode[peerWorldRank] == comm->node;
-  return comm->peerInfo[peerWorldRank].hostHash == comm->peerInfo[comm->rank].hostHash;
-}
-
 static int findConnByName(ncclGinRankInfo const* info, char const* name, int connCount) {
   for (int c = 0; c < connCount; c++) {
     if (strcmp(info->conns[c].name, name) == 0) return c;
@@ -451,10 +445,6 @@ static ncclResult_t buildRemoteConnByPeer(struct ncclComm* comm, int nGinRanks, 
         return ncclInternalError;
       }
       for (int lc = 0; lc < ginState->ginCommCount; lc++) {
-        if (ginPeerOnSameNode(comm, peerWorld)) {
-          ginState->remoteConnByPeer[lc * nGinRanks + peer] = lc;
-          continue;
-        }
         std::string targetName;
         int remoteConn = -1;
         NCCLCHECK(selectPeerAffinityConn(peerEntries, ginState->localGinNames[lc], peerInfo, ginState->ginCommCount,

--- a/src/include/gin.h
+++ b/src/include/gin.h
@@ -17,4 +17,11 @@ ncclResult_t ncclGinFinalize(struct ncclComm* comm);
 
 extern ncclGin_t ncclGinIbGdaki;
 
+ncclResult_t ncclGinIbGdakiCreateContextGroup(void** collComms, int nComms, ncclGinConfig_t* config,
+                                              const uint8_t* remoteConnByPeer, void** ginCtxs,
+                                              ncclNetDeviceHandle_t** devHandles);
+ncclResult_t ncclGinIbGdakiRegMrSymGroup(void** collComms, int nComms, const uint8_t* remoteConnByPeer, void* data,
+                                         size_t size, int type, uint64_t mrFlags,
+                                         void** mhandles, void** ginHandles);
+
 #endif

--- a/src/include/gin/gin_host.h
+++ b/src/include/gin/gin_host.h
@@ -17,6 +17,8 @@
 #include <mutex>
 #include <condition_variable>
 
+#define NCCL_GIN_NIC_NAME_MAX 64
+
 struct ncclGinStateDevComm {
   int contextCount;
   void* ginCtx[NCCL_GIN_MAX_CONNECTIONS];
@@ -33,6 +35,12 @@ struct ncclGinState {
   int ginCommCount;
   void* ginComms[NCCL_GIN_MAX_CONNECTIONS];
   ncclNetProperties_t ginProps[NCCL_GIN_MAX_CONNECTIONS];
+  int localGinDevs[NCCL_GIN_MAX_CONNECTIONS];
+  char localGinNames[NCCL_GIN_MAX_CONNECTIONS][NCCL_GIN_NIC_NAME_MAX];
+  uint8_t* remoteConnByPeer;
+  int ginRankCount;
+  bool gpuNicAffinityEnabled;
+  bool nicPeerAffinityEnabled;
   int needsProxyProgress;  // Whether we need to progress GIN operations with the proxy
   int ginProgress;         // GIN progress is enabled
   std::thread thread;

--- a/src/include/gin/gin_host_win_stub.h
+++ b/src/include/gin/gin_host_win_stub.h
@@ -23,6 +23,7 @@
 #include <condition_variable>
 
 #define NCCL_GIN_MAX_CONNECTIONS 4
+#define NCCL_GIN_NIC_NAME_MAX 64
 
 typedef void* ncclGinWindow_t;
 
@@ -86,6 +87,12 @@ struct ncclGinState {
   int ginCommCount;
   void* ginComms[NCCL_GIN_MAX_CONNECTIONS];
   ncclNetProperties_t ginProps[NCCL_GIN_MAX_CONNECTIONS];
+  int localGinDevs[NCCL_GIN_MAX_CONNECTIONS];
+  char localGinNames[NCCL_GIN_MAX_CONNECTIONS][NCCL_GIN_NIC_NAME_MAX];
+  uint8_t* remoteConnByPeer;
+  int ginRankCount;
+  bool gpuNicAffinityEnabled;
+  bool nicPeerAffinityEnabled;
   int needsProxyProgress;
   int ginProgress;
   std::thread thread;

--- a/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -267,6 +267,18 @@ public:
     return ncclSuccess;
   }
 
+  ncclResult_t set_rkeys(__be32* rkeys, unsigned int num_ranks) {
+    if (this->num_elements == 0) return ncclSuccess;
+    if (num_ranks != this->num_ranks) return ncclInvalidArgument;
+    memcpy(this->rkeys_hd_mhandle.host_buf, rkeys, num_ranks * sizeof(__be32));
+    NCCLCHECK(this->rkeys_hd_mhandle.copy_h_to_d());
+    return ncclSuccess;
+  }
+
+  __be32 local_rkey() {
+    return htobe32(this->mr->rkey);
+  }
+
   ncclResult_t allocate_elements(unsigned int num_elements, unsigned int* out_start_idx) {
     if (this->next_unused_idx + num_elements > this->num_elements) {
       WARN("Not enough space to get elements");
@@ -894,6 +906,461 @@ out:
   return status;
 }
 
+static int gdakiRemoteConn(const uint8_t* remoteConnByPeer, int nComms, int nranks, int localConn, int peer) {
+  if (remoteConnByPeer == nullptr) return localConn;
+  int remoteConn = remoteConnByPeer[localConn * nranks + peer];
+  return (remoteConn >= 0 && remoteConn < nComms) ? remoteConn : -1;
+}
+
+static void gdakiCleanupPartial(struct gdaki_context** ctxs, int nComms, int nranks, int ncontexts) {
+  if (ctxs == nullptr) return;
+  for (int c = 0; c < nComms; c++) {
+    struct gdaki_context* gdaki_ctx = ctxs[c];
+    if (gdaki_ctx == nullptr) continue;
+    struct ncclGinIbCollComm* cComm = gdaki_ctx->collComm;
+    const int nqps_for_comm = ncontexts * nranks;
+    const bool needCompanion = gdaki_ctx->needCompanion;
+    const int ncompanion_qps = needCompanion ? nqps_for_comm * 2 : 0;
+    const int nqps = ncontexts * (nranks + 1);
+
+    if (gdaki_ctx->gin_gdaki_gpu_ctx_host_staging && gdaki_ctx->gdev) {
+      struct doca_gpu_verbs_qp** gverbs_qps =
+        (struct doca_gpu_verbs_qp**)calloc(nranks, sizeof(struct doca_gpu_verbs_qp*));
+      if (gverbs_qps) {
+        for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
+          struct ncclGinGdakiGPUContext* gin_gdaki_gpu_ctx = &gdaki_ctx->gin_gdaki_gpu_ctx_host_staging[ctx_idx];
+          if (gin_gdaki_gpu_ctx->gdqp && gdaki_ctx->gqps) {
+            bool complete = true;
+            for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
+              if (gdaki_ctx->gqps[(ctx_idx * nranks) + qp_idx] == nullptr) {
+                complete = false;
+                break;
+              }
+              gverbs_qps[qp_idx] = gdaki_ctx->gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
+            }
+            if (complete) doca_gpu_verbs_unexport_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks,
+                                                                 gin_gdaki_gpu_ctx->gdqp);
+          }
+          if (gin_gdaki_gpu_ctx->companion_gdqp && gdaki_ctx->companion_gqps) {
+            bool complete = true;
+            for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
+              if (gdaki_ctx->companion_gqps[(ctx_idx * nranks) + qp_idx] == nullptr) {
+                complete = false;
+                break;
+              }
+              gverbs_qps[qp_idx] = gdaki_ctx->companion_gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
+            }
+            if (complete) doca_gpu_verbs_unexport_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks,
+                                                                 gin_gdaki_gpu_ctx->companion_gdqp);
+          }
+        }
+        free(gverbs_qps);
+      }
+    }
+
+    if (needCompanion && gdaki_ctx->gqp_groups) {
+      for (int qp_idx = 0; qp_idx < nqps_for_comm; qp_idx++) {
+        if (gdaki_ctx->gqp_groups[qp_idx]) doca_gpu_verbs_destroy_qp_group_hl(gdaki_ctx->gqp_groups[qp_idx]);
+      }
+    } else if (gdaki_ctx->gqps) {
+      for (int qp_idx = 0; qp_idx < nqps_for_comm; qp_idx++) {
+        if (gdaki_ctx->gqps[qp_idx]) doca_gpu_verbs_destroy_qp_hl(gdaki_ctx->gqps[qp_idx]);
+      }
+    }
+    if (gdaki_ctx->gqps) {
+      for (int qp_idx = nqps_for_comm; qp_idx < nqps; qp_idx++) {
+        if (gdaki_ctx->gqps[qp_idx]) doca_gpu_verbs_destroy_qp_hl(gdaki_ctx->gqps[qp_idx]);
+      }
+      free(gdaki_ctx->gqps);
+    }
+    if (gdaki_ctx->companion_gqps) {
+      for (int qp_idx = nqps_for_comm; qp_idx < ncompanion_qps; qp_idx++) {
+        if (gdaki_ctx->companion_gqps[qp_idx]) doca_gpu_verbs_destroy_qp_hl(gdaki_ctx->companion_gqps[qp_idx]);
+      }
+      free(gdaki_ctx->companion_gqps);
+    }
+    if (gdaki_ctx->gqp_groups) free(gdaki_ctx->gqp_groups);
+
+    if (gdaki_ctx->counters_table) delete gdaki_ctx->counters_table;
+    if (gdaki_ctx->signals_table) delete gdaki_ctx->signals_table;
+    if (gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle) delete gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle;
+    if (gdaki_ctx->gin_gdaki_gpu_ctx_host_staging) free(gdaki_ctx->gin_gdaki_gpu_ctx_host_staging);
+    if (gdaki_ctx->last_issued_get) ncclCudaFree(gdaki_ctx->last_issued_get, NULL);
+    if (gdaki_ctx->last_visible_get) ncclCudaFree(gdaki_ctx->last_visible_get, NULL);
+    if (gdaki_ctx->sink_buffer.mr) wrap_ibv_dereg_mr(gdaki_ctx->sink_buffer.mr);
+    if (gdaki_ctx->sink_buffer.addr) ncclCuMemFree(gdaki_ctx->sink_buffer.addr, nullptr);
+    if (gdaki_ctx->ah) doca_verbs_ah_attr_destroy(gdaki_ctx->ah);
+    if (gdaki_ctx->gdev) doca_gpu_destroy(gdaki_ctx->gdev);
+    if (gdaki_ctx->devHandle) free(gdaki_ctx->devHandle);
+    (void)cComm;
+    free(gdaki_ctx);
+  }
+}
+
+ncclResult_t ncclGinGdakiCreateContextGroup(struct ncclGinIbCollComm** collComms, int nComms, int nSignals,
+                                            int nCounters, int nContexts, int queueDepth, int trafficClass,
+                                            int backendVersion, const uint8_t* remoteConnByPeer, void** outGinCtxs,
+                                            ncclNetDeviceHandle_t** outDevHandles) {
+  ncclResult_t status = ncclSuccess;
+  if (backendVersion < 0 || backendVersion > NCCL_GIN_GDAKI_GPU_CONTEXT_VERSION) {
+    WARN("Invalid GIN gdaki backend version %d", backendVersion);
+    return ncclInternalError;
+  }
+  if (nComms <= 0 || nComms > NCCL_GIN_MAX_CONNECTIONS) return ncclInvalidArgument;
+
+  const int rank = collComms[0]->rank;
+  const int nranks = collComms[0]->nranks;
+  const int ncontexts = nContexts;
+  const int nqps_per_rank = ncontexts;
+  const int nqps_for_comm = nqps_per_rank * nranks;
+  const bool needCompanion = (nCounters > 0);
+  const int ncompanion_qps = needCompanion ? nqps_for_comm * 2 : 0;
+  const int nqps = nqps_per_rank * (nranks + 1);
+  const int num_counters = nCounters;
+  const int num_signals = nSignals;
+  const int ib_sl = (ncclParamIbSl() != -1)                        ? ncclParamIbSl() :
+                    (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                                     NCCL_IB_SL_DEFAULT;
+  const int ib_tc = (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_TC_DEFAULT;
+
+  struct gdaki_context** ctxs = nullptr;
+  struct gdaki_exch_info* local_exch_info = nullptr;
+  struct gdaki_exch_info* all_remote_exch_info = nullptr;
+  __be32* all_signal_rkeys = nullptr;
+  __be32* all_counter_rkeys = nullptr;
+  __be32* remapped_rkeys = nullptr;
+  struct doca_gpu_verbs_qp** gverbs_qps = nullptr;
+
+  NCCLCHECKGOTO(ncclCalloc(&ctxs, nComms), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&local_exch_info, nranks), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&all_remote_exch_info, nComms * ncontexts * nranks), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&remapped_rkeys, nranks), status, out);
+  if (num_signals) NCCLCHECKGOTO(ncclCalloc(&all_signal_rkeys, nComms * nranks), status, out);
+  if (num_counters) NCCLCHECKGOTO(ncclCalloc(&all_counter_rkeys, nComms * nranks), status, out);
+
+  for (int c = 0; c < nComms; c++) {
+    struct ncclGinIbCollComm* cComm = collComms[c];
+    if (cComm->rank != rank || cComm->nranks != nranks) {
+      WARN("GDAKI context group requires all GIN comms to have matching rank and nranks.");
+      status = ncclInvalidUsage;
+      goto out;
+    }
+    for (int peer = 0; peer < nranks; peer++) {
+      if (gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer) < 0) {
+        WARN("Invalid GIN remote connection map: localConn=%d peer=%d", c, peer);
+        status = ncclInvalidUsage;
+        goto out;
+      }
+    }
+
+    char pciBusId[MAX_PCI_ADDRESS_LEN];
+    ncclNetProperties_t props;
+    struct doca_gpu_verbs_qp_init_attr_hl qp_init_attr;
+    int ib_gid_index = 0;
+
+    NCCLCHECKGOTO(cComm->getProperties(cComm->dev, &props), status, out);
+
+    struct gdaki_context* gdaki_ctx = (struct gdaki_context*)calloc(1, sizeof(*gdaki_ctx));
+    EQCHECKGOTO(gdaki_ctx, nullptr, status, out);
+    ctxs[c] = gdaki_ctx;
+    gdaki_ctx->needCompanion = needCompanion;
+    gdaki_ctx->collComm = cComm;
+    gdaki_ctx->nContexts = ncontexts;
+    gdaki_ctx->backendVersion = backendVersion;
+
+    gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle = new GdakiHostGPUMemHandle<char>();
+    gdaki_ctx->counters_table = new GdakiGlobalGPUBufferTable<uint64_t>();
+    gdaki_ctx->signals_table = new GdakiGlobalGPUBufferTable<uint64_t>();
+    EQCHECKGOTO(gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle, nullptr, status, out);
+    EQCHECKGOTO(gdaki_ctx->counters_table, nullptr, status, out);
+    EQCHECKGOTO(gdaki_ctx->signals_table, nullptr, status, out);
+
+    NCCLCHECKGOTO(gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->allocate(
+                    ncontexts * NCCL_GIN_GDAKI_GPU_CONTEXT_MAX_SIZE),
+                  status, out);
+    NCCLCHECKGOTO(gdaki_ctx->counters_table->allocate(num_counters * ncontexts, nranks), status, out);
+    NCCLCHECKGOTO(gdaki_ctx->signals_table->allocate(num_signals * ncontexts, nranks), status, out);
+
+    gdaki_ctx->gin_gdaki_gpu_ctx_host_staging =
+      (struct ncclGinGdakiGPUContext*)calloc(ncontexts, sizeof(struct ncclGinGdakiGPUContext));
+    EQCHECKGOTO(gdaki_ctx->gin_gdaki_gpu_ctx_host_staging, nullptr, status, out);
+
+    gdaki_ctx->devHandle = (ncclNetDeviceHandle_t*)calloc(1, sizeof(*gdaki_ctx->devHandle));
+    EQCHECKGOTO(gdaki_ctx->devHandle, nullptr, status, out);
+
+    if (needCompanion) {
+      gdaki_ctx->gqp_groups =
+        (struct doca_gpu_verbs_qp_group_hl**)calloc(nqps_for_comm, sizeof(*gdaki_ctx->gqp_groups));
+      EQCHECKGOTO(gdaki_ctx->gqp_groups, nullptr, status, out);
+    }
+    gdaki_ctx->gqps = (struct doca_gpu_verbs_qp_hl**)calloc(nqps, sizeof(*gdaki_ctx->gqps));
+    EQCHECKGOTO(gdaki_ctx->gqps, nullptr, status, out);
+    if (needCompanion) {
+      gdaki_ctx->companion_gqps =
+        (struct doca_gpu_verbs_qp_hl**)calloc(ncompanion_qps, sizeof(*gdaki_ctx->companion_gqps));
+      EQCHECKGOTO(gdaki_ctx->companion_gqps, nullptr, status, out);
+    }
+
+    CUDACHECKGOTO(cudaGetDevice(&gdaki_ctx->cuda_id), status, out);
+    CUDACHECKGOTO(cudaDeviceGetPCIBusId(pciBusId, MAX_PCI_ADDRESS_LEN, gdaki_ctx->cuda_id), status, out);
+    DOCACHECKGOTO(doca_gpu_create(pciBusId, &gdaki_ctx->gdev), status, out);
+    NCCLCHECKGOTO(wrap_ibv_query_device(cComm->ib.context, &gdaki_ctx->ib_dev_attr), status, out);
+
+    NCCLCHECKGOTO(gdaki_ctx->counters_table->register_mr(cComm->ib.pd, true), status, out);
+    NCCLCHECKGOTO(gdaki_ctx->signals_table->register_mr(cComm->ib.pd, true), status, out);
+
+    gdaki_ctx->port_num = 1;
+    NCCLCHECKGOTO(wrap_ibv_query_port(cComm->ib.context, gdaki_ctx->port_num, &gdaki_ctx->port_attr), status, out);
+    NCCLCHECKGOTO(cComm->getGidIndex(cComm->ib.context, gdaki_ctx->port_num, &gdaki_ctx->port_attr, &ib_gid_index),
+                  status, out);
+    gdaki_ctx->gid_index = ib_gid_index;
+    NCCLCHECKGOTO(wrap_ibv_query_gid(cComm->ib.context, 1, ib_gid_index, &gdaki_ctx->rgid), status, out);
+    NCCLCHECKGOTO(gdakiCreateVerbsAh(gdaki_ctx, cComm->ib.context, ib_sl, ib_tc, ib_gid_index), status, out);
+
+    gdaki_ctx->qp_rq_size = 0;
+    gdaki_ctx->qp_sq_size = queueDepth > 0 ? queueDepth : ncclParamGinGdakiQpDepth();
+
+    memset(&qp_init_attr, 0, sizeof(qp_init_attr));
+    qp_init_attr.gpu_dev = gdaki_ctx->gdev;
+    qp_init_attr.ibpd = cComm->ib.pd;
+    qp_init_attr.sq_nwqe = gdaki_ctx->qp_sq_size;
+    qp_init_attr.nic_handler = (enum doca_gpu_dev_verbs_nic_handler)ncclParamGinGdakiNicHandler();
+    qp_init_attr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+    if (ncclParamGinGdakiUseReliableDB())
+      qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW;
+    else qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+
+    for (int qp_idx = 0; qp_idx < nqps_for_comm; qp_idx++) {
+      if (needCompanion) {
+      retry_create_qp_group_hl_group:
+        doca_error_t docaStatus = doca_gpu_verbs_create_qp_group_hl(&qp_init_attr, &gdaki_ctx->gqp_groups[qp_idx]);
+        if (docaStatus != DOCA_SUCCESS) {
+          if (qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW) {
+            qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED;
+            goto retry_create_qp_group_hl_group;
+          }
+          if ((qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) &&
+              ncclParamGinGdakiUseReliableDB() == 2) {
+            qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+            goto retry_create_qp_group_hl_group;
+          }
+          WARN("DOCA Error %d", docaStatus);
+          status = ncclSystemError;
+          goto out;
+        }
+        gdaki_ctx->gqps[qp_idx] = &gdaki_ctx->gqp_groups[qp_idx]->qp_main;
+        gdaki_ctx->companion_gqps[qp_idx] = &gdaki_ctx->gqp_groups[qp_idx]->qp_companion;
+      } else {
+      retry_create_qp_hl_group:
+        doca_error_t docaStatus = doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->gqps[qp_idx]);
+        if (docaStatus != DOCA_SUCCESS) {
+          if (qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW) {
+            qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED;
+            goto retry_create_qp_hl_group;
+          }
+          if ((qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) &&
+              ncclParamGinGdakiUseReliableDB() == 2) {
+            qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+            goto retry_create_qp_hl_group;
+          }
+          WARN("DOCA Error %d", docaStatus);
+          status = ncclSystemError;
+          goto out;
+        }
+      }
+      INFO(NCCL_NET, "[%d] Created grouped QP: conn=%d qp_idx=%d qpn=%#x", rank, c, qp_idx,
+           doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp));
+    }
+
+    qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+    for (int qp_idx = nqps_for_comm; qp_idx < nqps; qp_idx++) {
+      DOCACHECKGOTO(doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->gqps[qp_idx]), status, out);
+    }
+    for (int qp_idx = nqps_for_comm; qp_idx < ncompanion_qps; qp_idx++) {
+      DOCACHECKGOTO(doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->companion_gqps[qp_idx]), status, out);
+    }
+  }
+
+  if (num_signals) {
+    for (int c = 0; c < nComms; c++) {
+      __be32 rkey = ctxs[c]->signals_table->local_rkey();
+      NCCLCHECKGOTO(collComms[c]->allGather(collComms[c], &rkey, all_signal_rkeys + c * nranks, sizeof(__be32)),
+                    status, out);
+    }
+    for (int c = 0; c < nComms; c++) {
+      for (int peer = 0; peer < nranks; peer++) {
+        int remoteConn = gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer);
+        remapped_rkeys[peer] = all_signal_rkeys[remoteConn * nranks + peer];
+      }
+      NCCLCHECKGOTO(ctxs[c]->signals_table->set_rkeys(remapped_rkeys, nranks), status, out);
+    }
+  }
+  if (num_counters) {
+    for (int c = 0; c < nComms; c++) {
+      __be32 rkey = ctxs[c]->counters_table->local_rkey();
+      NCCLCHECKGOTO(collComms[c]->allGather(collComms[c], &rkey, all_counter_rkeys + c * nranks, sizeof(__be32)),
+                    status, out);
+    }
+    for (int c = 0; c < nComms; c++) {
+      for (int peer = 0; peer < nranks; peer++) {
+        int remoteConn = gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer);
+        remapped_rkeys[peer] = all_counter_rkeys[remoteConn * nranks + peer];
+      }
+      NCCLCHECKGOTO(ctxs[c]->counters_table->set_rkeys(remapped_rkeys, nranks), status, out);
+    }
+  }
+
+  for (int c = 0; c < nComms; c++) {
+    struct gdaki_context* gdaki_ctx = ctxs[c];
+    for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
+      for (int rank_idx = 0; rank_idx < nranks; rank_idx++) {
+        int qp_idx = rank_idx + ctx_idx * nranks;
+        gdakiFillExchInfo(&local_exch_info[rank_idx], gdaki_ctx, gdaki_ctx->gqps[qp_idx]);
+      }
+      NCCLCHECKGOTO(collComms[c]->allToAll(collComms[c], local_exch_info,
+                                           &all_remote_exch_info[(c * ncontexts + ctx_idx) * nranks],
+                                           sizeof(struct gdaki_exch_info)),
+                    status, out);
+    }
+  }
+
+  for (int c = 0; c < nComms; c++) {
+    struct gdaki_context* gdaki_ctx = ctxs[c];
+    for (int rank_idx = 0; rank_idx < nranks; rank_idx++) {
+      if (rank_idx == rank) continue;
+      int remoteConn = gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, rank_idx);
+      for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
+        int qp_idx = rank_idx + ctx_idx * nranks;
+        struct gdaki_exch_info* peer_info = &all_remote_exch_info[(remoteConn * ncontexts + ctx_idx) * nranks + rank_idx];
+        NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->gqps[qp_idx], peer_info), status, out);
+        INFO(NCCL_NET,
+             "[%d] Connected grouped main QP: conn=%d qp_idx=%d qpn=%#x remote_rank=%d remote_conn=%d remote_qpn=%#x",
+             rank, c, qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp), rank_idx, remoteConn,
+             peer_info->qpn);
+      }
+    }
+
+    for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
+      int qp_idx = rank + ctx_idx * nranks;
+      struct gdaki_exch_info exch_info;
+      gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->gqps[nqps_for_comm + ctx_idx]);
+      NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->gqps[qp_idx], &exch_info), status, out);
+    }
+    for (int qp_idx = 0; qp_idx < nqps_per_rank; qp_idx++) {
+      int peer_qp_idx = nqps_for_comm + qp_idx;
+      struct gdaki_exch_info exch_info;
+      gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->gqps[qp_idx * nranks + rank]);
+      NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->gqps[peer_qp_idx], &exch_info), status, out);
+    }
+    if (needCompanion) {
+      for (int qp_idx = 0; qp_idx < nqps_for_comm; qp_idx++) {
+        int peer_qp_idx = nqps_for_comm + qp_idx;
+        struct gdaki_exch_info exch_info;
+        gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->companion_gqps[peer_qp_idx]);
+        NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->companion_gqps[qp_idx], &exch_info), status, out);
+        gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->companion_gqps[qp_idx]);
+        NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->companion_gqps[peer_qp_idx], &exch_info), status, out);
+      }
+    }
+  }
+
+  gverbs_qps = (struct doca_gpu_verbs_qp**)calloc(nranks, sizeof(struct doca_gpu_verbs_qp*));
+  EQCHECKGOTO(gverbs_qps, nullptr, status, out);
+  for (int c = 0; c < nComms; c++) {
+    struct gdaki_context* gdaki_ctx = ctxs[c];
+    bool need_cpu_proxy = false;
+    uint64_t* sink_buffer = nullptr;
+    struct ibv_mr* sink_buffer_mr = nullptr;
+    CUmemGenericAllocationHandle sink_buffer_mhandle;
+
+    NCCLCHECKGOTO(ncclCuMemAlloc((void**)&sink_buffer, &sink_buffer_mhandle, CU_MEM_HANDLE_TYPE_NONE, sizeof(uint64_t),
+                                 nullptr),
+                  status, out);
+    gdaki_ctx->sink_buffer.addr = sink_buffer;
+    gdaki_ctx->sink_buffer.mhandle = sink_buffer_mhandle;
+    NCCLCHECKGOTO(gdakiRegMr(&sink_buffer_mr, collComms[c]->ib.pd, sink_buffer, sizeof(uint64_t),
+                             IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
+                               IBV_ACCESS_REMOTE_ATOMIC),
+                  status, out);
+    gdaki_ctx->sink_buffer.mr = sink_buffer_mr;
+
+    NCCLCHECKGOTO(ncclCudaCalloc(&gdaki_ctx->last_issued_get, ncontexts * nranks, NULL), status, out);
+    NCCLCHECKGOTO(ncclCudaCalloc(&gdaki_ctx->last_visible_get, ncontexts * nranks, NULL), status, out);
+
+    for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
+      struct ncclGinGdakiGPUContext* gin_gdaki_gpu_ctx = &gdaki_ctx->gin_gdaki_gpu_ctx_host_staging[ctx_idx];
+      unsigned int buffer_start;
+      for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
+        gverbs_qps[qp_idx] = gdaki_ctx->gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
+        need_cpu_proxy |= gverbs_qps[qp_idx]->cpu_proxy;
+      }
+      DOCACHECKGOTO(doca_gpu_verbs_export_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks, &gin_gdaki_gpu_ctx->gdqp),
+                    status, out);
+      if (needCompanion) {
+        for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
+          gverbs_qps[qp_idx] = gdaki_ctx->companion_gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
+          need_cpu_proxy |= gverbs_qps[qp_idx]->cpu_proxy;
+        }
+        DOCACHECKGOTO(doca_gpu_verbs_export_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks,
+                                                          &gin_gdaki_gpu_ctx->companion_gdqp),
+                      status, out);
+      } else {
+        gin_gdaki_gpu_ctx->companion_gdqp = nullptr;
+      }
+      if (nCounters) {
+        NCCLCHECKGOTO(gdaki_ctx->counters_table->allocate_elements(num_counters, &buffer_start), status, out);
+        gin_gdaki_gpu_ctx->counters_table.buffer = gdaki_ctx->counters_table->gpu_ptr + buffer_start;
+        gin_gdaki_gpu_ctx->counters_table.rkeys = gdaki_ctx->counters_table->get_rkeys_d();
+        gin_gdaki_gpu_ctx->counters_table.lkey = htobe32(gdaki_ctx->counters_table->mr->lkey);
+        gin_gdaki_gpu_ctx->counters_table.offset = buffer_start;
+      }
+      if (nSignals) {
+        NCCLCHECKGOTO(gdaki_ctx->signals_table->allocate_elements(num_signals, &buffer_start), status, out);
+        gin_gdaki_gpu_ctx->signals_table.buffer = gdaki_ctx->signals_table->gpu_ptr + buffer_start;
+        gin_gdaki_gpu_ctx->signals_table.rkeys = gdaki_ctx->signals_table->get_rkeys_d();
+        gin_gdaki_gpu_ctx->signals_table.lkey = htobe32(gdaki_ctx->signals_table->mr->lkey);
+        gin_gdaki_gpu_ctx->signals_table.offset = buffer_start;
+      }
+      gin_gdaki_gpu_ctx->sink_buffer_lkey = htobe32(sink_buffer_mr->lkey);
+      gin_gdaki_gpu_ctx->last_issued_get = gdaki_ctx->last_issued_get + ctx_idx * nranks;
+      gin_gdaki_gpu_ctx->last_visible_get = gdaki_ctx->last_visible_get + ctx_idx * nranks;
+      NCCLCHECKGOTO(ncclGinGdakiGPUContext_init(backendVersion, gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->host_buf,
+                                                ctx_idx, gin_gdaki_gpu_ctx->gdqp, gin_gdaki_gpu_ctx->companion_gdqp,
+                                                gin_gdaki_gpu_ctx->counters_table, gin_gdaki_gpu_ctx->signals_table,
+                                                gin_gdaki_gpu_ctx->sink_buffer_lkey,
+                                                gin_gdaki_gpu_ctx->last_issued_get,
+                                                gin_gdaki_gpu_ctx->last_visible_get),
+                    status, out);
+    }
+    NCCLCHECKGOTO(gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->copy_h_to_d(), status, out);
+    gdaki_ctx->devHandle->netDeviceType = NCCL_NET_DEVICE_GIN_GDAKI;
+    gdaki_ctx->devHandle->netDeviceVersion = NCCL_GIN_GDAKI_VERSION;
+    gdaki_ctx->devHandle->handle = (void*)gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->gpu_buf;
+    gdaki_ctx->devHandle->size = 0;
+    gdaki_ctx->devHandle->needsProxyProgress = need_cpu_proxy;
+
+    outGinCtxs[c] = gdaki_ctx;
+    outDevHandles[c] = gdaki_ctx->devHandle;
+  }
+
+out:
+  if (status != ncclSuccess) {
+    gdakiCleanupPartial(ctxs, nComms, nranks, ncontexts);
+    for (int c = 0; c < nComms; c++) {
+      outGinCtxs[c] = nullptr;
+      outDevHandles[c] = nullptr;
+    }
+  }
+  if (ctxs) free(ctxs);
+  if (local_exch_info) free(local_exch_info);
+  if (all_remote_exch_info) free(all_remote_exch_info);
+  if (all_signal_rkeys) free(all_signal_rkeys);
+  if (all_counter_rkeys) free(all_counter_rkeys);
+  if (remapped_rkeys) free(remapped_rkeys);
+  if (gverbs_qps) free(gverbs_qps);
+  return status;
+}
+
 ncclResult_t ncclGinGdakiDestroyContext(void* ginCtx) {
   if (!ginCtx) return ncclInvalidArgument;
 
@@ -1047,6 +1514,103 @@ out:
     delete gdaki_mhandle_hd_mhandle;
     delete rkeys_hd_mhandle;
   }
+  return status;
+}
+
+ncclResult_t ncclGinGdakiRegMrSymGroup(struct ncclGinIbCollComm** collComms, int nComms,
+                                       const uint8_t* remoteConnByPeer, void* data, size_t size, int type,
+                                       uint64_t mr_flags, void** mhandles, void** ginHandles) {
+  ncclResult_t status = ncclSuccess;
+  if (nComms <= 0 || nComms > NCCL_GIN_MAX_CONNECTIONS) return ncclInvalidArgument;
+
+  const int rank = collComms[0]->rank;
+  const int nranks = collComms[0]->nranks;
+  const bool force_strict_ordering = (mr_flags & NCCL_NET_MR_FLAG_FORCE_SO);
+  struct ibv_mr** mrs = nullptr;
+  GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle>** gdaki_hd_mhandles = nullptr;
+  GdakiHostGPUMemHandle<__be32>** rkeys_hd_mhandles = nullptr;
+  struct gdaki_mem_handle** gdaki_mhandles = nullptr;
+  __be32* all_rkeys = nullptr;
+
+  NCCLCHECKGOTO(ncclCalloc(&mrs, nComms), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&gdaki_hd_mhandles, nComms), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&rkeys_hd_mhandles, nComms), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&gdaki_mhandles, nComms), status, out);
+  NCCLCHECKGOTO(ncclCalloc(&all_rkeys, nComms * nranks), status, out);
+
+  for (int c = 0; c < nComms; c++) {
+    mhandles[c] = nullptr;
+    ginHandles[c] = nullptr;
+    if (collComms[c]->rank != rank || collComms[c]->nranks != nranks) {
+      WARN("GDAKI MR group requires all GIN comms to have matching rank and nranks.");
+      status = ncclInvalidUsage;
+      goto out;
+    }
+    for (int peer = 0; peer < nranks; peer++) {
+      if (gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer) < 0) {
+        WARN("Invalid GIN remote connection map for MR group: localConn=%d peer=%d", c, peer);
+        status = ncclInvalidUsage;
+        goto out;
+      }
+    }
+
+    NCCLCHECKGOTO(gdakiRegMr(&mrs[c], collComms[c]->ib.pd, data, size,
+                             IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
+                               IBV_ACCESS_REMOTE_ATOMIC,
+                             force_strict_ordering),
+                  status, out);
+    __be32 rkey = htobe32(mrs[c]->rkey);
+    NCCLCHECKGOTO(collComms[c]->allGather(collComms[c], &rkey, all_rkeys + c * nranks, sizeof(__be32)), status, out);
+  }
+
+  for (int c = 0; c < nComms; c++) {
+    gdaki_mhandles[c] = (struct gdaki_mem_handle*)calloc(1, sizeof(*gdaki_mhandles[c]));
+    gdaki_hd_mhandles[c] = new GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle>();
+    rkeys_hd_mhandles[c] = new GdakiHostGPUMemHandle<__be32>();
+    EQCHECKGOTO(gdaki_mhandles[c], nullptr, status, out);
+    EQCHECKGOTO(gdaki_hd_mhandles[c], nullptr, status, out);
+    EQCHECKGOTO(rkeys_hd_mhandles[c], nullptr, status, out);
+
+    NCCLCHECKGOTO(rkeys_hd_mhandles[c]->allocate(nranks), status, out);
+    for (int peer = 0; peer < nranks; peer++) {
+      int remoteConn = gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer);
+      rkeys_hd_mhandles[c]->host_buf[peer] = all_rkeys[remoteConn * nranks + peer];
+    }
+    NCCLCHECKGOTO(rkeys_hd_mhandles[c]->copy_h_to_d(), status, out);
+
+    NCCLCHECKGOTO(gdaki_hd_mhandles[c]->allocate(1), status, out);
+    gdaki_hd_mhandles[c]->host_buf->rkeys = rkeys_hd_mhandles[c]->gpu_buf;
+    gdaki_hd_mhandles[c]->host_buf->lkey = htobe32(mrs[c]->lkey);
+    NCCLCHECKGOTO(gdaki_hd_mhandles[c]->copy_h_to_d(), status, out);
+
+    gdaki_mhandles[c]->type = type;
+    gdaki_mhandles[c]->mr = mrs[c];
+    gdaki_mhandles[c]->gdaki_mhandle_hd_mhandle = gdaki_hd_mhandles[c];
+    gdaki_mhandles[c]->rkeys_hd_mhandle = rkeys_hd_mhandles[c];
+
+    INFO(NCCL_NET, "[%d] Registered grouped MR: conn=%d data=%p, size=%zu, lkey(be32)=%#x, rkey(be32)=%#x",
+         rank, c, data, size, htobe32(mrs[c]->lkey), htobe32(mrs[c]->rkey));
+
+    mhandles[c] = (void*)gdaki_mhandles[c];
+    ginHandles[c] = (void*)gdaki_hd_mhandles[c]->gpu_buf;
+  }
+
+out:
+  if (status != ncclSuccess) {
+    for (int c = 0; c < nComms; c++) {
+      if (mhandles) mhandles[c] = nullptr;
+      if (ginHandles) ginHandles[c] = nullptr;
+      if (mrs && mrs[c]) wrap_ibv_dereg_mr(mrs[c]);
+      if (gdaki_mhandles && gdaki_mhandles[c]) free(gdaki_mhandles[c]);
+      if (gdaki_hd_mhandles && gdaki_hd_mhandles[c]) delete gdaki_hd_mhandles[c];
+      if (rkeys_hd_mhandles && rkeys_hd_mhandles[c]) delete rkeys_hd_mhandles[c];
+    }
+  }
+  if (mrs) free(mrs);
+  if (gdaki_hd_mhandles) free(gdaki_hd_mhandles);
+  if (rkeys_hd_mhandles) free(rkeys_hd_mhandles);
+  if (gdaki_mhandles) free(gdaki_mhandles);
+  if (all_rkeys) free(all_rkeys);
   return status;
 }
 

--- a/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -344,6 +344,8 @@ struct gdaki_context {
 
   GdakiGlobalGPUBufferTable<uint64_t>* counters_table;
   GdakiGlobalGPUBufferTable<uint64_t>* signals_table;
+  struct ibv_mr** counters_table_mrs_by_pd;
+  struct ibv_mr** signals_table_mrs_by_pd;
   struct ncclGinGdakiGPUContext* gin_gdaki_gpu_ctx_host_staging; // formatted according to current version
   GdakiHostGPUMemHandle<char>* gin_gdaki_gpu_ctx_hd_mhandle; // formatted according to backendVersion
   int backendVersion;
@@ -360,7 +362,45 @@ struct gdaki_context {
   struct ncclGinIbCollComm* collComm;
   ncclNetDeviceHandle_t* devHandle;
   int nContexts;
+  int groupSize;
+  int groupIndex;
 };
+
+static size_t gdakiControlRkeyIndex(int nComms, int nranks, int targetConn, int pdConn, int peer) {
+  return ((size_t)targetConn * nComms + pdConn) * nranks + peer;
+}
+
+static struct ibv_mr* gdakiControlMrForPd(GdakiGlobalGPUBufferTable<uint64_t>* table, struct ibv_mr** mrs_by_pd,
+                                          int targetConn, int pdConn) {
+  if (pdConn == targetConn) return table ? table->mr : nullptr;
+  return mrs_by_pd ? mrs_by_pd[pdConn] : nullptr;
+}
+
+static void gdakiDeregisterCrossPdMrs(struct gdaki_context* gdaki_ctx) {
+  if (gdaki_ctx == nullptr) return;
+
+  if (gdaki_ctx->counters_table_mrs_by_pd) {
+    for (int pdConn = 0; pdConn < gdaki_ctx->groupSize; pdConn++) {
+      if (pdConn == gdaki_ctx->groupIndex) continue;
+      if (gdaki_ctx->counters_table_mrs_by_pd[pdConn]) {
+        (void)wrap_ibv_dereg_mr(gdaki_ctx->counters_table_mrs_by_pd[pdConn]);
+      }
+    }
+    free(gdaki_ctx->counters_table_mrs_by_pd);
+    gdaki_ctx->counters_table_mrs_by_pd = nullptr;
+  }
+
+  if (gdaki_ctx->signals_table_mrs_by_pd) {
+    for (int pdConn = 0; pdConn < gdaki_ctx->groupSize; pdConn++) {
+      if (pdConn == gdaki_ctx->groupIndex) continue;
+      if (gdaki_ctx->signals_table_mrs_by_pd[pdConn]) {
+        (void)wrap_ibv_dereg_mr(gdaki_ctx->signals_table_mrs_by_pd[pdConn]);
+      }
+    }
+    free(gdaki_ctx->signals_table_mrs_by_pd);
+    gdaki_ctx->signals_table_mrs_by_pd = nullptr;
+  }
+}
 
 static void gdakiFillExchInfo(struct gdaki_exch_info* exch_info, struct gdaki_context* gdaki_ctx,
                               struct doca_gpu_verbs_qp_hl* gqp) {
@@ -981,6 +1021,7 @@ static void gdakiCleanupPartial(struct gdaki_context** ctxs, int nComms, int nra
     }
     if (gdaki_ctx->gqp_groups) free(gdaki_ctx->gqp_groups);
 
+    gdakiDeregisterCrossPdMrs(gdaki_ctx);
     if (gdaki_ctx->counters_table) delete gdaki_ctx->counters_table;
     if (gdaki_ctx->signals_table) delete gdaki_ctx->signals_table;
     if (gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle) delete gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle;
@@ -1035,8 +1076,8 @@ ncclResult_t ncclGinGdakiCreateContextGroup(struct ncclGinIbCollComm** collComms
   NCCLCHECKGOTO(ncclCalloc(&local_exch_info, nranks), status, out);
   NCCLCHECKGOTO(ncclCalloc(&all_remote_exch_info, nComms * ncontexts * nranks), status, out);
   NCCLCHECKGOTO(ncclCalloc(&remapped_rkeys, nranks), status, out);
-  if (num_signals) NCCLCHECKGOTO(ncclCalloc(&all_signal_rkeys, nComms * nranks), status, out);
-  if (num_counters) NCCLCHECKGOTO(ncclCalloc(&all_counter_rkeys, nComms * nranks), status, out);
+  if (num_signals) NCCLCHECKGOTO(ncclCalloc(&all_signal_rkeys, (size_t)nComms * nComms * nranks), status, out);
+  if (num_counters) NCCLCHECKGOTO(ncclCalloc(&all_counter_rkeys, (size_t)nComms * nComms * nranks), status, out);
 
   for (int c = 0; c < nComms; c++) {
     struct ncclGinIbCollComm* cComm = collComms[c];
@@ -1067,6 +1108,8 @@ ncclResult_t ncclGinGdakiCreateContextGroup(struct ncclGinIbCollComm** collComms
     gdaki_ctx->collComm = cComm;
     gdaki_ctx->nContexts = ncontexts;
     gdaki_ctx->backendVersion = backendVersion;
+    gdaki_ctx->groupSize = nComms;
+    gdaki_ctx->groupIndex = c;
 
     gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle = new GdakiHostGPUMemHandle<char>();
     gdaki_ctx->counters_table = new GdakiGlobalGPUBufferTable<uint64_t>();
@@ -1181,30 +1224,87 @@ ncclResult_t ncclGinGdakiCreateContextGroup(struct ncclGinIbCollComm** collComms
     }
   }
 
+  if (num_signals || num_counters) {
+    const int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
+                       IBV_ACCESS_REMOTE_ATOMIC;
+    const size_t signal_bytes = (size_t)num_signals * ncontexts * sizeof(uint64_t);
+    const size_t counter_bytes = (size_t)num_counters * ncontexts * sizeof(uint64_t);
+    for (int targetConn = 0; targetConn < nComms; targetConn++) {
+      if (num_signals) {
+        NCCLCHECKGOTO(ncclCalloc(&ctxs[targetConn]->signals_table_mrs_by_pd, nComms), status, out);
+        for (int pdConn = 0; pdConn < nComms; pdConn++) {
+          if (pdConn == targetConn) continue;
+          NCCLCHECKGOTO(gdakiRegMr(&ctxs[targetConn]->signals_table_mrs_by_pd[pdConn], collComms[pdConn]->ib.pd,
+                                   ctxs[targetConn]->signals_table->gpu_ptr, signal_bytes, access, true),
+                        status, out);
+          INFO(NCCL_NET,
+               "[%d] Registered grouped signal table on peer PD: target_conn=%d pd_conn=%d rkey(be32)=%#x", rank,
+               targetConn, pdConn, htobe32(ctxs[targetConn]->signals_table_mrs_by_pd[pdConn]->rkey));
+        }
+      }
+      if (num_counters) {
+        NCCLCHECKGOTO(ncclCalloc(&ctxs[targetConn]->counters_table_mrs_by_pd, nComms), status, out);
+        for (int pdConn = 0; pdConn < nComms; pdConn++) {
+          if (pdConn == targetConn) continue;
+          NCCLCHECKGOTO(gdakiRegMr(&ctxs[targetConn]->counters_table_mrs_by_pd[pdConn], collComms[pdConn]->ib.pd,
+                                   ctxs[targetConn]->counters_table->gpu_ptr, counter_bytes, access, true),
+                        status, out);
+          INFO(NCCL_NET,
+               "[%d] Registered grouped counter table on peer PD: target_conn=%d pd_conn=%d rkey(be32)=%#x", rank,
+               targetConn, pdConn, htobe32(ctxs[targetConn]->counters_table_mrs_by_pd[pdConn]->rkey));
+        }
+      }
+    }
+  }
+
   if (num_signals) {
-    for (int c = 0; c < nComms; c++) {
-      __be32 rkey = ctxs[c]->signals_table->local_rkey();
-      NCCLCHECKGOTO(collComms[c]->allGather(collComms[c], &rkey, all_signal_rkeys + c * nranks, sizeof(__be32)),
-                    status, out);
+    for (int targetConn = 0; targetConn < nComms; targetConn++) {
+      for (int pdConn = 0; pdConn < nComms; pdConn++) {
+        struct ibv_mr* mr = gdakiControlMrForPd(ctxs[targetConn]->signals_table,
+                                                ctxs[targetConn]->signals_table_mrs_by_pd, targetConn, pdConn);
+        if (mr == nullptr) {
+          WARN("Missing grouped signal table MR: targetConn=%d pdConn=%d", targetConn, pdConn);
+          status = ncclInternalError;
+          goto out;
+        }
+        __be32 rkey = htobe32(mr->rkey);
+        NCCLCHECKGOTO(collComms[pdConn]->allGather(
+                        collComms[pdConn], &rkey,
+                        all_signal_rkeys + gdakiControlRkeyIndex(nComms, nranks, targetConn, pdConn, 0),
+                        sizeof(__be32)),
+                      status, out);
+      }
     }
     for (int c = 0; c < nComms; c++) {
       for (int peer = 0; peer < nranks; peer++) {
         int remoteConn = gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer);
-        remapped_rkeys[peer] = all_signal_rkeys[remoteConn * nranks + peer];
+        remapped_rkeys[peer] = all_signal_rkeys[gdakiControlRkeyIndex(nComms, nranks, c, remoteConn, peer)];
       }
       NCCLCHECKGOTO(ctxs[c]->signals_table->set_rkeys(remapped_rkeys, nranks), status, out);
     }
   }
   if (num_counters) {
-    for (int c = 0; c < nComms; c++) {
-      __be32 rkey = ctxs[c]->counters_table->local_rkey();
-      NCCLCHECKGOTO(collComms[c]->allGather(collComms[c], &rkey, all_counter_rkeys + c * nranks, sizeof(__be32)),
-                    status, out);
+    for (int targetConn = 0; targetConn < nComms; targetConn++) {
+      for (int pdConn = 0; pdConn < nComms; pdConn++) {
+        struct ibv_mr* mr = gdakiControlMrForPd(ctxs[targetConn]->counters_table,
+                                                ctxs[targetConn]->counters_table_mrs_by_pd, targetConn, pdConn);
+        if (mr == nullptr) {
+          WARN("Missing grouped counter table MR: targetConn=%d pdConn=%d", targetConn, pdConn);
+          status = ncclInternalError;
+          goto out;
+        }
+        __be32 rkey = htobe32(mr->rkey);
+        NCCLCHECKGOTO(collComms[pdConn]->allGather(
+                        collComms[pdConn], &rkey,
+                        all_counter_rkeys + gdakiControlRkeyIndex(nComms, nranks, targetConn, pdConn, 0),
+                        sizeof(__be32)),
+                      status, out);
+      }
     }
     for (int c = 0; c < nComms; c++) {
       for (int peer = 0; peer < nranks; peer++) {
         int remoteConn = gdakiRemoteConn(remoteConnByPeer, nComms, nranks, c, peer);
-        remapped_rkeys[peer] = all_counter_rkeys[remoteConn * nranks + peer];
+        remapped_rkeys[peer] = all_counter_rkeys[gdakiControlRkeyIndex(nComms, nranks, c, remoteConn, peer)];
       }
       NCCLCHECKGOTO(ctxs[c]->counters_table->set_rkeys(remapped_rkeys, nranks), status, out);
     }
@@ -1431,6 +1531,7 @@ ncclResult_t ncclGinGdakiDestroyContext(void* ginCtx) {
   if (gdaki_ctx->gqps) free(gdaki_ctx->gqps);
   if (gdaki_ctx->companion_gqps) free(gdaki_ctx->companion_gqps);
 
+  gdakiDeregisterCrossPdMrs(gdaki_ctx);
   if (gdaki_ctx->counters_table) {
     NCCLCHECK(gdaki_ctx->counters_table->deregister_mr());
     NCCLCHECK(gdaki_ctx->counters_table->deallocate());

--- a/src/transport/net_ib/gdaki/gin_host_gdaki.h
+++ b/src/transport/net_ib/gdaki/gin_host_gdaki.h
@@ -25,12 +25,21 @@
 #include "nccl.h"
 #include "gin/gin_host.h"
 
+struct ncclGinIbCollComm;
+
 ncclResult_t ncclGinGdakiCreateContext(void* collComm, int nSignals, int nCounters, int nContexts, int queueDepth,
                                        int trafficClass, int backendVersion, void** outGinCtx,
                                        ncclNetDeviceHandle_t** outDevHandle);
+ncclResult_t ncclGinGdakiCreateContextGroup(struct ncclGinIbCollComm** collComms, int nComms, int nSignals,
+                                            int nCounters, int nContexts, int queueDepth, int trafficClass,
+                                            int backendVersion, const uint8_t* remoteConnByPeer, void** outGinCtxs,
+                                            ncclNetDeviceHandle_t** outDevHandles);
 ncclResult_t ncclGinGdakiDestroyContext(void* ginCtx);
 ncclResult_t ncclGinGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle,
                                   void** ginHandle);
+ncclResult_t ncclGinGdakiRegMrSymGroup(struct ncclGinIbCollComm** collComms, int nComms,
+                                       const uint8_t* remoteConnByPeer, void* data, size_t size, int type,
+                                       uint64_t mr_flags, void** mhandles, void** ginHandles);
 ncclResult_t ncclGinGdakiDeregMrSym(void* collComm, void* mhandle);
 ncclResult_t ncclGinGdakiProgress(void* ginCtx);
 ncclResult_t ncclGinGdakiQueryLastError(void* ginCtx, bool* hasError);

--- a/src/transport/net_ib/gin.cc
+++ b/src/transport/net_ib/gin.cc
@@ -290,9 +290,31 @@ ncclResult_t ncclGinIbGdakiCreateContext(void* collComm, ncclGinConfig_t* config
   return ncclSuccess;
 }
 
+ncclResult_t ncclGinIbGdakiCreateContextGroup(void** collComms, int nComms, ncclGinConfig_t* config,
+                                              const uint8_t* remoteConnByPeer, void** ginCtxs,
+                                              ncclNetDeviceHandle_t** devHandles) {
+  if (nComms <= 0) return ncclInvalidArgument;
+  struct ncclGinIbCollComm** cComms = (struct ncclGinIbCollComm**)collComms;
+
+  if (ncclParamGinIbTc() != -1) config->trafficClass = ncclParamGinIbTc();
+  else if (ncclParamIbTc() != -1) config->trafficClass = ncclParamIbTc();
+
+  NCCLCHECK(ncclGinGdakiCreateContextGroup(cComms, nComms, config->nSignals, config->nCounters, config->nContexts,
+                                           config->queueDepth, config->trafficClass, config->backendVersion,
+                                           remoteConnByPeer, ginCtxs, devHandles));
+  return ncclSuccess;
+}
+
 ncclResult_t ncclGinIbGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags,
                                     void** mhandle, void** ginHandle) {
   return ncclGinGdakiRegMrSym((struct ncclGinIbCollComm*)collComm, data, size, type, mr_flags, mhandle, ginHandle);
+}
+
+ncclResult_t ncclGinIbGdakiRegMrSymGroup(void** collComms, int nComms, const uint8_t* remoteConnByPeer, void* data,
+                                         size_t size, int type, uint64_t mrFlags, void** mhandles, void** ginHandles) {
+  if (nComms <= 0) return ncclInvalidArgument;
+  return ncclGinGdakiRegMrSymGroup((struct ncclGinIbCollComm**)collComms, nComms, remoteConnByPeer, data, size, type,
+                                   mrFlags, mhandles, ginHandles);
 }
 
 ncclResult_t ncclGinIbGdakiDeregMrSym(void* collComm, void* mhandle) {


### PR DESCRIPTION
# Add GIN GPU/NIC peer affinity mapping

## Description

This change adds optional GIN affinity controls for multi-GPU, multi-NIC deployments. It lets users:

- override the local GIN NIC list selected for a CUDA device; and
- map each local GIN NIC to one or more peer GIN NIC candidates.

The main use case is a homogeneous RDMA cluster where every node exposes the same GIN-capable NIC names, but the desired data path is not always the same-index local-to-peer NIC connection. When `NCCL_NIC_PEER_AFFINITY` resolves to a non-identity peer mapping, GIN builds a per-local-connection, per-peer-rank remote connection table and uses the grouped GDAKI context setup and symmetric memory registration paths. Identity mappings keep the existing per-connection GDAKI path.

Default behavior is unchanged when the new affinity environment variables are not set.

## Usage

### Assumptions

The affinity rules are intended for homogeneous clusters. They assume:

- each server exposes the same GIN-capable NIC names, such as `mlx5_0`, `mlx5_1`, and so on;
- each server has the same CUDA-device to NIC topology; and
- the same affinity rules can be reused across ranks and nodes.

### `NCCL_GPU_NIC_AFFINITY`

Overrides the GIN NIC list selected for a CUDA logical device.

Example:

```bash
export NCCL_GPU_NIC_AFFINITY="cuda:0=mlx5_4,mlx5_6;cuda:1=mlx5_5,mlx5_7"
```

### `NCCL_NIC_PEER_AFFINITY`

Describes which peer NICs should be used for each selected local NIC.

Example:

```bash
export NCCL_NIC_PEER_AFFINITY="mlx5_0=mlx5_4,mlx5_5;mlx5_1=mlx5_6,mlx5_7"
```

For each local GIN connection and peer rank, the code:

1. gathers the selected GIN NIC names for every rank;
2. looks up the peer NIC candidates configured for the local NIC;
3. selects the matching peer connection from the peer rank's selected NIC list;
4. validates that the mapping is reciprocal;
5. stores the selected remote connection in `remoteConnByPeer`.

Self-peer entries keep the identity mapping. If `NCCL_NIC_PEER_AFFINITY` resolves to identity mappings only, the code keeps the existing per-connection GDAKI setup path.

## Validation

I validated this change with DeepEP v1.2.1 using `DeepEP/tests/elastic/test_ep.py` on four H200 servers.

Partial workload parameters:

```bash
--num-tokens:-32
--hidden:-6144
--num-topk:-8
--num-experts:-256
```

The run used 32 ranks. The comparison below uses:

- Existing destination-device affinity baseline;
- HCA peer affinity with cross-rail mapping.

### Existing destination-device affinity baseline

| Operation | Ranks | SO GB/s avg | SU GB/s avg | Kernel us avg | Epilogue | Epilogue GB/s avg | Epilogue us avg |
|---|---:|---:|---:|---:|---|---:|---:|
| dispatch | 32 | 4.69 | 9.40 | 89.00 | copy | 598.18 | 2.57 |
| expanded dispatch | 32 | 5.23 | 10.43 | 78.30 | copy | 2354.30 | 2.83 |
| cached dispatch | 32 | 6.50 | 12.85 | 60.99 | copy | 210.07 | 7.96 |
| combine | 32 | 8.05 | 16.05 | 92.42 | reduce | 135.60 | 6.80 |
| reduced combine | 32 | 7.47 | 14.92 | 99.81 | reduce | 138.40 | 6.64 |

### HCA peer affinity with cross-rail mapping

| Operation | Ranks | SO GB/s avg | SU GB/s avg | Kernel us avg | Epilogue | Epilogue GB/s avg | Epilogue us avg |
|---|---:|---:|---:|---:|---|---:|---:|
| dispatch | 32 | 4.88 | 9.73 | 80.71 | copy | 599.74 | 2.57 |
| expanded dispatch | 32 | 5.23 | 10.39 | 76.17 | copy | 2358.21 | 2.82 |
| cached dispatch | 32 | 6.37 | 12.53 | 63.28 | copy | 208.42 | 7.76 |
| combine | 32 | 7.84 | 15.75 | 94.30 | reduce | 136.50 | 6.76 |
| reduced combine | 32 | 7.17 | 14.40 | 104.54 | reduce | 138.98 | 6.63 |
