### PR TITLE
Fix device list leak in ncclIbInitDevices error paths

### DIFF
--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -286,6 +286,7 @@ ncclResult_t ncclIbFinalizeDevices(void) {
 extern int64_t ncclIbArThreshold;
 ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
+  struct ibv_device** devices = NULL;
   if (netRefCount++) return ret;
   ncclProfilerFunction = profFunction;
   if (ncclParamIbDisable()) return ncclInternalError;
@@ -311,7 +312,6 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // Detect IB cards
       int nIbDevs;
-      struct ibv_device** devices;
 
       // Check if user defined which IB device:port to use
       const char* userIbEnv = ncclGetEnv("NCCL_IB_HCA");
@@ -390,7 +390,8 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
                 TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
               } else {
                 WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
-                return res;
+                ret = res;
+                goto fail;
               }
             }
           }
@@ -421,7 +422,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
                           ret, fail);
             if (dev == 1) {
               snprintf(ncclIbDevs[ncclNIbDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
-              NCCLCHECK(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX));
+              NCCLCHECKGOTO(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX), ret, fail);
               strncpy(ncclIbDevs[ncclNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
               ncclIbDevs[ncclNIbDevs].capsProvider.mlx5.dataDirect = 1;
             }
@@ -431,7 +432,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
             ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
             ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
-            NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
+            NCCLCHECKGOTO(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats), ret, fail);
 
             ncclIbDevs[ncclNIbDevs].railId = (userIfId >= 0) ? userIfs[userIfId].rail : -1;
             ncclIbDevs[ncclNIbDevs].planeId = (userIfId >= 0) ? userIfs[userIfId].plane : -1;
@@ -461,9 +462,13 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
         }
       }
 
-      if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) {
-        ret = ncclInternalError;
-        goto fail;
+      if (devices) {
+        ncclResult_t freeRes = wrap_ibv_free_device_list(devices);
+        devices = NULL;
+        if (ncclSuccess != freeRes) {
+          ret = ncclInternalError;
+          goto fail;
+        }
       }
     }
     if (ncclNIbDevs == 0) {
@@ -516,6 +521,10 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 exit:
   return ret;
 fail:
+  if (devices) {
+    wrap_ibv_free_device_list(devices);
+    devices = NULL;
+  }
   goto exit;
 }
 


### PR DESCRIPTION
Fixes #2189

I traced through `ncclIbInitDevices()` in `src/transport/net_ib/init.cc` after reading the issue. The device list from `wrap_ibv_get_device_list()` only gets freed on the normal success path near the bottom of the function, but there are several error exits reachable after the list is obtained that skip that free:

- the data direct sysfs path failure branch did a plain `return res` (this is the exact leak from the issue)
- `ncclCalloc` and `ncclIbStatsInit` inside the device loop use the plain `NCCLCHECK` macro, which does `return RES` directly, so those also bypass the free
- and even the existing `goto fail` paths (OOO RQ query, PCI path lookup, etc) didn't help either, since the `fail:` label itself never freed `devices`

So the leak isn't just the one branch mentioned in the issue, it's every error path in this function once the list has been fetched.

Fix: moved `devices` to function scope and initialized it to NULL, then added the free (guarded by `if (devices)`) to the `fail:` label so every error path funnels through the same cleanup. Also switched the two `NCCLCHECK` sites in the loop to `NCCLCHECKGOTO(..., ret, fail)` so they go through that path too instead of returning straight out.

I don't have IB/RDMA hardware or the ibverbs dev headers in my environment so I wasn't able to actually build and run this under valgrind to reproduce the original report. I read through every exit path in the function carefully to make sure the free happens exactly once (no double free) and that paths before the list is ever obtained still see `devices == NULL` and skip the free correctly. Happy to adjust if a maintainer can confirm this compiles/tests clean.