### PR TITLE
Add profiler proxy poll backoff

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -210,6 +210,7 @@ struct ncclProxyArgs {
   int nPeers;
 
   int idle;
+  int64_t pollDelayUsec;
 
   // Element linking
   struct ncclProxyArgs* next;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -427,6 +427,8 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
   args->nChannels = op->nChannels;
   args->nPeers = op->nPeers;
   args->specifics = op->specifics;
+  args->idle = 0;
+  args->pollDelayUsec = 0;
   args->state = ncclProxyOpReady;
   args->progress = op->connection->tcomm->proxyProgress;
   args->proxyAppendPtr = op->connection->proxyAppendPtr;
@@ -799,7 +801,7 @@ static ncclResult_t removeOp(struct ncclProxyProgressState* state, struct ncclPr
 }
 
 static ncclResult_t progressOps(struct ncclProxyState* proxyState, struct ncclProxyProgressState* state,
-                                struct ncclProxyArgs* opStart, int* idle) {
+                                struct ncclProxyArgs* opStart, int* idle, int64_t* pollDelayUsec) {
   struct ncclProxyArgs* prevOp = NULL;
   struct ncclProxyArgs* op = opStart;
   ncclResult_t status = ncclSuccess;
@@ -811,9 +813,17 @@ static ncclResult_t progressOps(struct ncclProxyState* proxyState, struct ncclPr
     if (op->idle) {
       TIME_STOP(1);
       TIME_CANCEL(0);
+      if (*pollDelayUsec != 0) {
+        if (op->pollDelayUsec <= 0) {
+          *pollDelayUsec = 0;
+        } else if (*pollDelayUsec < 0 || op->pollDelayUsec < *pollDelayUsec) {
+          *pollDelayUsec = op->pollDelayUsec;
+        }
+      }
     } else {
       TIME_CANCEL(1);
       TIME_STOP(0);
+      *pollDelayUsec = 0;
     }
     *idle &= op->idle;
     if (op->state == ncclProxyOpNone || ret != ncclSuccess) {
@@ -977,7 +987,8 @@ void* ncclProxyProgress(void* proxyState_) {
   int proxyOpAppendCounter = 0;
   do {
     int idle = 1;
-    ncclResult_t ret = progressOps(proxyState, state, state->active, &idle);
+    int64_t pollDelayUsec = -1;
+    ncclResult_t ret = progressOps(proxyState, state, state->active, &idle, &pollDelayUsec);
     if (ret != ncclSuccess) {
       COMPILER_ATOMIC_STORE(&proxyState->asyncResult, ret, std::memory_order_release);
       INFO_LOC(NCCL_ALL, "-> %d [Progress Thread]", ret);
@@ -1002,7 +1013,11 @@ void* ncclProxyProgress(void* proxyState_) {
         INFO_LOC(NCCL_ALL, "-> %d [Progress Thread]", ret);
       }
       if (added == 0) {
-        std::this_thread::yield(); // No request progressed. Let others run.
+        if (idle && pollDelayUsec > 0) {
+          std::this_thread::sleep_for(std::chrono::microseconds(pollDelayUsec));
+        } else {
+          std::this_thread::yield(); // No request progressed. Let others run.
+        }
       }
     }
     lastIdle = idle;

--- a/src/transport/profiler.cc
+++ b/src/transport/profiler.cc
@@ -8,6 +8,9 @@
 #include "proxy.h"
 #include "profiler.h"
 #include "device.h"
+#include "param.h"
+
+NCCL_PARAM(ProfilerKernelChPollSleepUsec, "PROFILER_KERNEL_CH_POLL_SLEEP_USEC", 1);
 
 static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
                                          void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
@@ -18,8 +21,8 @@ static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection,
 
 // The following ncclProxySubArgs are overloaded by the profiler progress function:
 // - base       : is set to the current value of workCounter[channelId]
-// - posted     : is set to sub->nsteps to indicate that the profiler has started the event
-// - transmitted: is set to sub->nsteps to indicate that the profiler has stopped the event
+// - posted     : is set to 1 to indicate that the profiler has started the event
+// - transmitted: is set to 1 to indicate that the profiler has stopped the event
 static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
     for (int s = 0; s < args->nsubs; s++) {
@@ -29,27 +32,34 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
     }
     args->state = ncclProxyOpProgress;
   }
+  args->idle = 1;
+  args->pollDelayUsec = 0;
   if (args->state == ncclProxyOpProgress) {
     for (int s = 0; s < args->nsubs; s++) {
       struct ncclProxySubArgs* sub = args->subs + s;
       struct ncclDevProfiler* workStarted = (struct ncclDevProfiler*)sub->sendbuff;
       struct ncclDevProfiler* workCompleted = (struct ncclDevProfiler*)sub->recvbuff;
-      if (sub->posted < sub->nsteps &&
+      if (sub->posted == 0 &&
           sub->base <= workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
         ncclProfilerStartKernelChEvent(
           args, s, workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
-        sub->posted = sub->nsteps;
+        sub->posted = 1;
+        args->idle = 0;
         continue; // allow events on every channel to start
       }
-      if (sub->transmitted < sub->nsteps &&
+      if (sub->transmitted == 0 &&
           sub->base <= workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
         ncclProfilerStopKernelChEvent(
           args, s, workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
-        sub->transmitted = sub->nsteps;
+        sub->transmitted = 1;
+        args->idle = 0;
         args->done++;
       }
     }
     if (args->done == args->nsubs) args->state = ncclProxyOpNone;
+    if (args->idle && args->state == ncclProxyOpProgress) {
+      args->pollDelayUsec = ncclParamProfilerKernelChPollSleepUsec();
+    }
   }
   return ncclSuccess;
 }


### PR DESCRIPTION
## Summary

Add an explicit proxy poll backoff for profiler kernel-channel timing waits.

## Motivation

This targets a profiler-specific manifestation of the proxy busy-wait concern discussed in #374. Profiler kernel-channel proxy ops wait for GPU-written start/completion counters; when those counters have not advanced, the proxy can repeatedly poll only those memory locations while staying runnable, which may show up as high CPU usage for the proxy progress thread.

## Changes

- Add `pollDelayUsec` to `ncclProxyArgs` so progress callbacks can request a bounded poll delay separately from the existing `idle` signal.
- Have the main proxy progress loop sleep for the smallest requested positive delay only when all active work is idle and no new proxy ops were appended.
- Have the profiler transport request `NCCL_PROFILER_KERNEL_CH_POLL_SLEEP_USEC`, defaulting to 1 usec, while it is waiting for kernel-channel counters.
- Use explicit `0/1` profiler start/stop sentinels instead of using `sub->nsteps` as the marker.

## Validation

- `git diff --check`
- `make -C src /Users/pawel.chojnacki/work/nccl/build/obj/transport/profiler.o` reaches `transport/profiler.cc` but cannot compile in this environment because `cuda_runtime.h` is missing from the CUDA include path.
