### PR TITLE
Add profiler proxy poll backoff

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -210,6 +210,7 @@ struct ncclProxyArgs {
   int nPeers;
 
   int idle;
+  int64_t pollDelayUsec;
 
   // Element linking
   struct ncclProxyArgs* next;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1014,7 +1014,11 @@ void* ncclProxyProgress(void* proxyState_) {
       }
       if (added == 0) {
         if (idle && pollDelayUsec > 0) {
-          std::this_thread::sleep_for(std::chrono::microseconds(pollDelayUsec));
+          struct ncclProxyOpsPool* pool = state->opsPool;
+          std::unique_lock<std::mutex> lock(pool->mutex);
+          pool->cond.wait_for(lock, std::chrono::microseconds(pollDelayUsec), [&]() {
+            return pool->nextOps != -1 || state->stop != 0;
+          });
         } else {
           std::this_thread::yield(); // No request progressed. Let others run.
         }

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -427,6 +427,8 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
   args->nChannels = op->nChannels;
   args->nPeers = op->nPeers;
   args->specifics = op->specifics;
+  args->idle = 0;
+  args->pollDelayUsec = 0;
   args->state = ncclProxyOpReady;
   args->progress = op->connection->tcomm->proxyProgress;
   args->proxyAppendPtr = op->connection->proxyAppendPtr;
@@ -799,7 +801,7 @@ static ncclResult_t removeOp(struct ncclProxyProgressState* state, struct ncclPr
 }
 
 static ncclResult_t progressOps(struct ncclProxyState* proxyState, struct ncclProxyProgressState* state,
-                                struct ncclProxyArgs* opStart, int* idle) {
+                                struct ncclProxyArgs* opStart, int* idle, int64_t* pollDelayUsec) {
   struct ncclProxyArgs* prevOp = NULL;
   struct ncclProxyArgs* op = opStart;
   ncclResult_t status = ncclSuccess;
@@ -811,9 +813,17 @@ static ncclResult_t progressOps(struct ncclProxyState* proxyState, struct ncclPr
     if (op->idle) {
       TIME_STOP(1);
       TIME_CANCEL(0);
+      if (*pollDelayUsec != 0) {
+        if (op->pollDelayUsec <= 0) {
+          *pollDelayUsec = 0;
+        } else if (*pollDelayUsec < 0 || op->pollDelayUsec < *pollDelayUsec) {
+          *pollDelayUsec = op->pollDelayUsec;
+        }
+      }
     } else {
       TIME_CANCEL(1);
       TIME_STOP(0);
+      *pollDelayUsec = 0;
     }
     *idle &= op->idle;
     if (op->state == ncclProxyOpNone || ret != ncclSuccess) {
@@ -977,7 +987,8 @@ void* ncclProxyProgress(void* proxyState_) {
   int proxyOpAppendCounter = 0;
   do {
     int idle = 1;
-    ncclResult_t ret = progressOps(proxyState, state, state->active, &idle);
+    int64_t pollDelayUsec = -1;
+    ncclResult_t ret = progressOps(proxyState, state, state->active, &idle, &pollDelayUsec);
     if (ret != ncclSuccess) {
       COMPILER_ATOMIC_STORE(&proxyState->asyncResult, ret, std::memory_order_release);
       INFO_LOC(NCCL_ALL, "-> %d [Progress Thread]", ret);
@@ -1002,7 +1013,11 @@ void* ncclProxyProgress(void* proxyState_) {
         INFO_LOC(NCCL_ALL, "-> %d [Progress Thread]", ret);
       }
       if (added == 0) {
-        std::this_thread::yield(); // No request progressed. Let others run.
+        if (idle && pollDelayUsec > 0) {
+          std::this_thread::sleep_for(std::chrono::microseconds(pollDelayUsec));
+        } else {
+          std::this_thread::yield(); // No request progressed. Let others run.
+        }
       }
     }
     lastIdle = idle;

--- a/src/transport/profiler.cc
+++ b/src/transport/profiler.cc
@@ -8,6 +8,9 @@
 #include "proxy.h"
 #include "profiler.h"
 #include "device.h"
+#include "param.h"
+
+NCCL_PARAM(ProfilerKernelChPollSleepUsec, "PROFILER_KERNEL_CH_POLL_SLEEP_USEC", 1);
 
 static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
                                          void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
@@ -29,6 +32,8 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
     }
     args->state = ncclProxyOpProgress;
   }
+  args->idle = 1;
+  args->pollDelayUsec = 0;
   if (args->state == ncclProxyOpProgress) {
     for (int s = 0; s < args->nsubs; s++) {
       struct ncclProxySubArgs* sub = args->subs + s;
@@ -39,6 +44,7 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
         ncclProfilerStartKernelChEvent(
           args, s, workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
         sub->posted = sub->nsteps;
+        args->idle = 0;
         continue; // allow events on every channel to start
       }
       if (sub->transmitted < sub->nsteps &&
@@ -46,10 +52,14 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
         ncclProfilerStopKernelChEvent(
           args, s, workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
         sub->transmitted = sub->nsteps;
+        args->idle = 0;
         args->done++;
       }
     }
     if (args->done == args->nsubs) args->state = ncclProxyOpNone;
+    if (args->idle && args->state == ncclProxyOpProgress) {
+      args->pollDelayUsec = ncclParamProfilerKernelChPollSleepUsec();
+    }
   }
   return ncclSuccess;
 }


### PR DESCRIPTION
## Description

Add an explicit proxy poll backoff for profiler kernel-channel timing waits.

This targets a profiler-specific manifestation of the proxy busy-wait concern discussed in #374. Profiler kernel-channel proxy ops wait for GPU-written start/completion counters; when those counters have not advanced, the proxy can repeatedly poll only those memory locations while staying runnable, which may show up as high CPU usage for the proxy progress thread.

To reproduce, run a two-rank single-node NCCL collective workload with a profiler plugin loaded and kernel-channel profiling enabled:

```bash
NCCL_PROFILER_PLUGIN=/path/to/libnccl-profiler-example.so \
NCCL_PROFILE_EVENT_MASK=64 \
NCCL_PROFILE_DUMP_FILE=/tmp/nccl-prof \
mpirun -np 2 ./build/all_reduce_perf -b 8 -e 1G -f 2 -g 1
```

`NCCL_PROFILE_EVENT_MASK=4095` also enables this path.

## Related Issues

Possibly related to #374 as the symptoms are identical

## Changes & Impact

- Add `pollDelayUsec` to `ncclProxyArgs` so progress callbacks can request a bounded poll delay separately from the existing `idle` signal.
- Have the main proxy progress loop sleep for the smallest requested positive delay only when all active work is idle and no new proxy ops were appended.
- Have the profiler transport request `NCCL_PROFILER_KERNEL_CH_POLL_SLEEP_USEC`, defaulting to 1 usec, while it is waiting for kernel-channel counters.
- Keep profiler kernel-channel start/stop tracking aligned with the existing `sub->nsteps` counter convention.

This does not change the public NCCL API. The new behavior is limited to idle profiler kernel-channel polling.

## Performance Impact

Expected impact is lower proxy progress thread CPU usage while profiler kernel-channel polling is idle, with a small potential profiling-latency tradeoff controlled by `NCCL_PROFILER_KERNEL_CH_POLL_SLEEP_USEC`.
