### PR TITLE
net/ib: fix out-of-bounds write when active ports exceed MAX_IB_DEVS

### DIFF
--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -354,7 +354,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
           }
           continue;
         }
-        for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
+        for (int port_num = 1; port_num <= devAttr.phys_port_cnt && ncclNIbDevs < MAX_IB_DEVS; port_num++) {
           struct ibv_port_attr portAttr;
           if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
             WARN("NET/IB : Unable to query port_num %d", port_num);
@@ -394,7 +394,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
               }
             }
           }
-          for (int dev = devOffset; dev < devCount; ++dev) {
+          for (int dev = devOffset; dev < devCount && ncclNIbDevs < MAX_IB_DEVS; ++dev) {
             ncclIbDevs[ncclNIbDevs].device = d;
             ncclIbDevs[ncclNIbDevs].ibProvider = ibProvider;
             ncclIbDevs[ncclNIbDevs].guid = devAttr.sys_image_guid;
@@ -464,6 +464,10 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) {
         ret = ncclInternalError;
         goto fail;
+      }
+      if (ncclNIbDevs >= MAX_IB_DEVS) {
+        WARN("NET/IB : Reached MAX_IB_DEVS=%d IB devices; any additional ports are not used. "
+             "Use NCCL_IB_HCA to select which devices NCCL should use.", MAX_IB_DEVS);
       }
     }
     if (ncclNIbDevs == 0) {


### PR DESCRIPTION
## Description

Fix an out-of-bounds write in the NET/IB device enumeration (`ncclIbInitDevices`,
`src/transport/net_ib/init.cc`) that crashes NCCL initialization on hosts with more
than `MAX_IB_DEVS` active IB/RoCE ports.

The bound `ncclNIbDevs < MAX_IB_DEVS` is only evaluated in the outer per-device loop
condition. The inner per-port loop and the data-direct sub-loop both write to
`ncclIbDevs[ncclNIbDevs]` and increment `ncclNIbDevs` without re-checking the bound,
so a single multi-port device can push `ncclNIbDevs` past `MAX_IB_DEVS` within one
outer iteration and write past the end of the global `ncclIbDevs[MAX_IB_DEVS]` array.
The overflowed index is also handed to the per-device async thread and later to
`qsort()`.

This guards both inner loops with the same `ncclNIbDevs < MAX_IB_DEVS` check so
enumeration stops cleanly at the limit, and adds a one-time `WARN` when the limit is
reached so the ignored ports are not silent. `MAX_IB_DEVS` itself is intentionally
left unchanged -- this PR only prevents the overflow; whether the limit should be
raised/made dynamic is a separate discussion.

## Related Issues

Fixes #2282

## Changes & Impact

- `src/transport/net_ib/init.cc`:
  - add `&& ncclNIbDevs < MAX_IB_DEVS` to the per-port loop and the data-direct
    (`dev < devCount`) loop conditions;
  - add a single `WARN` after enumeration when `ncclNIbDevs >= MAX_IB_DEVS`,
    pointing users to `NCCL_IB_HCA` for device selection.
- No public API / ABI changes.
- Behavior change only on nodes that exceed `MAX_IB_DEVS` active ports: previously
  undefined behavior / crash, now capped at `MAX_IB_DEVS` with a warning. Nodes with
  <= `MAX_IB_DEVS` active ports are byte-for-byte unaffected (the guard never fires).

## Performance Impact

None. The added checks are integer comparisons on the cold initialization path;
the data path is untouched.

### Testing

- Builds cleanly (0 warnings, 0 errors) with CUDA 13.2 and NCCL's default flags.
- Reproduced on a host with 22 IB devices / 54 active RoCE ports:
  - **Before** (default `MAX_IB_DEVS=32`, unpatched): NCCL crashes during
    `ncclIbInitDevices` (out-of-bounds write on `ncclIbDevs[32]`).
  - **After** (patched, `MAX_IB_DEVS=32`): `all_reduce_perf -g 8` initializes and
    completes correctly (`# Out of bounds values : 0 OK`), and NCCL prints exactly
    one warning from `net_ib/init.cc`:
    `NET/IB : Reached MAX_IB_DEVS=32 IB devices; any additional ports are not used.`
