### PR TITLE
[RFC] Device Profiler Hook

### DIFF
--- a/plugins/profiler/example/CMakeLists.txt
+++ b/plugins/profiler/example/CMakeLists.txt
@@ -1,9 +1,16 @@
-# Find all C source files in current directory
+# Host sources plus the device-hook TU (plugin_dev.cu, profiler v7).
 set(SRC_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/print_event.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler_plugin_ce.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugin_dev.cu
 )
+
+# The device hook needs CUDA; enable it and default an architecture if unset.
+enable_language(CUDA)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES native)
+endif()
 
 # Create shared library
 add_library(nccl-profiler-example SHARED ${SRC_FILES})
@@ -19,6 +26,9 @@ set_target_properties(nccl-profiler-example PROPERTIES
     OUTPUT_NAME "nccl-profiler-example"
     PREFIX "lib"
     POSITION_INDEPENDENT_CODE ON
+    # Relocatable device code: the __device__ hook must have a real, callable
+    # global address for NCCL's kernel to invoke it indirectly.
+    CUDA_SEPARABLE_COMPILATION ON
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
 )
 

--- a/plugins/profiler/example/Makefile
+++ b/plugins/profiler/example/Makefile
@@ -8,18 +8,32 @@
 include ../../../makefiles/common.mk
 BUILDDIR ?= .
 NCCLDIR  := $(BUILDDIR)
+DST_DIR  := $(BUILDDIR)
 
-SRC_FILES := $(wildcard *.cc)
-DST_DIR   := $(BUILDDIR)
-OBJ_FILES := $(SRC_FILES:%.cc=${DST_DIR}/%.o)
-DEP_FILES := $(OBJ_FILES:%.o=%.dep)
+# Host sources build with $(CXX); the device-hook TU (plugin_dev.cu) builds with
+# nvcc. It needs relocatable device code so the __device__ hook has a real,
+# callable global address for NCCL's kernel to invoke it; the final link goes
+# through nvcc to perform the device link.
+CC_SRC := $(wildcard *.cc)
+CU_SRC := $(wildcard *.cu)
+CC_OBJ := $(CC_SRC:%.cc=${DST_DIR}/%.o)
+CU_OBJ := $(CU_SRC:%.cu=${DST_DIR}/%.o)
 
 build: ${DST_DIR}/libnccl-profiler-example.so
 
-${DST_DIR}/libnccl-profiler-example.so: ${SRC_FILES}
+${DST_DIR}/%.o: %.cc
 	@printf "Compiling  %-35s > %s\n" $< $@
 	@mkdir -p ${DST_DIR}
-	$(CXX) -Inccl -I${CUDA_INC} -fPIC -shared -o $@ $^
+	$(CXX) -Inccl -I${CUDA_INC} -fPIC -c -o $@ $<
+
+${DST_DIR}/%.o: %.cu
+	@printf "Compiling  %-35s > %s\n" $< $@
+	@mkdir -p ${DST_DIR}
+	$(NVCC) $(NVCC_GENCODE) --relocatable-device-code=true -std=c++17 -Inccl -I${CUDA_INC} -Xcompiler -fPIC -c -o $@ $<
+
+${DST_DIR}/libnccl-profiler-example.so: ${CC_OBJ} ${CU_OBJ}
+	@printf "Linking    %-35s\n" $@
+	$(NVCC) $(NVCC_GENCODE) --relocatable-device-code=true -Xcompiler -fPIC -shared -o $@ $^
 
 clean:
-	rm -f ${DST_DIR}/libnccl-profiler-example.so
+	rm -f ${DST_DIR}/*.o ${DST_DIR}/libnccl-profiler-example.so

--- a/plugins/profiler/example/nccl/profiler.h
+++ b/plugins/profiler/example/nccl/profiler.h
@@ -84,7 +84,9 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v3_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v4_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v5_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
+typedef ncclProfilerEventState_t ncclProfilerEventState_v7_t;
 
+#include "profiler_v7.h"
 #include "profiler_v6.h"
 #include "profiler_v5.h"
 #include "profiler_v4.h"
@@ -93,10 +95,11 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
 #include "profiler_v1.h"
 #include "profiler_net.h"
 
-// Use v6 as default to support CE events
-// v5 and earlier versions are still supported for backward compatibility
-typedef ncclProfiler_v6_t ncclProfiler_t;
-typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_t;
-typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_t;
+// Use v7 as default: v6 event descriptor/state args plus the optional device
+// profiler hook getter. v6 and earlier are still supported for backward
+// compatibility.
+typedef ncclProfiler_v7_t ncclProfiler_t;
+typedef ncclProfilerEventDescr_v7_t ncclProfilerEventDescr_t;
+typedef ncclProfilerEventStateArgs_v7_t ncclProfilerEventStateArgs_t;
 
 #endif // end include guard

--- a/plugins/profiler/example/nccl/profiler_dev.h
+++ b/plugins/profiler/example/nccl/profiler_dev.h
@@ -1,0 +1,49 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+/*************************************************************************
+ * Device-side profiler hook ABI (mirror of NCCL's src/include/profiler_dev.h).
+ *
+ * A profiler plugin provides a __device__ callback (via ncclProfiler_v7's
+ * getDeviceHook) that ncclKernelMain's profiler() invokes at each kernel
+ * work-item boundary. The plugin owns its telemetry (format, buffer, atomicity,
+ * depth, drain). When a hook is registered NCCL does not arm the profiler proxy
+ * op, so no CUDA host callback is added to captured graphs.
+ *************************************************************************/
+#ifndef NCCL_PROFILER_DEV_H_
+#define NCCL_PROFILER_DEV_H_
+
+#include <stdint.h>
+
+#define NCCL_PROFILER_DEV_START 0
+#define NCCL_PROFILER_DEV_STOP 1
+
+// One kernel work-item boundary event. POD + fixed layout for ABI stability.
+typedef struct {
+  uint64_t timestamp;   // globaltimer() ns (device clock)
+  uint64_t workCounter; // monotonic per-channel work counter
+  uint32_t funcId;      // collective identity (index into ncclDevFuncTable)
+  uint8_t channelId;
+  uint8_t phase;       // NCCL_PROFILER_DEV_START / _STOP
+  uint16_t rsvd;
+} ncclProfilerDevEvent_t;
+
+// Plugin device hook. Called on lane 0, once per profiler-enabled work item,
+// when registered. Must be cheap and must not touch the collective's data/sync.
+typedef void (*ncclProfilerDevHook_t)(const ncclProfilerDevEvent_t* ev, void* devCtx);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Exported by libnccl: resolve an event's funcId to a human-readable name (e.g.
+// "AllReduce_Sum_f32_RING_LL"), or "unknown" if out of range.
+const char* ncclProfilerDevFuncName(int funcId);
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NCCL_PROFILER_DEV_H_

--- a/plugins/profiler/example/nccl/profiler_v7.h
+++ b/plugins/profiler/example/nccl/profiler_v7.h
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef PROFILER_V7_H_
+#define PROFILER_V7_H_
+
+#include "profiler_v6.h"
+
+// v7 reuses the v6 event descriptor / state args verbatim (no new host-side
+// events) and only adds an optional device-side profiler hook getter.
+typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_v7_t;
+typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_v7_t;
+
+typedef struct {
+  const char* name;
+
+  // init - initialize the profiler plugin
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes,
+                       int nranks, int rank, ncclDebugLogger_t logfn);
+
+  // startEvent - initialize and start a new event
+  ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v7_t* eDescr);
+
+  // stopEvent - stop/finalize an event
+  ncclResult_t (*stopEvent)(void* eHandle);
+
+  // recordEventState - record event state transitions and updates
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v7_t eState,
+                                   ncclProfilerEventStateArgs_v7_t* eStateArgs);
+
+  // finalize - finalize the profiler plugin
+  ncclResult_t (*finalize)(void* context);
+
+  // getDeviceHook - optional device-side profiler hook (see profiler_dev.h).
+  // Return the plugin's __device__ hook (a device fn ptr valid on cudaDev) plus
+  // an opaque device context; *devHook = nullptr for no hook on this device.
+  ncclResult_t (*getDeviceHook)(int cudaDev, void** devHook, void** devCtx);
+} ncclProfiler_v7_t;
+
+#endif // PROFILER_V7_H_

--- a/plugins/profiler/example/plugin.cc
+++ b/plugins/profiler/example/plugin.cc
@@ -17,6 +17,9 @@
 #include "print_event.h"
 #include "profiler_plugin_ce.h"
 
+extern "C" ncclResult_t exampleProfilerGetDeviceHook(int cudaDev, void** devHook, void** devCtx);
+extern "C" void exampleProfilerDrainDeviceHook(void);
+
 #define __hidden __attribute__ ((visibility("hidden")))
 
 static int initialized;             // initialization counter for profiler
@@ -451,6 +454,7 @@ __hidden ncclResult_t exampleProfilerFinalize(void* context) {
   if (__atomic_sub_fetch(&initialized, 1, __ATOMIC_RELAXED) == 0) {
     finalizeGlobalProfiler(fh);
     freeDeferredContexts();
+    exampleProfilerDrainDeviceHook(); 
   }
 
   if (fh) fprintf(fh, "{}]\n");
@@ -1140,3 +1144,13 @@ ncclProfiler_v6_t ncclProfiler_v6 = {
   exampleProfilerFinalize,
 };
 
+// adds the optional device-side profiler hook (see plugin_dev.cu).
+ncclProfiler_v7_t ncclProfiler_v7 = {
+  "Example-profiler-v7",
+  exampleProfilerInit,
+  exampleProfilerStartEvent_v6,
+  exampleProfilerStopEvent_v6,
+  exampleProfilerRecordEventState_v6,
+  exampleProfilerFinalize,
+  exampleProfilerGetDeviceHook,
+};

--- a/plugins/profiler/example/plugin_dev.cu
+++ b/plugins/profiler/example/plugin_dev.cu
@@ -1,0 +1,95 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+/*************************************************************************
+ * Device-side profiler hook for the example plugin (profiler interface v7).
+ *
+ * exampleProfilerGetDeviceHook() returns a __device__ callback that NCCL invokes
+ * once per work item from inside ncclKernelMain's profiler(). The hook counts
+ * events per device into its own device context (the plugin owns all telemetry);
+ * exampleProfilerDrainDeviceHook() copies the counters back and prints them at
+ * finalize, resolving the last funcId via the libnccl-exported
+ * ncclProfilerDevFuncName().
+ *
+ * Opt-in: the hook is only returned when NCCL_PROFILER_EXAMPLE_DEV_HOOK is set,
+ * so loading this example otherwise keeps its host-side behavior unchanged.
+ *
+ * Built with nvcc + relocatable device code (see Makefile): the __device__ hook
+ * must have a real, callable global address for NCCL's kernel to invoke it.
+ *************************************************************************/
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include "err.h" // ncclResult_t
+#include "profiler_dev.h"
+
+#define EXAMPLE_MAX_DEVICES 64
+
+// Per-device telemetry owned by the hook (its ctx). A real plugin would use its
+// own ring/buffer; here a counter plus the last event's identity suffices.
+struct ExampleDevCtx {
+  unsigned long long count;
+  unsigned int lastFuncId;
+  unsigned int lastPhase;
+};
+
+// The device hook: cheap, leaf, touches only its own ctx. Runs on lane 0, once
+// per profiler-enabled work item, directly inside the NCCL kernel.
+__device__ void exampleDevHook(const ncclProfilerDevEvent_t* ev, void* ctx) {
+  ExampleDevCtx* c = (ExampleDevCtx*)ctx;
+  atomicAdd(&c->count, 1ULL);
+  c->lastFuncId = ev->funcId;
+  c->lastPhase = ev->phase;
+}
+
+// Capture exampleDevHook's callable device address at runtime. Requires
+// relocatable device code (-rdc=true) so the __device__ function has a real
+// global address that NCCL's kernel can call indirectly across modules.
+__global__ void exampleCaptureHookAddr(void** out) { *out = (void*)exampleDevHook; }
+
+static ExampleDevCtx* gDevCtx[EXAMPLE_MAX_DEVICES] = {nullptr};
+
+extern "C" ncclResult_t exampleProfilerGetDeviceHook(int cudaDev, void** devHook, void** devCtx) {
+  if (devHook) *devHook = nullptr;
+  if (devCtx) *devCtx = nullptr;
+  // Opt-in: no device hook unless explicitly enabled.
+  if (getenv("NCCL_PROFILER_EXAMPLE_DEV_HOOK") == nullptr) return ncclSuccess;
+  if (cudaDev < 0 || cudaDev >= EXAMPLE_MAX_DEVICES) return ncclSuccess;
+  if (cudaSetDevice(cudaDev) != cudaSuccess) return ncclSuccess;
+
+  // Resolve the hook's device address (see exampleCaptureHookAddr).
+  void** dOut = nullptr;
+  if (cudaMalloc(&dOut, sizeof(void*)) != cudaSuccess) return ncclSuccess;
+  exampleCaptureHookAddr<<<1, 1>>>(dOut);
+  cudaDeviceSynchronize();
+  void* fn = nullptr;
+  cudaMemcpy(&fn, dOut, sizeof(fn), cudaMemcpyDeviceToHost);
+  cudaFree(dOut);
+  if (!fn) return ncclSuccess;
+
+  // Allocate this device's telemetry context once.
+  if (!gDevCtx[cudaDev]) {
+    if (cudaMalloc(&gDevCtx[cudaDev], sizeof(ExampleDevCtx)) != cudaSuccess) return ncclSuccess;
+    cudaMemset(gDevCtx[cudaDev], 0, sizeof(ExampleDevCtx));
+  }
+  *devHook = fn;
+  *devCtx = gDevCtx[cudaDev];
+  return ncclSuccess;
+}
+
+// Print each device's captured counts. Called from the plugin's finalize; a
+// no-op unless a device hook was handed out (gDevCtx allocated).
+extern "C" void exampleProfilerDrainDeviceHook(void) {
+  for (int d = 0; d < EXAMPLE_MAX_DEVICES; d++) {
+    if (!gDevCtx[d]) continue;
+    ExampleDevCtx h = {};
+    cudaSetDevice(d);
+    cudaMemcpy(&h, gDevCtx[d], sizeof(h), cudaMemcpyDeviceToHost);
+    fprintf(stderr, "PROFILER/DeviceHook: dev=%d events=%llu lastFunc=%s phase=%s\n", d, h.count,
+            ncclProfilerDevFuncName((int)h.lastFuncId), h.lastPhase == NCCL_PROFILER_DEV_STOP ? "STOP" : "START");
+  }
+}

--- a/src/device/common.h
+++ b/src/device/common.h
@@ -10,6 +10,7 @@
 
 #include "collectives.h"
 #include "device.h"
+#include "profiler_dev.h"
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
@@ -328,22 +329,24 @@ __device__ __forceinline__ bool profilerEnabled(int workItemIdx) {
 
 __device__ __forceinline__ void profiler(int action) {
   if (threadIdx.x == 0) {
+    ncclProfilerDevHook_t hook = (ncclProfilerDevHook_t)ncclShmem.comm.profilerDevHook;
+    void* hookCtx = ncclShmem.comm.profilerDevCtx;
+    uint8_t phase = (action == START) ? NCCL_PROFILER_DEV_START : NCCL_PROFILER_DEV_STOP;
     int idx = 0;
     uint64_t wc = ncclShmem.channel.workCounter + 1;
-    if (action == START) {
-      for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-        if (!profilerEnabled(idx++)) continue;
-        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp =
-          globaltimer();
-        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+    for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
+      bool enabled = profilerEnabled(idx++);
+      if (hook) {
+        ncclProfilerDevEvent_t ev = {globaltimer(), wc, ncclShmem.funcId, (uint8_t)ncclShmem.channelId, phase, 0};
+        hook(&ev, hookCtx);
       }
-    } else {
-      for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-        if (!profilerEnabled(idx++)) continue;
-        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp =
-          globaltimer();
-        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+      if (enabled) {
+        auto* ring = (action == START) ? ncclShmem.comm.workStarted : ncclShmem.comm.workCompleted;
+        ring[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
+        ring[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
+    }
+    if (action != START) {
       ncclShmem.channel.workCounter += ncclShmem.nWorks;
       if (action == FINI)
         ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter =

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -272,6 +272,15 @@ with open(os.path.join(gensrc, "host_table.cc"), "w") as f:
   out("-1};\n")
   out("\n")
 
+  # Maps a primary function id (what ncclDevFuncId() returns, i.e. the funcId
+  # seen by the device profiler hook) to a human-readable name. Indexed the same
+  # as ncclDevKernelForFunc[]; length is ncclDevFuncIdCount.
+  out("extern const char* const ncclDevFuncName[] = {\n")
+  for index, fn in enumerate(primary_funcs):
+    out('/*%4d*/ "%s",\n' % (index, paste("_", *fn)))
+  out("nullptr};\n")
+  out("\n")
+
   # Forward declarations of kernels.
   for kfn in kernel_funcs:
     cudart, _ = required_cuda(*kfn)

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -457,6 +457,15 @@ struct ncclKernelComm {
   // Profiler counters
   struct ncclDevProfiler* workStarted /*[MAXCHANNELS]*/;
   struct ncclDevProfiler* workCompleted /*[MAXCHANNELS]*/;
+
+  // Optional device-side profiler hook (see include/profiler_dev.h). When
+  // profilerDevHook != nullptr, profiler() calls it once per work item, in
+  // addition to and independent of the workStarted/workCompleted rings (which
+  // stay gated by each work item's profilerEnabled flag). The hook itself needs
+  // no proxy op or host callback. Typed void* to keep device.h free of the hook
+  // typedef; common.h casts it.
+  void* profilerDevHook; // ncclProfilerDevHook_t
+  void* profilerDevCtx;  // opaque device context passed to the hook
 };
 
 struct alignas(16) ncclKernelCommAndChannels {
@@ -578,6 +587,9 @@ extern int ncclDevKernelRequirements[/*ncclDevKernelCount*/];
 extern int const ncclDevFuncRowToId[];
 extern void* const ncclDevKernelForFunc[/*funcIndex*/];
 extern bool const ncclDevKernelForFuncIsSpecialized[/*funcIndex*/];
+// Human-readable name per primary func id (the funcId the profiler hook sees).
+extern int const ncclDevFuncIdCount;
+extern const char* const ncclDevFuncName[/*funcIndex*/];
 
 // Launch a one-rank reduction on stream.
 ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct ncclDevRedOpFull redOp,

--- a/src/include/plugin/nccl_profiler.h
+++ b/src/include/plugin/nccl_profiler.h
@@ -79,10 +79,12 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v3_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v4_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v5_t;
 typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
+typedef ncclProfilerEventState_t ncclProfilerEventState_v7_t;
 
 /* profiler_v*.h use ncclPid_t, defined in os.h (os/linux.h or os/windows.h) */
 #include "os.h"
 #include <cstdint>
+#include "profiler/profiler_v7.h"
 #include "profiler/profiler_v6.h"
 #include "profiler/profiler_v5.h"
 #include "profiler/profiler_v4.h"
@@ -90,11 +92,12 @@ typedef ncclProfilerEventState_t ncclProfilerEventState_v6_t;
 #include "profiler/profiler_v2.h"
 #include "profiler/profiler_v1.h"
 
-// Use v6 as default to support CE events
-// v5 and earlier versions are still supported for backward compatibility
-typedef ncclProfiler_v6_t ncclProfiler_t;
-typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_t;
-typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_t;
+// Use v7 as default: the v6 event descriptor/state args plus the optional
+// device-side profiler hook getter. v6 and earlier are still supported for
+// backward compatibility (their shims adapt to v7 with no device hook).
+typedef ncclProfiler_v7_t ncclProfiler_t;
+typedef ncclProfilerEventDescr_v7_t ncclProfilerEventDescr_t;
+typedef ncclProfilerEventStateArgs_v7_t ncclProfilerEventStateArgs_t;
 
 #define NCCL_PROFILER_NET_VER_BITS (16)
 #define NCCL_PROFILER_NET_VER_MASK (~0U >> NCCL_PROFILER_NET_VER_BITS)

--- a/src/include/plugin/profiler/profiler_v7.h
+++ b/src/include/plugin/profiler/profiler_v7.h
@@ -1,0 +1,42 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef PROFILER_V7_H_
+#define PROFILER_V7_H_
+
+#include "profiler_v6.h"
+
+// v7 reuses the v6 event descriptor / state args verbatim (no new host-side
+// events) and only adds an optional device-side profiler hook getter.
+typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_v7_t;
+typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_v7_t;
+
+typedef struct {
+  const char* name;
+
+  // init - initialize the profiler plugin
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes,
+                       int nranks, int rank, ncclDebugLogger_t logfn);
+
+  // startEvent - initialize and start a new event
+  ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v7_t* eDescr);
+
+  // stopEvent - stop/finalize an event
+  ncclResult_t (*stopEvent)(void* eHandle);
+
+  // recordEventState - record event state transitions and updates
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v7_t eState,
+                                   ncclProfilerEventStateArgs_v7_t* eStateArgs);
+
+  // finalize - finalize the profiler plugin
+  ncclResult_t (*finalize)(void* context);
+
+  // getDeviceHook - optional device-side profiler hook
+  ncclResult_t (*getDeviceHook)(int cudaDev, void** devHook, void** devCtx);
+} ncclProfiler_v7_t;
+
+#endif // PROFILER_V7_H_

--- a/src/include/profiler.h
+++ b/src/include/profiler.h
@@ -27,6 +27,9 @@ struct ncclProfilerProxy {
   uint64_t workCounter[MAXCHANNELS]; // host work counter
   struct ncclProxyConnector sendProxyConn[MAXCHANNELS];
   struct ncclProxyConnector recvProxyConn[MAXCHANNELS];
+  // Optional device-side profiler hook 
+  void* devHook; // ncclProfilerDevHook_t (device fn ptr)
+  void* devCtx;  // opaque device context passed to the hook
 };
 
 enum groupApiState {
@@ -53,6 +56,9 @@ extern int ncclProfilerEventMask;
 // Plugin Init/Finalize Wrappers
 ncclResult_t ncclProfilerPluginInit(struct ncclComm* comm);
 ncclResult_t ncclProfilerPluginFinalize(struct ncclComm* comm);
+
+// Device-side profiler hook
+ncclResult_t ncclProfilerDevGetHook(int device, void** devHook, void** devCtx);
 
 // Profiler Start/Stop/Record wrappers for ncclGroupStart and ncclGroupEnd API calls
 ncclResult_t ncclProfilerStartGroupApiEvent(struct ncclInfo* info, bool isGraphCaptured);

--- a/src/include/profiler_dev.h
+++ b/src/include/profiler_dev.h
@@ -1,0 +1,45 @@
+/*************************************************************************
+ * Device-side profiler hook ABI.
+ *
+ * Lets a profiler plugin provide a __device__ callback that ncclKernelMain's
+ * profiler() invokes at each kernel work-item boundary. The plugin writes its
+ * own telemetry (its own format, buffer, atomicity, depth) and drains it itself
+ * -- an alternative to the fixed workStarted/workCompleted ring + proxy delivery.
+ * The hook is additive and needs no proxy op or host callback: a plugin that
+ * uses it without enabling ncclProfileKernelCh gets kernel timing with nothing
+ * added to captured graphs. See plugins/profiler/example for a reference consumer.
+ *************************************************************************/
+#ifndef NCCL_PROFILER_DEV_H_
+#define NCCL_PROFILER_DEV_H_
+
+#include <stdint.h>
+
+#define NCCL_PROFILER_DEV_START 0
+#define NCCL_PROFILER_DEV_STOP 1
+
+// One kernel work-item boundary event. POD + fixed layout for ABI stability.
+typedef struct {
+  uint64_t timestamp;   // globaltimer() ns (device clock)
+  uint64_t workCounter; // monotonic per-channel work counter
+  uint32_t funcId;      // collective identity (index into ncclDevFuncTable)
+  uint8_t channelId;
+  uint8_t phase;       // NCCL_PROFILER_DEV_START / _STOP
+  uint16_t rsvd;
+} ncclProfilerDevEvent_t;
+
+// Plugin device hook. Called on lane 0, once per profiler-enabled work item,
+// when registered. Must be cheap and must not touch the collective's data/sync.
+typedef void (*ncclProfilerDevHook_t)(const ncclProfilerDevEvent_t* ev, void* devCtx);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Resolve an event's funcId to a human-readable name (e.g.
+// "AllReduce_Sum_f32_RING_LL"); returns a static NCCL-owned string, or
+// "unknown" if out of range. Backed by the generated device-func name table.
+const char* ncclProfilerDevFuncName(int funcId);
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NCCL_PROFILER_DEV_H_

--- a/src/init.cc
+++ b/src/init.cc
@@ -651,6 +651,9 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->profiler.workCompleted, MAXCHANNELS), ret, fail);
   tmpCommAndChans.comm.workStarted = comm->profiler.workStarted;
   tmpCommAndChans.comm.workCompleted = comm->profiler.workCompleted;
+  NCCLCHECKGOTO(ncclProfilerDevGetHook(comm->cudaDev, &comm->profiler.devHook, &comm->profiler.devCtx), ret, fail);
+  tmpCommAndChans.comm.profilerDevHook = comm->profiler.devHook;
+  tmpCommAndChans.comm.profilerDevCtx = comm->profiler.devCtx;
   ncclCommPushCudaHostFree(comm, comm->profiler.workStarted);
   ncclCommPushCudaHostFree(comm, comm->profiler.workCompleted);
 

--- a/src/plugin/profiler.cc
+++ b/src/plugin/profiler.cc
@@ -24,6 +24,7 @@ extern ncclProfiler_t* getNcclProfiler_v3(void* lib);
 extern ncclProfiler_t* getNcclProfiler_v4(void* lib);
 extern ncclProfiler_t* getNcclProfiler_v5(void* lib);
 extern ncclProfiler_t* getNcclProfiler_v6(void* lib);
+extern ncclProfiler_t* getNcclProfiler_v7(void* lib);
 
 static std::mutex profilerMutex;
 static int profilerPluginRefCount;
@@ -70,7 +71,10 @@ static ncclResult_t ncclProfilerPluginLoad(void) {
     profilerName = ncclPluginLibPaths[ncclPluginTypeProfiler];
   }
 
-  ncclProfiler = getNcclProfiler_v6(profilerPluginLib);
+  ncclProfiler = getNcclProfiler_v7(profilerPluginLib);
+  if (ncclProfiler == nullptr) {
+    ncclProfiler = getNcclProfiler_v6(profilerPluginLib);
+  }
   if (ncclProfiler == nullptr) {
     ncclProfiler = getNcclProfiler_v5(profilerPluginLib);
   }
@@ -257,6 +261,15 @@ ncclResult_t ncclProfilerPluginInit(struct ncclComm* comm) {
     printProfilerEventMask(ncclProfilerEventMask);
   }
   TIME_STOP_EVENT(init);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclProfilerDevGetHook(int device, void** devHook, void** devCtx) {
+  if (devHook) *devHook = nullptr;
+  if (devCtx) *devCtx = nullptr;
+  if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && ncclProfiler->getDeviceHook) {
+    NCCLCHECK(ncclProfiler->getDeviceHook(device, devHook, devCtx));
+  }
   return ncclSuccess;
 }
 

--- a/src/plugin/profiler/profiler_v6.cc
+++ b/src/plugin/profiler/profiler_v6.cc
@@ -12,12 +12,22 @@
 #include "os.h"
 
 static ncclProfiler_v6_t* ncclProfiler_v6;
+static ncclProfiler_t ncclProfiler;
 
 ncclProfiler_t* getNcclProfiler_v6(void* lib) {
   ncclProfiler_v6 = (ncclProfiler_v6_t*)ncclOsDlsym(lib, "ncclProfiler_v6");
   if (ncclProfiler_v6) {
+    // v7 reuses the v6 event descriptor / state args, so the host-side callbacks
+    // pass straight through; v6 plugins carry no device hook.
+    ncclProfiler.name = ncclProfiler_v6->name;
+    ncclProfiler.init = ncclProfiler_v6->init;
+    ncclProfiler.startEvent = ncclProfiler_v6->startEvent;
+    ncclProfiler.stopEvent = ncclProfiler_v6->stopEvent;
+    ncclProfiler.recordEventState = ncclProfiler_v6->recordEventState;
+    ncclProfiler.finalize = ncclProfiler_v6->finalize;
+    ncclProfiler.getDeviceHook = nullptr;
     INFO(NCCL_INIT, "PROFILER/Plugin: Loaded %s (v6)", ncclProfiler_v6->name);
-    return ncclProfiler_v6;
+    return &ncclProfiler;
   }
   return NULL;
 }

--- a/src/plugin/profiler/profiler_v7.cc
+++ b/src/plugin/profiler/profiler_v7.cc
@@ -1,0 +1,24 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "comm.h"
+#include "nccl_profiler.h"
+#include "plugin/profiler/profiler_v7.h"
+#include "checks.h"
+#include "os.h"
+
+static ncclProfiler_v7_t* ncclProfiler_v7;
+
+// v7 is the current default ncclProfiler_t, so the plugin struct is used as-is.
+ncclProfiler_t* getNcclProfiler_v7(void* lib) {
+  ncclProfiler_v7 = (ncclProfiler_v7_t*)ncclOsDlsym(lib, "ncclProfiler_v7");
+  if (ncclProfiler_v7) {
+    INFO(NCCL_INIT, "PROFILER/Plugin: Loaded %s (v7)", ncclProfiler_v7->name);
+    return ncclProfiler_v7;
+  }
+  return NULL;
+}

--- a/src/plugin/profiler_dev.cc
+++ b/src/plugin/profiler_dev.cc
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Device-side profiler hook support.
+ *
+ * The device hook itself is provided by the profiler plugin .so and resolved
+ * by NCCL through the profiler v7 getDeviceHook method (ncclProfiler_v7_t, see
+ * plugin/profiler/profiler_v7.h and plugin/profiler.cc); this file only holds
+ * the funcId -> name resolver that a plugin can call to label events.
+ *************************************************************************/
+#include "nccl.h"
+#include "profiler_dev.h"
+
+// Generated name table for primary func ids (device/host_table.cc); lets a
+// consumer resolve a hook event's funcId to a name without reproducing the
+// codegen's variant enumeration.
+extern int const ncclDevFuncIdCount;
+extern const char* const ncclDevFuncName[];
+
+extern "C" __attribute__((visibility("default"))) const char* ncclProfilerDevFuncName(int funcId) {
+  if (funcId >= 0 && funcId < ncclDevFuncIdCount) return ncclDevFuncName[funcId];
+  return "unknown";
+}


### PR DESCRIPTION
# RFC: Device-Side Profiler Hook

## Summary

Add an optional **device-side profiler hook**: a `__device__` callback that
`ncclKernelMain`'s `profiler()` invokes at each kernel work-item boundary
(START / STOP). A profiler plugin `.so` **provides** the hook + opaque context
per device, NCCL **discovers** it through the same plugin-`.so` path as the host
profiler, and from then on calls it directly from the kernel with a small POD
event. The plugin owns its telemetry end-to-end — buffer, format, atomicity,
depth, and draining.

The hook is **additive and independent** of the legacy path: it fires per work
item whenever registered, needs no proxy op or host callback, and does not
disable the ring. A plugin gets graph-launch-overhead-free kernel timing simply
by using the hook and **not** enabling `ncclProfileKernelCh` — so no proxy op /
host callback is armed at all — which the legacy ring alone cannot offer.

This is an alternative to the fixed `workStarted` / `workCompleted` ring +
proxy-delivery path for consumers that want it, while leaving that path fully
intact for everyone else.

## Motivation

Today NCCL's device profiler writes two fixed-size per-channel rings
(`workStarted`, `workCompleted`), each entry a `{timestamp, counter}` pair, and
delivers them to the host profiler plugin via a proxy op. That design has two
limits:

1. **Fixed schema.** The ring records only a timestamp and work counter. A
   consumer wanting richer per-work telemetry (func identity, custom fields,
   its own ring depth/format) can't get it without patching core.
2. **Graph overhead.** Proxy delivery adds a CUDA host callback to captured
   CUDA graphs, which perturbs exactly the kernel timing a profiler is trying to
   measure.

We want a path where a plugin can capture whatever it needs, directly on the
device, with zero added host-side work in the graph.

## Design

### Event ABI (`src/include/profiler_dev.h`, new)

A POD event with a fixed layout for ABI stability:

```c
typedef struct {
  uint64_t timestamp;   // globaltimer() ns (device clock)
  uint64_t workCounter; // monotonic per-channel work counter
  uint32_t funcId;      // collective identity (index into ncclDevFuncTable)
  uint8_t  channelId;
  uint8_t  phase;       // NCCL_PROFILER_DEV_START / _STOP
  uint16_t rsvd;
} ncclProfilerDevEvent_t;

typedef void (*ncclProfilerDevHook_t)(const ncclProfilerDevEvent_t* ev, void* devCtx);
```

The hook is called **on lane 0, once per profiler-enabled work item**. It must
be cheap and must not touch the collective's data or synchronization.

A helper resolves a `funcId` to a human-readable name (e.g.
`"AllReduce_Sum_f32_RING_LL"`):

```c
const char* ncclProfilerDevFuncName(int funcId);
```

### Discovery (`src/plugin/profiler/profiler_v7.{h,cc}`, new)

The device hook is provided by the profiler plugin `.so` as a new method on the
versioned profiler interface. `ncclProfiler_v7` reuses the v6 event descriptor /
state args verbatim (no new host-side events) and adds one method:

```c
typedef struct {
  const char* name;
  ncclResult_t (*init)(...);              // same as v6
  ncclResult_t (*startEvent)(...);        // same as v6
  ncclResult_t (*stopEvent)(...);         // same as v6
  ncclResult_t (*recordEventState)(...);  // same as v6
  ncclResult_t (*finalize)(...);          // same as v6
  // Return the plugin's device hook (a __device__ fn ptr valid on `cudaDev`)
  // and opaque context. *devHook == nullptr => no hook on this device.
  ncclResult_t (*getDeviceHook)(int cudaDev, void** devHook, void** devCtx);
} ncclProfiler_v7_t;
```

- `ncclProfiler_v7_t` becomes the default `ncclProfiler_t`. `profiler.cc` tries
  `getNcclProfiler_v7()` first in the existing version-fallback chain
  (v7 → v6 → … → v1).
- The **v6 shim now adapts** into v7: host callbacks pass straight through (the
  descriptor is identical) and `getDeviceHook` is set to `nullptr`. v5-and-older
  shims already adapt into `ncclProfiler_t`; their zero-initialized struct leaves
  `getDeviceHook` null. So a plugin built against any version ≤ v6 simply has no
  device hook.
- `ncclProfilerDevGetHook(device, …)` (internal) forwards to
  `ncclProfiler->getDeviceHook` when non-null. The plugin resolves its own
  `__device__` symbol on `device` (a `__device__` function has a distinct address
  per device — the plugin owns the device code, so resolution lives where it
  belongs).
- **No new exported libnccl symbol.** Control stays inverted (NCCL pulls from a
  passive plugin), exactly like the rest of the profiler. `ncclProfilerDevFuncName`
  remains exported for plugins to resolve `funcId` → name.

### Propagation (`src/init.cc`)

At comm init (`devCommSetup`, after `ncclProfilerPluginInit` has loaded the
plugin), NCCL pulls the hook for the comm's device into the device comm:

```c
ncclProfilerDevGetHook(comm->cudaDev, &comm->profiler.devHook, &comm->profiler.devCtx);
tmpCommAndChans.comm.profilerDevHook = comm->profiler.devHook;
tmpCommAndChans.comm.profilerDevCtx  = comm->profiler.devCtx;
```

`nullptr` (no plugin, or plugin returns none) => legacy ring behavior, unchanged.

`ncclKernelComm` (`src/include/device.h`) gains two `void*` fields
(`profilerDevHook`, `profilerDevCtx`), typed as `void*` to keep `device.h` free
of the hook typedef; `common.h` casts them. `ncclProfilerState`
(`src/include/profiler.h`) gains the matching host-side `devHook` / `devCtx`.

### Kernel path (`src/device/common.h`)

`profiler()` is restructured into a single loop over work items. For each
profiler-enabled item:

- If a hook is registered, build a stack `ncclProfilerDevEvent_t` and call the
  hook.
- Independently, if the item is `profilerEnabled`, write the legacy
  `workStarted` / `workCompleted` ring as before.

The hook fires **whenever registered** and is independent of the host profiler
plugin; the legacy ring stays gated by `profilerEnabled` (the plugin's per-work
flag). Both can run simultaneously.

### Func-name table (`src/device/generate.py`)

Codegen now emits `ncclDevFuncName[]` — one human-readable name per primary
func id, indexed the same as `ncclDevKernelForFunc[]` — plus
`ncclDevFuncIdCount`. This backs `ncclProfilerDevFuncName()` so a consumer can
resolve `funcId` without reproducing the codegen's variant enumeration.

### Example / testing (`plugins/profiler/example`)

The example profiler plugin is bumped to v7 and gains a real device hook
(`plugin_dev.cu`): a `__device__` callback that counts events per device into its
own device context and, at finalize, prints the counts and resolves the last
`funcId` via `ncclProfilerDevFuncName()`. It is opt-in via
`NCCL_PROFILER_EXAMPLE_DEV_HOOK`, so the example's host-side behavior is
unchanged by default. It is built with nvcc + relocatable device code (the
`__device__` hook needs a real, callable global address for the kernel to invoke
it indirectly). This ships as a separate commit on top of the core change.

Validated end to end on 2× GB200 via `all_reduce_perf`: with the hook enabled it
fires per work item (e.g. ~6.7k events/device for a size sweep), resolves func
names (e.g. `AllReduce_Sum_f32_RING_LL`), and reports `#wrong = 0`; with the hook
disabled (default) behavior and results are unchanged.

## Compatibility

- **Fully backward compatible.** No hook registered (`nullptr`) => existing
  `workStarted` / `workCompleted` ring + proxy path is unchanged.
- New ABI (`ncclProfilerDevEvent_t`) is POD with fixed layout and a reserved
  field for forward evolution.
- Only additive changes to `ncclKernelComm` / `ncclProfilerState`; no existing
  fields removed or reordered.

## Alternatives considered

- **Exported push API (`ncclProfilerDevSetHook`).** The consumer resolves its own
  `__device__` fn ptr and pushes it into a process-wide per-device store in
  libnccl before creating comms. Rejected as the OSS ABI: it adds a new exported
  libnccl symbol and a second registration mechanism unlike the established
  plugin-discovery model. Note the tradeoff — push is a more direct fit for a
  consumer that *generates* its hook at runtime (e.g. NVRTC), since pull requires
  such a consumer to wrap the runtime-resolved pointer behind a plugin `.so` +
  its own setter. We chose pull for ABI cleanliness; a runtime consumer builds a
  thin plugin whose `getDeviceHook` returns its runtime-set pointer.
- **Dedicated `ncclProfilerDev_v1` symbol** on the same `.so`, independent of the
  host profiler version. Rejected: its only real advantage is letting a plugin
  provide a device hook *without* being the host profiler — a marginal case, since
  only one profiler plugin loads and a device profiler *is* a profiler. Folding
  the method onto `ncclProfiler_v7` keeps a single versioned interface and reuses
  the existing fallback machinery; v7 reuses the v6 descriptor by typedef, so there
  is no struct duplication.
- **Extend the existing ring schema.** Rejected: still incurs proxy/host-callback
  graph overhead, and bakes one more fixed format into core.
- **Deliver richer events through the proxy.** Rejected for the same graph-overhead
  reason; the whole point is to avoid host callbacks in captured graphs.

## Open questions

- The hook is pulled once at comm init; hot re-registration after comms exist is
  not supported (existing device comms keep their copy).
