### PR TITLE
Fix CE synchronization for two-rank LSA teams

### DIFF
--- a/src/ce_coll.cc
+++ b/src/ce_coll.cc
@@ -130,6 +130,10 @@ bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_
   return true;
 }
 
+bool ncclCeUseMCSync(struct ncclComm* comm) {
+  return comm->nvlsSupport && ncclTeamLsa(comm).nRanks > 2 && !comm->p2pCrossClique;
+}
+
 ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, CUstreamBatchMemOpParams* batchParams,
                             size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
@@ -237,9 +241,9 @@ ncclResult_t ncclMemOpSync(struct ncclComm* comm, cudaStream_t stream, struct nc
   uint32_t* readyPtrs = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
 
-  // Allocate enough slots for all possible ops
-  // For cross-clique, NVLS multicast isn't available across cliques - use unicast sync instead
-  bool useMCSync = comm->nvlsSupport && !comm->p2pCrossClique;
+  // Allocate enough slots for all possible ops. LSA multicast is only enabled
+  // for teams where NCCL's symmetric-kernel path also enables it.
+  bool useMCSync = ncclCeUseMCSync(comm);
   size_t batchSize = (useMCSync ? NCCL_CE_SYNC_OPS_PER_RANK_MC : NCCL_CE_SYNC_OPS_PER_RANK_UC) * lsaSize;
   size_t opIdx = 0;
   CUstreamBatchMemOpParams* batchParams = nullptr;
@@ -1431,7 +1435,7 @@ ncclResult_t scheduleCeCollTaskToPlan(struct ncclComm* comm, struct ncclKernelPl
       INFO(NCCL_TUNING, "%s [Hierarchical CE]: %ld Bytes -> RMA proxy + CE", ncclFuncToString(task->func),
            task->count * ncclTypeSize(task->datatype));
     } else {
-      const char* nvlsSync = comm->nvlsSupport ? "; CE synchronization with NVLS" : "";
+      const char* nvlsSync = ncclCeUseMCSync(comm) ? "; CE synchronization with NVLS" : "";
       INFO(NCCL_TUNING, "%s [Copy Engine]: %ld Bytes -> cudaMemcpy%s", ncclFuncToString(task->func),
            task->count * ncclTypeSize(task->datatype), nvlsSync);
     }

--- a/src/include/ce_coll.h
+++ b/src/include/ce_coll.h
@@ -64,6 +64,8 @@ struct ncclCeBatchOpsParams {
 bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
                      ncclSymRegType_t winRegType);
 
+bool ncclCeUseMCSync(struct ncclComm* comm);
+
 bool ncclHierCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
                          ncclSymRegType_t winRegType);
 

--- a/src/plugin/profiler.cc
+++ b/src/plugin/profiler.cc
@@ -837,8 +837,7 @@ ncclResult_t ncclProfilerStartCeCollEvent(struct ncclComm* comm, struct ncclCeCo
       eDescr.ceColl.count = args->nElts;
       eDescr.ceColl.root = args->rootRank;
       eDescr.ceColl.datatype = ncclDatatypeToString(args->datatype);
-      // NVLS multicast isn't available across cliques - report UC for cross-clique
-      eDescr.ceColl.syncStrategy = (comm->nvlsSupport && !comm->p2pCrossClique) ? "MC" : "UC";
+      eDescr.ceColl.syncStrategy = ncclCeUseMCSync(comm) ? "MC" : "UC";
       eDescr.ceColl.intraBatchSync = false;
       eDescr.ceColl.batchSize = 0;
       eDescr.ceColl.numBatches = 0;


### PR DESCRIPTION
## Why is this change needed?

Copy-engine collectives can hang or fail with `invalid resource handle` on two-rank LSA (sub)communicators. 

Main reason is: `ncclMemOpSync` selects multicast synchronization whenever NVLS is generally available (`src/ce_coll.cc`), while symmetric-kernel initialization only enables LSA multicast for teams larger than two ranks (`src/sym_kernels.cc`).

For a two-rank communicator, the first CE collective therefore requests a multicast team that initialization deliberately did not establish. The team is created lazily in `symTeamObtain`, whose contract requires a team barrier afterward (`src/dev_runtime.cc`) that the CE path does not perform: the creating rank's 4-byte multicast flag write can execute before the peer rank has imported the multicast handle and bound its memory, so the write is lost and the peer's `CU_STREAM_MEM_OP_WAIT_VALUE_32` waits forever. On multi-node NVLink (MNNVL) systems the fabric-handle import latency makes this a deterministic hang rather than a rare race.

## Summary

- Use a shared `ncclCeUseMCSync` predicate matching the symmetric-kernel LSA multicast capability gate.
- Keep CE payload copies enabled for two-rank teams, but synchronize their ready/completion flags with unicast peer writes.
- Report the effective multicast/unicast strategy consistently in tuning logs and profiler events.

## Repro

nccl-tests on two MNNVL-connected nodes with 4 GPUs each. 

```
mpirun -H <nodeA>:4,<nodeB>:4 -np 8 -x NCCL_TESTS_SPLIT=MOD4 \
-x NCCL_CTA_POLICY=ZERO \
./build/all_gather_perf -b 1M -e 32M -f 2 -g 1 -R 2
```

With `NCCL 2.30.7` this hangs in the first warmup iteration (no result rows are ever printed). Dropping `-x NCCL_CTA_POLICY=ZERO` (kernel path) completes normally. With this fix, both commands complete.
