### PR TITLE
Fix plugin-specific topology device indices

### DIFF
--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -572,11 +572,12 @@ ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool* a
 NCCL_PARAM(NetForceFlush, "NET_FORCE_FLUSH", 0);
 
 // Based on the system topology, determine whether an explicit iflush is needed on the GDR recv path.
-ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank,
+ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank, bool collNet,
                                enum ncclTopoFlushType* flush) {
   *flush = ncclTopoFlushAlways;
   ncclNetProperties_t props;
-  NCCLCHECK(comm->ncclNet->getProperties(netDev, &props));
+  if (collNet) NCCLCHECK(comm->ncclCollNet->getProperties(netDev, &props));
+  else NCCLCHECK(comm->ncclNet->getProperties(netDev, &props));
   if (props.forceFlush == 1 || ncclParamNetForceFlush()) return ncclSuccess;
   int g;
   struct ncclTopoSystem* system = comm->topo;

--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -1411,7 +1411,7 @@ ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoG
     } else {
       NCCLCHECK(getNvlsNetDev(comm, graph, channelId, &netId));
     }
-    NCCLCHECK(ncclTopoIdToNetDev(comm->topo, netId, &netDev));
+    NCCLCHECK(ncclTopoIdToNetDev(comm->topo, netId, graph->collNet, &netDev));
     if (dev) *dev = netDev;
     if (id) *id = netId;
     NCCLCHECK(ncclTopoGetIntermediateRank(comm->topo, rank, netId, proxyRank));

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -398,15 +398,24 @@ ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float*
   return ncclSuccess;
 }
 
+static ncclResult_t ncclTopoGetPluginDev(struct ncclXmlNode* xmlNet, const char* attr, int* dev) {
+  NCCLCHECK(xmlGetAttrIntDefault(xmlNet, attr, dev, -1));
+  // Topology files created before plugin-specific indices were introduced only have "dev".
+  if (*dev == -1 && strcmp(attr, "dev") != 0) NCCLCHECK(xmlGetAttrInt(xmlNet, "dev", dev));
+  return ncclSuccess;
+}
+
 ncclResult_t ncclTopoAddNet(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic,
                             int systemId) {
-  int dev;
-  NCCLCHECK(xmlGetAttrInt(xmlNet, "dev", &dev));
+  int dev, collDev;
+  NCCLCHECK(ncclTopoGetPluginDev(xmlNet, "dev", &dev));
+  NCCLCHECK(ncclTopoGetPluginDev(xmlNet, "cdev", &collDev));
 
   int64_t netId = NCCL_TOPO_ID(systemId, dev);
   struct ncclTopoNode* net;
   NCCLCHECK(ncclTopoCreateNode(system, &net, NET, netId));
   net->net.dev = dev;
+  net->net.collDev = collDev;
   const char* str;
   // if not guid is present use the net->id unique id instead, which will be unique within the node/NVLD
   NCCLCHECK(xmlGetAttr(xmlNet, "guid", &str));
@@ -448,7 +457,7 @@ ncclResult_t ncclTopoAddNet(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* s
 ncclResult_t ncclTopoAddGin(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic,
                             int systemId) {
   int dev;
-  NCCLCHECK(xmlGetAttrInt(xmlNet, "dev", &dev));
+  NCCLCHECK(ncclTopoGetPluginDev(xmlNet, "gdev", &dev));
 
   int64_t netId = NCCL_TOPO_ID(systemId, dev);
   struct ncclTopoNode* net;
@@ -468,7 +477,7 @@ ncclResult_t ncclTopoAddGin(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* s
 ncclResult_t ncclTopoAddRma(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic,
                             int systemId) {
   int dev;
-  NCCLCHECK(xmlGetAttrInt(xmlNet, "dev", &dev));
+  NCCLCHECK(ncclTopoGetPluginDev(xmlNet, "rdev", &dev));
 
   int64_t netId = NCCL_TOPO_ID(systemId, dev);
   struct ncclTopoNode* net;
@@ -490,20 +499,19 @@ ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* s
   for (int s = 0; s < xmlNic->nSubs; s++) {
     struct ncclXmlNode* xmlNet = xmlNic->subs[s];
     if (strcmp(xmlNet->name, "net") != 0) continue;
-    int index;
-    NCCLCHECK(xmlGetAttrIndex(xmlNet, "dev", &index));
-    // This means that the "dev" attribute wasn't set on this net xml node. That means it should not be added to
-    // the system topology graph
-    if (index == -1) continue;
 
-    // Backward compatibility: net withouh "net" attr is a net dev, net without a "gin" is not a gin dev
+    // Backward compatibility: a net without "net" is a NET device. Plugin-specific indices fall back to "dev".
     int net = 0, gin = 0, rma = 0;
     NCCLCHECK(xmlGetAttrIntDefault(xmlNet, "net", &net, 1));
     NCCLCHECK(xmlGetAttrIntDefault(xmlNet, "gin", &gin, 0));
     NCCLCHECK(xmlGetAttrIntDefault(xmlNet, "rma", &rma, 0));
-    if (net) NCCLCHECK(ncclTopoAddNet(xmlNet, system, nic, systemId));
-    if (gin) NCCLCHECK(ncclTopoAddGin(xmlNet, system, nic, systemId));
-    if (rma) NCCLCHECK(ncclTopoAddRma(xmlNet, system, nic, systemId));
+    int devIndex, ginDevIndex, rmaDevIndex;
+    NCCLCHECK(xmlGetAttrIndex(xmlNet, "dev", &devIndex));
+    NCCLCHECK(xmlGetAttrIndex(xmlNet, "gdev", &ginDevIndex));
+    NCCLCHECK(xmlGetAttrIndex(xmlNet, "rdev", &rmaDevIndex));
+    if (net && devIndex != -1) NCCLCHECK(ncclTopoAddNet(xmlNet, system, nic, systemId));
+    if (gin && (ginDevIndex != -1 || devIndex != -1)) NCCLCHECK(ncclTopoAddGin(xmlNet, system, nic, systemId));
+    if (rma && (rmaDevIndex != -1 || devIndex != -1)) NCCLCHECK(ncclTopoAddRma(xmlNet, system, nic, systemId));
   }
   return ncclSuccess;
 }
@@ -1615,6 +1623,7 @@ out:
 
 static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIndex, struct ncclTopoNetInfo* netInfo,
                                          int virtualNics) {
+  const char* devAttr = netInfo->gin ? "gdev" : netInfo->rma ? "rdev" : netInfo->coll ? "cdev" : "dev";
   for (int n = startIndex; n < endIndex; n++) {
     ncclNetProperties_t props;
     NCCLCHECK(netInfo->getProperties(n, &props));
@@ -1636,11 +1645,11 @@ static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIn
 
     NCCLCHECK(xmlSetAttrInt(netNode, "keep", 1));
     int dev;
-    xmlGetAttrIntDefault(netNode, "dev", &dev, -1);
+    NCCLCHECK(xmlGetAttrIntDefault(netNode, devAttr, &dev, -1));
     if (dev != -1 && dev != n) {
-      INFO(NCCL_GRAPH, "TOPO/NET : Changing %s dev index from %d to %d", netInfo->name, dev, n);
+      INFO(NCCL_GRAPH, "TOPO/NET : Changing %s %s index from %d to %d", netInfo->name, devAttr, dev, n);
     }
-    NCCLCHECK(xmlSetAttrInt(netNode, "dev", n));
+    NCCLCHECK(xmlSetAttrInt(netNode, devAttr, n));
     NCCLCHECK(xmlInitAttrInt(netNode, "latency", props.latency));
     NCCLCHECK(xmlInitAttrInt(netNode, "speed", props.speed));
     NCCLCHECK(xmlInitAttrInt(netNode, "port", props.port));
@@ -1665,16 +1674,23 @@ static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIn
     if (netInfo->gin) NCCLCHECK(xmlInitAttrInt(netNode, "gin", netInfo->gin));
     if (netInfo->rma) NCCLCHECK(xmlInitAttrInt(netNode, "rma", netInfo->rma));
 
-    const char *keepAttr, *ginAttr, *rmaAttr;
+    const char *keepAttr, *ginAttr, *rmaAttr, *devValue, *ginDevValue, *rmaDevValue, *collDevValue;
     NCCLCHECK(xmlGetAttr(netNode, "net", &netAttr));
     NCCLCHECK(xmlGetAttr(netNode, "gin", &ginAttr));
     NCCLCHECK(xmlGetAttr(netNode, "rma", &rmaAttr));
     NCCLCHECK(xmlGetAttr(netNode, "coll", &colAttr));
     NCCLCHECK(xmlGetAttr(netNode, "keep", &keepAttr));
+    NCCLCHECK(xmlGetAttr(netNode, "dev", &devValue));
+    NCCLCHECK(xmlGetAttr(netNode, "gdev", &ginDevValue));
+    NCCLCHECK(xmlGetAttr(netNode, "rdev", &rmaDevValue));
+    NCCLCHECK(xmlGetAttr(netNode, "cdev", &collDevValue));
     INFO(
       NCCL_GRAPH,
-      "ncclTopoPopulateNics : Filled %s in topo with pciPath=%s net=%s gin=%s rma=%s keep=%s coll=%s rail=%d plane=%d",
-      props.name, props.pciPath, netAttr, ginAttr, rmaAttr, keepAttr, colAttr, props.railId, props.planeId);
+      "ncclTopoPopulateNics : Filled %s in topo with pciPath=%s net=%s/%s gin=%s/%s rma=%s/%s coll=%s/%s keep=%s "
+      "rail=%d plane=%d",
+      props.name, props.pciPath, netAttr, devValue ? devValue : "-", ginAttr ? ginAttr : "0",
+      ginDevValue ? ginDevValue : "-", rmaAttr ? rmaAttr : "0", rmaDevValue ? rmaDevValue : "-",
+      colAttr ? colAttr : "0", collDevValue ? collDevValue : "-", keepAttr, props.railId, props.planeId);
   }
 
   return ncclSuccess;
@@ -1682,6 +1698,7 @@ static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIn
 
 static ncclResult_t ncclTopoUpdateVNics(ncclXml* xml, struct ncclTopoNetInfo* net, int nPhysicalNics,
                                         int nVirtualNics) {
+  const char* typeAttr = net->gin ? "gin" : net->rma ? "rma" : net->coll ? "coll" : "net";
   for (int n = nPhysicalNics; n < nPhysicalNics + nVirtualNics; n++) {
     ncclNetProperties_t vProps;
     NCCLCHECK(net->getProperties(n, &vProps));
@@ -1691,14 +1708,15 @@ static ncclResult_t ncclTopoUpdateVNics(ncclXml* xml, struct ncclTopoNetInfo* ne
       struct ncclXmlNode* physNetNode = NULL;
       NCCLCHECK(xmlFindTagKv(xml, "net", &physNetNode, "name", physProps.name));
       if (physNetNode) {
-        NCCLCHECK(xmlSetAttrInt(physNetNode, net->net ? "net" : (net->gin ? "gin" : "coll"), 0));
+        NCCLCHECK(xmlSetAttrInt(physNetNode, typeAttr, 0));
         // net is always present (see ncclTopoPopulateNics).
-        int net = 0, gin = 0, coll = 0;
+        int net = 0, gin = 0, rma = 0, coll = 0;
         NCCLCHECK(xmlGetAttrInt(physNetNode, "net", &net));
         NCCLCHECK(xmlGetAttrIntDefault(physNetNode, "gin", &gin, 0));
+        NCCLCHECK(xmlGetAttrIntDefault(physNetNode, "rma", &rma, 0));
         NCCLCHECK(xmlGetAttrIntDefault(physNetNode, "coll", &coll, 0));
         // Set "keep = 0" only if no plugin is using the physical device
-        if (net == 0 && gin == 0 && coll == 0) NCCLCHECK(xmlSetAttrInt(physNetNode, "keep", 0));
+        if (net == 0 && gin == 0 && rma == 0 && coll == 0) NCCLCHECK(xmlSetAttrInt(physNetNode, "keep", 0));
       }
     }
   }

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -120,7 +120,8 @@ struct ncclTopoNode {
       int nGpus; // number of GPU partitions attached to this DEV node
     } dev;
     struct {
-      int dev; // Plugin dev number
+      int dev;     // NET plugin dev number
+      int collDev; // CollNet plugin dev number
       uint64_t pciId;
       uint64_t asic;
       int port;
@@ -258,11 +259,11 @@ static ncclResult_t ncclTopoDevToRank(struct ncclTopoSystem* system, int systemI
 
 extern struct kvDict nicPathKvList[];
 
-static ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id, int* netDev) {
+static ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id, bool collNet, int* netDev) {
   *netDev = -1;
   for (int i = 0; i < system->nodes[NET].count; i++) {
     if (system->nodes[NET].nodes[i].id == id) {
-      *netDev = system->nodes[NET].nodes[i].net.dev;
+      *netDev = collNet ? system->nodes[NET].nodes[i].net.collDev : system->nodes[NET].nodes[i].net.dev;
       return ncclSuccess;
     }
   }

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -20,7 +20,7 @@
 
 // A few constraints to make the implementation easy
 #define MAX_STR_LEN 255
-#define MAX_ATTR_COUNT 16
+#define MAX_ATTR_COUNT 20 // NET nodes store independent indices for each network plugin API.
 #define MAX_SUBS 640
 
 #define NODE_TYPE_NONE 0

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -61,7 +61,7 @@ static inline uint32_t ncclGdcPinFlag(enum ncclTopoFlushType flush) {
   if (flush == ncclTopoFlushC2c && ncclGdrPinV2Available()) return GDR_PIN_FLAG_FORCE_PCIE;
   return GDR_PIN_FLAG_DEFAULT;
 }
-ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank,
+ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank, bool collNet,
                                enum ncclTopoFlushType* flush);
 ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw);
 ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool* avail);

--- a/src/transport/coll_net.cc
+++ b/src/transport/coll_net.cc
@@ -200,7 +200,8 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   NCCLCHECK(ncclTopoCheckGdr(comm->topo, myInfo->rank, netId, 0, &req.useGdr));
   recv->conn.flags |= req.useGdr ? NCCL_DIRECT_NIC : 0;
   // Determine whether we need to flush the GDR buffer on recv or not
-  if (req.useGdr) NCCLCHECK(ncclTopoNeedFlush(comm, netId, req.netDev, myInfo->rank, &req.needFlush));
+  if (req.useGdr)
+    NCCLCHECK(ncclTopoNeedFlush(comm, netId, req.netDev, myInfo->rank, /*collNet=*/true, &req.needFlush));
 
   recv->proxyConn.tpLocalRank = comm->topParentLocalRanks[comm->localRank];
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_COLLNET, 0, myInfo->rank, &recv->proxyConn));

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -362,7 +362,8 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   if (!req.useGdr && connIndex == 0) comm->useGdr = 0;
 
   // Determine whether we need to flush the GDR buffer on recv or not
-  if (req.useGdr) NCCLCHECK(ncclTopoNeedFlush(comm, netId, req.netDev, myInfo->rank, &req.needFlush));
+  if (req.useGdr)
+    NCCLCHECK(ncclTopoNeedFlush(comm, netId, req.netDev, myInfo->rank, /*collNet=*/false, &req.needFlush));
 
   // We don't support PXN on receive yet
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_NET, 0, myInfo->rank, &recv->proxyConn));


### PR DESCRIPTION
## Summary

Store device indices independently for each network plugin API instead of sharing a single topology `dev` attribute.

The topology XML now uses:

| Plugin API | Device index attribute |
|------------|------------------------|
| NET        | `dev`                  |
| GIN        | `gdev`                 |
| RMA        | `rdev`                 |
| CollNet    | `cdev`                 |

Legacy topology XML files containing only `dev` remain supported through fallback logic.

## Problem

NET, GIN, RMA, and CollNet share the same physical `<net>` XML nodes, matched by device name. However, their device indices belong to separate plugin-local namespaces and are not guaranteed to use the same ordering.

This is visible on B300 systems using bonded Mellanox devices:

- The external NET plugin enumerates devices in bond-name order.
- Internal GIN/RMA devices may be reordered by PCI topology.
- Each plugin previously overwrote the same XML `dev` attribute.
- NET is imported last, so GIN/RMA topology nodes received NET plugin indices.
- GIN then interpreted the NET index in its own namespace and selected a different bond device.

The physical topology node was correct, but the device index passed to the plugin was incorrect.

## Changes

- Store NET, GIN, RMA, and CollNet indices in separate XML attributes.
- Make GIN and RMA topology nodes read `gdev` and `rdev`.
- Preserve compatibility with legacy XML by falling back to `dev`.
- Store a separate CollNet device index in NET topology nodes.
- Return the CollNet index when resolving devices for CollNet graphs.
- Query flush properties through the corresponding NET or CollNet plugin.
- Include RMA when updating and pruning virtual NIC topology entries.
- Increase the XML attribute capacity to accommodate the additional indices.
- Log all plugin-specific indices for topology diagnostics.

## Validation

- Validated on a B300 bond configuration where NET and GIN device enumeration orders differ.
- Confirmed topology-selected devices resolve to the expected bond interfaces.
- Confirmed performance is restored after eliminating the cross-plugin index overwrite.
- Patch application check passed.

## Compatibility

Existing topology XML files containing only `dev` continue to work. The new attributes are used when available and otherwise fall back to the legacy NET device index.