### PR TITLE
Add CMake builds for NCCL examples

### DIFF
--- a/docs/examples/01_communicators/01_multiple_devices_single_process/c/CMakeLists.txt
+++ b/docs/examples/01_communicators/01_multiple_devices_single_process/c/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(multiple_devices_single_process LANGUAGES CXX)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.14 REQUIRED)
+
+add_executable(multiple_devices_single_process main.cc)
+target_link_libraries(multiple_devices_single_process PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+)

--- a/docs/examples/01_communicators/02_one_device_per_pthread/c/CMakeLists.txt
+++ b/docs/examples/01_communicators/02_one_device_per_pthread/c/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(one_device_per_pthread LANGUAGES CXX)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.14 REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(one_device_per_pthread main.cc)
+target_link_libraries(one_device_per_pthread PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+    Threads::Threads
+)

--- a/docs/examples/01_communicators/03_one_device_per_process_mpi/c/CMakeLists.txt
+++ b/docs/examples/01_communicators/03_one_device_per_process_mpi/c/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(one_device_per_process_mpi LANGUAGES CXX)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.14 REQUIRED)
+find_package(MPI REQUIRED COMPONENTS CXX)
+
+add_executable(one_device_per_process_mpi main.cc)
+target_link_libraries(one_device_per_process_mpi PRIVATE
+    CUDA::cudart
+    MPI::MPI_CXX
+    NCCL::nccl
+)

--- a/docs/examples/01_communicators/CMakeLists.txt
+++ b/docs/examples/01_communicators/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_multiple_devices_single_process/c)
+add_subdirectory(02_one_device_per_pthread/c)
+if(NCCLExamples_USE_MPI)
+    add_subdirectory(03_one_device_per_process_mpi/c)
+endif()

--- a/docs/examples/02_point_to_point/01_ring_pattern/c/CMakeLists.txt
+++ b/docs/examples/02_point_to_point/01_ring_pattern/c/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(ring_pattern LANGUAGES CXX)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.14 REQUIRED)
+
+add_executable(ring_pattern main.cc)
+target_link_libraries(ring_pattern PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+)

--- a/docs/examples/02_point_to_point/CMakeLists.txt
+++ b/docs/examples/02_point_to_point/CMakeLists.txt
@@ -1,0 +1,6 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_ring_pattern/c)

--- a/docs/examples/03_collectives/01_allreduce/c/CMakeLists.txt
+++ b/docs/examples/03_collectives/01_allreduce/c/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(allreduce LANGUAGES CXX)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.14 REQUIRED)
+
+add_executable(allreduce main.cc)
+target_link_libraries(allreduce PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+)

--- a/docs/examples/03_collectives/CMakeLists.txt
+++ b/docs/examples/03_collectives/CMakeLists.txt
@@ -1,0 +1,6 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_allreduce/c)

--- a/docs/examples/04_user_buffer_registration/01_allreduce/c/CMakeLists.txt
+++ b/docs/examples/04_user_buffer_registration/01_allreduce/c/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(allreduce_ub LANGUAGES CXX)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.19 REQUIRED)
+
+add_executable(allreduce_ub
+    main.cc
+    ../../../common/src/utils.cc
+)
+target_include_directories(allreduce_ub PRIVATE
+    ../../../common/include
+)
+target_link_libraries(allreduce_ub PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(allreduce_ub PRIVATE MPI_SUPPORT)
+    target_link_libraries(allreduce_ub PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(allreduce_ub PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/04_user_buffer_registration/CMakeLists.txt
+++ b/docs/examples/04_user_buffer_registration/CMakeLists.txt
@@ -1,0 +1,6 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_allreduce/c)

--- a/docs/examples/05_symmetric_memory/01_allreduce/c/CMakeLists.txt
+++ b/docs/examples/05_symmetric_memory/01_allreduce/c/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(allreduce_sm LANGUAGES CXX)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.27 REQUIRED)
+
+add_executable(allreduce_sm
+    main.cc
+    ../../../common/src/utils.cc
+)
+target_include_directories(allreduce_sm PRIVATE
+    ../../../common/include
+)
+target_link_libraries(allreduce_sm PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(allreduce_sm PRIVATE MPI_SUPPORT)
+    target_link_libraries(allreduce_sm PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(allreduce_sm PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/05_symmetric_memory/02_allgather/c/CMakeLists.txt
+++ b/docs/examples/05_symmetric_memory/02_allgather/c/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(allgather_ce LANGUAGES CXX)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.28.3 REQUIRED)
+
+add_executable(allgather_ce
+    main.cc
+    ../../../common/src/utils.cc
+)
+target_include_directories(allgather_ce PRIVATE
+    ../../../common/include
+)
+target_link_libraries(allgather_ce PRIVATE
+    CUDA::cudart
+    NCCL::nccl
+)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(allgather_ce PRIVATE MPI_SUPPORT)
+    target_link_libraries(allgather_ce PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(allgather_ce PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/05_symmetric_memory/CMakeLists.txt
+++ b/docs/examples/05_symmetric_memory/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_allreduce/c)
+add_subdirectory(02_allgather/c)

--- a/docs/examples/06_device_api/01_allreduce_lsa/c/CMakeLists.txt
+++ b/docs/examples/06_device_api/01_allreduce_lsa/c/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(allreduce_lsa LANGUAGES CXX CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.29.7 REQUIRED)
+
+add_executable(allreduce_lsa
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(allreduce_lsa PRIVATE
+    ../../../common/include
+)
+target_link_libraries(allreduce_lsa PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(allreduce_lsa PRIVATE MPI_SUPPORT)
+    target_link_libraries(allreduce_lsa PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(allreduce_lsa PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/06_device_api/02_alltoall_gin/c/CMakeLists.txt
+++ b/docs/examples/06_device_api/02_alltoall_gin/c/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(alltoall_gin LANGUAGES CXX CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.30.7 REQUIRED)
+
+add_executable(alltoall_gin
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(alltoall_gin PRIVATE
+    ../../../common/include
+)
+target_link_libraries(alltoall_gin PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(alltoall_gin PRIVATE MPI_SUPPORT)
+    target_link_libraries(alltoall_gin PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(alltoall_gin PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/06_device_api/03_alltoall_hybrid/c/CMakeLists.txt
+++ b/docs/examples/06_device_api/03_alltoall_hybrid/c/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(alltoall_hybrid LANGUAGES CXX CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.30.7 REQUIRED)
+
+add_executable(alltoall_hybrid
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(alltoall_hybrid PRIVATE
+    ../../../common/include
+)
+target_link_libraries(alltoall_hybrid PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(alltoall_hybrid PRIVATE MPI_SUPPORT)
+    target_link_libraries(alltoall_hybrid PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(alltoall_hybrid PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/06_device_api/CMakeLists.txt
+++ b/docs/examples/06_device_api/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_allreduce_lsa/c)
+add_subdirectory(02_alltoall_gin/c)
+add_subdirectory(03_alltoall_hybrid/c)

--- a/docs/examples/07_kernel_fusion/01_rmsnorm_lsa/c/CMakeLists.txt
+++ b/docs/examples/07_kernel_fusion/01_rmsnorm_lsa/c/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(rmsnorm_lsa LANGUAGES CXX CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.30 REQUIRED)
+
+add_executable(rmsnorm_lsa
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(rmsnorm_lsa PRIVATE
+    ../../include
+    ../../../common/include
+)
+target_link_libraries(rmsnorm_lsa PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(rmsnorm_lsa PRIVATE MPI_SUPPORT)
+    target_link_libraries(rmsnorm_lsa PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(rmsnorm_lsa PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/07_kernel_fusion/02_rmsnorm_multimem/c/CMakeLists.txt
+++ b/docs/examples/07_kernel_fusion/02_rmsnorm_multimem/c/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+
+project(rmsnorm_multimem LANGUAGES CXX)
+
+if(NOT "${CMAKE_CUDA_ARCHITECTURES}" AND NOT "$ENV{CUDAARCHS}")
+    set(CMAKE_CUDA_ARCHITECTURES 90)
+endif()
+
+enable_language(CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.30 REQUIRED)
+
+add_executable(rmsnorm_multimem
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(rmsnorm_multimem PRIVATE
+    ../../include
+    ../../../common/include
+)
+target_link_libraries(rmsnorm_multimem PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(rmsnorm_multimem PRIVATE MPI_SUPPORT)
+    target_link_libraries(rmsnorm_multimem PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(rmsnorm_multimem PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/07_kernel_fusion/03_rmsnorm_gin/c/CMakeLists.txt
+++ b/docs/examples/07_kernel_fusion/03_rmsnorm_gin/c/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(rmsnorm_gin LANGUAGES CXX CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.30.7 REQUIRED)
+
+add_executable(rmsnorm_gin
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(rmsnorm_gin PRIVATE
+    ../../include
+    ../../../common/include
+)
+target_link_libraries(rmsnorm_gin PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(rmsnorm_gin PRIVATE MPI_SUPPORT)
+    target_link_libraries(rmsnorm_gin PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(rmsnorm_gin PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/07_kernel_fusion/04_rmsnorm_hybrid/c/CMakeLists.txt
+++ b/docs/examples/07_kernel_fusion/04_rmsnorm_hybrid/c/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(rmsnorm_hybrid LANGUAGES CXX CUDA)
+
+option(NCCLExamples_USE_MPI "Use MPI for process coordination" OFF)
+
+find_package(CUDAToolkit REQUIRED)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+find_package(NCCL 2.30.7 REQUIRED)
+
+add_executable(rmsnorm_hybrid
+    main.cu
+    ../../../common/src/utils.cc
+)
+target_include_directories(rmsnorm_hybrid PRIVATE
+    ../../include
+    ../../../common/include
+)
+target_link_libraries(rmsnorm_hybrid PRIVATE NCCL::nccl)
+if(NCCLExamples_USE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    target_compile_definitions(rmsnorm_hybrid PRIVATE MPI_SUPPORT)
+    target_link_libraries(rmsnorm_hybrid PRIVATE MPI::MPI_CXX)
+else()
+    find_package(Threads REQUIRED)
+    target_link_libraries(rmsnorm_hybrid PRIVATE Threads::Threads)
+endif()

--- a/docs/examples/07_kernel_fusion/CMakeLists.txt
+++ b/docs/examples/07_kernel_fusion/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(01_rmsnorm_lsa/c)
+add_subdirectory(02_rmsnorm_multimem/c)
+add_subdirectory(03_rmsnorm_gin/c)
+add_subdirectory(04_rmsnorm_hybrid/c)

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -1,0 +1,60 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.18)
+
+project(NCCLExamples)
+
+if(NOT "${CMAKE_CUDA_ARCHITECTURES}" AND NOT "$ENV{CUDAARCHS}")
+    set(CMAKE_CUDA_ARCHITECTURES 90)
+endif()
+
+if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+endif()
+if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+endif()
+if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+endif()
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+
+# Map Make options to their canonical CMake equivalents.
+macro(nccl_examples_cmake_from_make_var CMAKE_VAR MAKE_VAR)
+    if(NOT DEFINED ${CMAKE_VAR})
+        if(DEFINED ENV{${CMAKE_VAR}})
+            set(${CMAKE_VAR} "$ENV{${CMAKE_VAR}}")
+        elseif(DEFINED ${MAKE_VAR})
+            set(${CMAKE_VAR} "${${MAKE_VAR}}")
+        elseif(DEFINED ENV{${MAKE_VAR}})
+            set(${CMAKE_VAR} "$ENV{${MAKE_VAR}}")
+        endif()
+    endif()
+
+    unset(ENV{${CMAKE_VAR}})
+    unset(${MAKE_VAR})
+    unset(${MAKE_VAR} CACHE)
+    unset(ENV{${MAKE_VAR}})
+endmacro()
+
+nccl_examples_cmake_from_make_var(NCCL_ROOT NCCL_HOME)
+nccl_examples_cmake_from_make_var(MPI_ROOT MPI_HOME)
+nccl_examples_cmake_from_make_var(CUDAToolkit_ROOT CUDA_HOME)
+
+nccl_examples_cmake_from_make_var(mpi_default MPI)
+if(NOT DEFINED mpi_default)
+    set(mpi_default OFF)
+endif()
+option(NCCLExamples_USE_MPI "Enable MPI examples" "${mpi_default}")
+unset(mpi_default)
+
+add_subdirectory(01_communicators)
+add_subdirectory(02_point_to_point)
+add_subdirectory(03_collectives)
+add_subdirectory(04_user_buffer_registration)
+add_subdirectory(05_symmetric_memory)
+add_subdirectory(06_device_api)
+add_subdirectory(07_kernel_fusion)

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -125,6 +125,30 @@ cd docs/examples
 make NCCL_HOME=<path-to-nccl> [MPI=1]
 ```
 
+From the repository root, each C/CUDA example is also an independent top-level
+CMake project. CMake 3.18 or later is required. Pass the NCCL build tree or
+installation prefix as `-DNCCL_ROOT=<path-to-nccl>`:
+
+```shell
+cmake -S docs/examples/<category>/<example>/c -B build/example \
+  -DNCCL_ROOT=<path-to-nccl>
+cmake --build build/example
+```
+
+The complete C/CUDA example suite can be built from `docs/examples`. The
+aggregate project defaults to CUDA architecture 90 because the Multimem
+example requires SM 9.0 or later. Set `CMAKE_CUDA_ARCHITECTURES` or
+`CUDAARCHS` to override that default. Add `-DNCCLExamples_USE_MPI=ON` to
+include the MPI-only communicator and enable MPI coordination in the other
+examples.
+
+```shell
+cmake -S docs/examples -B build/examples \
+  -DNCCL_ROOT=<path-to-nccl> \
+  -DNCCLExamples_USE_MPI=ON
+cmake --build build/examples
+```
+
 Python examples are run from the corresponding example's `python/` directory.
 Each Python README includes exact setup and run instructions. In most cases the
 workflow is:
@@ -154,7 +178,7 @@ the top-level requirements).
 ### Build Stage
 Users can use these optional variables to choose which libraries are used to
 build these examples:
-- `NCCL_HOME=<path>`: Local base directory of a NCCL installation.
+- `NCCL_HOME=<path>`: NCCL build or installation prefix.
 - `MPI` : [0,1] Build the examples with MPI support.
 - `MPI_HOME=<path>` : Local base directory of a MPI installation.
 - `CUDA_HOME=<path>` : Local base directory of a CUDA installation.

--- a/docs/examples/cmake/FindNCCL.cmake
+++ b/docs/examples/cmake/FindNCCL.cmake
@@ -1,0 +1,265 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#[=======================================================================[.rst:
+FindNCCL
+--------
+
+Finds the NVIDIA Collective Communication Library (NCCL):
+
+.. code-block:: cmake
+
+find_package(NCCL [<version>|<version_range>] [...])
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following :ref:`Imported Targets`:
+
+``NCCL::nccl``
+
+  Target that encapsulates the NCCL usage requirements.  It is available
+  only when NCCL is found
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``NCCL_FOUND``
+  Boolean indicating whether (the requested version of) NCCL was found.
+
+``NCCL_VERSION``
+  The version of the NCCL library which was found.
+
+``NCCL_INCLUDE_DIRS``
+  Include directories needed to use NCCL.
+
+``NCCL_LIBRARIES``
+  Libraries needed to link to NCCL.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``NCCL_INCLUDE_DIR``
+  The directory containing ``nccl.h``.
+
+``NCCL_LIBRARY``
+  The path to the NCCL library.
+
+Hints
+^^^^^
+
+``NCCL_ROOT``
+  A user may set this variable to a NCCL installation root to help locate
+  NCCL in a custom installation path.
+
+#]=======================================================================]
+
+# Capture the find_package version and quiet args to forward
+# to the CONFIG and pkgconfig searches.
+
+set(_NCCL_FP_VERSION ${NCCL_FIND_VERSION})
+if(NCCL_FIND_VERSION_RANGE)
+  set(_NCCL_FP_VERSION ${NCCL_FIND_VERSION_RANGE})
+endif()
+
+set(_NCCL_FP_EXACT)
+if(NCCL_FIND_VERSION_EXACT)
+  set(_NCCL_FP_EXACT EXACT)
+endif()
+
+set(_NCCL_FP_QUIET)
+if(NCCL_FIND_QUIETLY)
+  set(_NCCL_FP_QUIET QUIET)
+endif()
+
+# Look for the CMake package first
+find_package(NCCL
+  ${_NCCL_FP_VERSION} ${_NCCL_FP_EXACT} ${_NCCL_FP_QUIET}
+  CONFIG QUIET
+)
+
+include(FindPackageHandleStandardArgs)
+set(_NCCL_FPHSA_ARGS)
+if(NCCL_FOUND AND NCCL_CONFIG)
+  list(APPEND _NCCL_FPHSA_ARGS CONFIG_MODE)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
+    list(APPEND _NCCL_FPHSA_ARGS HANDLE_VERSION_RANGE)
+  endif()
+  find_package_handle_standard_args(NCCL ${_NCCL_FPHSA_ARGS})
+
+  # Check for older compatibility imported targets
+  if(NCCL_FOUND AND NOT TARGET NCCL::nccl AND TARGET nccl::nccl)
+    add_library(NCCL::nccl ALIAS nccl::nccl)
+  endif()
+
+  # Set the compatibility vars
+  if(NOT NCCL_INCLUDE_DIRS)
+    if(TARGET NCCL::nccl_headers)
+      set(_NCCL_INC_TARGET NCCL::nccl_headers)
+    else()
+      set(_NCCL_INC_TARGET NCCL::nccl)
+    endif()
+    get_target_property(
+      NCCL_INCLUDE_DIRS
+      ${_NCCL_INC_TARGET}
+      INTERFACE_INCLUDE_DIRECTORIES
+    )
+    unset(_NCCL_INC_TARGET)
+  endif()
+  if(NOT NCCL_LIBRARIES)
+    set(NCCL_LIBRARIES NCCL::nccl)
+  endif()
+else()
+  # Clear state from a half found / rejected CONFIG search
+  unset(NCCL_FOUND)
+  unset(NCCL_CONFIG)
+  unset(NCCL_VERSION)
+
+  # NCCLConfig.cmake not found, try manual search seeded by pkgconfig
+  find_package(CUDAToolkit ${_NCCL_FP_QUIET})
+
+  if(CUDAToolkit_FOUND)
+    set(_NCCL_INCLUDE_PATHS)
+    set(_NCCL_LIBRARY_PATHS)
+    set(_NCCL_LIBRARY_NAMES)
+
+    # Use pkgconfig to guide the manual search and discovery
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      # build the pkgconfig module spec
+      set(_PC_NCCL_SPEC "nccl")
+
+      if(NCCL_FIND_VERSION)
+        if(_NCCL_FP_EXACT)
+          string(APPEND _PC_NCCL_SPEC
+            " = ${NCCL_FIND_VERSION}"
+          )
+        else()
+          string(APPEND _PC_NCCL_SPEC
+            " >= ${NCCL_FIND_VERSION}"
+          )
+          if(NCCL_FIND_VERSION_RANGE)
+            if(NCCL_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE")
+              list(APPEND _PC_NCCL_SPEC
+                "nccl <= ${NCCL_FIND_VERSION_MAX}"
+              )
+            else()
+              list(APPEND _PC_NCCL_SPEC
+                "nccl < ${NCCL_FIND_VERSION_MAX}"
+              )
+            endif()
+          endif()
+        endif()
+      endif()
+
+      pkg_check_modules(PC_NCCL ${_NCCL_FP_QUIET} ${_PC_NCCL_SPEC})
+
+      # Populate hints from pkg_config
+      if(PC_NCCL_FOUND)
+        if(PC_NCCL_INCLUDE_DIRS)
+          list(APPEND _NCCL_INCLUDE_PATHS
+            PATHS ${PC_NCCL_INCLUDE_DIRS}
+            NO_DEFAULT_PATH
+          )
+        endif()
+        if(PC_NCCL_LIBRARY_DIRS)
+          list(APPEND _NCCL_LIBRARY_PATHS
+            PATHS ${PC_NCCL_LIBRARY_DIRS}
+            NO_DEFAULT_PATH
+          )
+        endif()
+        if(PC_NCCL_LIBRARIES)
+          list(APPEND _NCCL_LIBRARY_NAMES NAMES ${PC_NCCL_LIBRARIES})
+        endif()
+      endif()
+      unset(_PC_NCCL_SPEC)
+    endif()
+
+    if(NOT _NCCL_LIBRARY_NAMES)
+      list(APPEND _NCCL_LIBRARY_NAMES NAMES nccl)
+
+      # Handle the special case for the nvidia-nccl python wheels on
+      # Linux that don't ship the unversioned symlink
+      # libnccl.so -> libnccl.so.2
+      if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        list(APPEND _NCCL_LIBRARY_NAMES libnccl.so.2)
+      endif()
+    endif()
+
+    # Perform the manual search, possibly guided by pkgconfig
+    find_path(NCCL_INCLUDE_DIR NAMES nccl.h ${_NCCL_INCLUDE_PATHS})
+    find_library(NCCL_LIBRARY ${_NCCL_LIBRARY_NAMES} ${_NCCL_LIBRARY_PATHS})
+    mark_as_advanced(NCCL_INCLUDE_DIR NCCL_LIBRARY)
+    unset(_NCCL_INCLUDE_PATHS)
+    unset(_NCCL_LIBRARY_PATHS)
+    unset(_NCCL_LIBRARY_NAMES)
+
+    # Parse NCCL_VERSION from nccl.h
+    if(NCCL_INCLUDE_DIR AND NCCL_LIBRARY AND NOT NCCL_VERSION)
+      set(_NCCL_VERSION_REGEX
+        [[^#define[ \t]+NCCL_(MAJOR|MINOR|PATCH)[ \t]+([0-9]+)[ \t]*$]]
+      )
+      file(STRINGS
+        "${NCCL_INCLUDE_DIR}/nccl.h"
+        _NCCL_HEADER_LINES
+        REGEX ${_NCCL_VERSION_REGEX}
+      )
+      if(_NCCL_HEADER_LINES)
+        list(TRANSFORM _NCCL_HEADER_LINES
+          REPLACE ${_NCCL_VERSION_REGEX} [[\2]]
+        )
+        list(JOIN _NCCL_HEADER_LINES "." NCCL_VERSION)
+      endif()
+      unset(_NCCL_VERSION_REGEX)
+      unset(_NCCL_HEADER_LINES)
+    endif()
+
+    # Fallback to PC_NCCL_VERSION if the header couldn't be parsed and
+    # is found in pkgconfig's location
+    if(NOT NCCL_VERSION AND PC_NCCL_VERSION AND
+      PC_NCCL_INCLUDE_DIRS AND NCCL_INCLUDE_DIR IN_LIST PC_NCCL_INCLUDE_DIRS)
+      set(NCCL_VERSION ${PC_NCCL_VERSION})
+    endif()
+  endif()
+
+  list(APPEND _NCCL_FPHSA_ARGS
+    REQUIRED_VARS NCCL_INCLUDE_DIR NCCL_LIBRARY CUDAToolkit_FOUND
+    VERSION_VAR NCCL_VERSION
+  )
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
+    list(APPEND _NCCL_FPHSA_ARGS HANDLE_VERSION_RANGE)
+  endif()
+  find_package_handle_standard_args(NCCL ${_NCCL_FPHSA_ARGS})
+
+  # Create the imported targets
+  if(NCCL_FOUND)
+    if(NOT TARGET NCCL::nccl)
+      add_library(NCCL::nccl UNKNOWN IMPORTED)
+      set_target_properties(NCCL::nccl PROPERTIES
+        IMPORTED_LOCATION "${NCCL_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${NCCL_INCLUDE_DIR}"
+      )
+      if(TARGET CUDA::toolkit)
+        set_target_properties(NCCL::nccl PROPERTIES
+          INTERFACE_LINK_LIBRARIES CUDA::toolkit
+        )
+      endif()
+    endif()
+
+    # Set the compatibility variables
+    set(NCCL_INCLUDE_DIRS "${NCCL_INCLUDE_DIR}")
+    set(NCCL_LIBRARIES "${NCCL_LIBRARY}")
+  endif()
+endif()
+
+# Cleanup after ourselves
+unset(_NCCL_FPHSA_ARGS)
+unset(_NCCL_FP_QUIET)
+unset(_NCCL_FP_EXACT)
+unset(_NCCL_FP_VERSION)


### PR DESCRIPTION
## Description

Add standalone CMake projects for the C and CUDA examples, together with
an aggregate project that builds the complete example suite.

Provide a `FindNCCL` module that prefers an NCCL CMake package config and
falls back to pkg-config and manual discovery. This lets the examples
serve as independent consumers of both NCCL build trees and installation
trees through the `NCCL::nccl` imported target.

## Related Issues

None.

## Changes & Impact

This is additive; the existing Makefile example builds remain available.

The CMake builds honor toolchain-provided CUDA architecture selections,
support optional MPI examples, and specify the minimum NCCL version
required by each example. Make-style configuration inputs are mapped to
their canonical CMake equivalents at the aggregate-project boundary.

There are no changes to NCCL APIs or library behavior.

## Performance Impact

No runtime performance impact is expected. This PR changes only example
build descriptions and package discovery.
