### PR TITLE
nccl4py/cute: Add opt_flags support for gin.put, put_value and signal

### DIFF
--- a/bindings/nccl4py/nccl/core/device/cute/_bindings.py
+++ b/bindings/nccl4py/nccl/core/device/cute/_bindings.py
@@ -177,8 +177,8 @@ def ncclGin_C_init(gin_ptr, backend_mask, dev_comm, context_id):
     )
 
 
-_raw_ncclGinPut = _ffi(
-    name="ncclGinPut",
+_raw_ncclGinPut_v2 = _ffi(
+    name="ncclGinPut_v2",
     params_types=[
         _LLVMPtrType,        # ncclGin_C* gin
         ncclTeam,            # team
@@ -199,13 +199,14 @@ _raw_ncclGinPut = _ffi(
         _LLVMPtrType,        # descriptor_ptr
         cutlass.Int32,       # given_release
         cutlass.Int32,       # required_release
+        cutlass.Int32,       # opt_flags
     ])
 
 def ncclGinPut(gin_ptr, team, peer, dst_win, dst_offset, src_win, src_offset,
                size, is_signal, signal_id, signal_op, signal_op_arg,
                is_counter, counter_id, coop, is_descriptor, descriptor_ptr,
-               given_release, required_release):
-    _raw_ncclGinPut(
+               given_release, required_release, opt_flags):
+    _raw_ncclGinPut_v2(
         _to_ptr(gin_ptr), team, cutlass.Int32(peer),
         _to_ptr(dst_win), cutlass.Int64(dst_offset),
         _to_ptr(src_win), cutlass.Int64(src_offset),
@@ -216,11 +217,12 @@ def ncclGinPut(gin_ptr, team, peer, dst_win, dst_offset, src_win, src_offset,
         _to_coop_value(coop),
         cutlass.Boolean(is_descriptor), _to_ptr(descriptor_ptr),
         cutlass.Int32(given_release), cutlass.Int32(required_release),
+        cutlass.Int32(opt_flags),
     )
 
 
-_raw_ncclGinPutValue = _ffi(
-    name="ncclGinPutValue",
+_raw_ncclGinPutValue_v2 = _ffi(
+    name="ncclGinPutValue_v2",
     params_types=[
         _LLVMPtrType,        # ncclGin_C* gin
         ncclTeam,            # team
@@ -238,13 +240,14 @@ _raw_ncclGinPutValue = _ffi(
         _LLVMPtrType,        # descriptor_ptr
         cutlass.Int32,       # given_release
         cutlass.Int32,       # required_release
+        cutlass.Int32,       # opt_flags
     ])
 
 def ncclGinPutValue(gin_ptr, team, peer, dst_win, dst_offset, value, size,
                     is_signal, signal_id, signal_op, signal_op_arg, coop,
                     is_descriptor, descriptor_ptr,
-                    given_release, required_release):
-    _raw_ncclGinPutValue(
+                    given_release, required_release, opt_flags):
+    _raw_ncclGinPutValue_v2(
         _to_ptr(gin_ptr), team, cutlass.Int32(peer),
         _to_ptr(dst_win), cutlass.Int64(dst_offset),
         cutlass.Int64(value), cutlass.Int64(size),
@@ -253,6 +256,7 @@ def ncclGinPutValue(gin_ptr, team, peer, dst_win, dst_offset, value, size,
         _to_coop_value(coop),
         cutlass.Boolean(is_descriptor), _to_ptr(descriptor_ptr),
         cutlass.Int32(given_release), cutlass.Int32(required_release),
+        cutlass.Int32(opt_flags),
     )
 
 
@@ -297,8 +301,8 @@ def ncclGinFlush(gin_ptr, coop, ord):
     )
 
 
-_raw_ncclGinSignal = _ffi(
-    name="ncclGinSignal",
+_raw_ncclGinSignal_v2 = _ffi(
+    name="ncclGinSignal_v2",
     params_types=[
         _LLVMPtrType,        # ncclGin_C* gin
         ncclTeam,            # team
@@ -312,17 +316,21 @@ _raw_ncclGinSignal = _ffi(
         _LLVMPtrType,        # descriptor_ptr
         cutlass.Int32,       # given_release
         cutlass.Int32,       # required_release
+        cutlass.Int32,       # opt_flags
     ])
 
-def ncclGinSignal(gin_ptr, team, peer, is_signal, signal_id, signal_op, signal_op_arg,
-                  coop, is_descriptor, descriptor_ptr, given_release, required_release):
-    _raw_ncclGinSignal(
+def ncclGinSignal(gin_ptr, team, peer, is_signal, signal_id,
+                  signal_op, signal_op_arg, coop,
+                  is_descriptor, descriptor_ptr,
+                  given_release, required_release, opt_flags):
+    _raw_ncclGinSignal_v2(
         _to_ptr(gin_ptr), team, cutlass.Int32(peer),
         cutlass.Boolean(is_signal), cutlass.Int32(signal_id),
         cutlass.Int32(signal_op), cutlass.Int64(signal_op_arg),
         _to_coop_value(coop),
         cutlass.Boolean(is_descriptor), _to_ptr(descriptor_ptr),
         cutlass.Int32(given_release), cutlass.Int32(required_release),
+        cutlass.Int32(opt_flags),
     )
 
 

--- a/bindings/nccl4py/nccl/core/device/cute/gin.py
+++ b/bindings/nccl4py/nccl/core/device/cute/gin.py
@@ -48,6 +48,7 @@ class Gin:
         descriptor_ptr=0,
         given_release: int = 3,
         required_release: int = 1,
+        opt_flags: int = 0,
     ) -> None:
         """Put ``src`` to ``dst`` on ``peer`` of ``team``.
 
@@ -87,7 +88,7 @@ class Gin:
             is_signal, signal_id, signal_op, signal_op_arg,
             is_counter, counter_id, coop,
             is_descriptor, descriptor_ptr,
-            given_release, required_release,
+            given_release, required_release, opt_flags,
         )
 
     def put_value(
@@ -107,6 +108,7 @@ class Gin:
         descriptor_ptr=0,
         given_release: int = 3,
         required_release: int = 1,
+        opt_flags: int = 0,
     ) -> None:
         """Put scalar ``value`` to ``dst`` on ``peer`` of ``team``.
 
@@ -139,7 +141,7 @@ class Gin:
             self.ptr, team, peer, dst_win, dst_offset, value, size,
             is_signal, signal_id, signal_op, signal_op_arg,
             coop, is_descriptor, descriptor_ptr,
-            given_release, required_release,
+            given_release, required_release, opt_flags,
         )
 
     def get(
@@ -202,6 +204,7 @@ class Gin:
         descriptor_ptr=0,
         given_release: int = 3,
         required_release: int = 1,
+        opt_flags: int = 0,
     ) -> None:
         """Signal a GIN operation.
 
@@ -219,9 +222,10 @@ class Gin:
             required_release: release-fence flags required by the op.
         """
         raw.ncclGinSignal(
-            self.ptr, team, peer, is_signal, signal_id, signal_op, signal_op_arg,
-            coop, is_descriptor, descriptor_ptr, given_release, required_release,
-    )
+            self.ptr, team, peer, is_signal, signal_id,
+            signal_op, signal_op_arg, coop, is_descriptor, descriptor_ptr,
+            given_release, required_release, opt_flags,
+        )
 
     def read_signal(
         self,


### PR DESCRIPTION
## Description

This PR add support for an optional opt_flags parameter to gin.put, gin.put_value and gin.signal APIs by routing the entry points to v2 APIs in the IR library.

## Related Issues

N/A

## Changes & Impact

Introduces an additional optional parameter to the CuTe GIN APIs, backward compatible with the original version.

## Performance Impact

N/A
