### PR TITLE
gin: return rounded-up context count to application via devComm

### DIFF
--- a/src/gin/gin_host.cc
+++ b/src/gin/gin_host.cc
@@ -280,13 +280,13 @@ ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequir
 
   // Allocate contexts
   int nContextsTotal = reqs->ginContextCount;
-  devComm->ginContextCount = nContextsTotal;
   devComm->ginConnectionCount = backend->ginCommCount;
   if (!reqs->ginExclusiveContexts) {
     // TODO: check if a shared devComm in the list could match our requirements.
   }
 
   nContextsTotal = ROUNDUP(nContextsTotal, backend->ginCommCount);
+  devComm->ginContextCount = nContextsTotal;
   int nContextsPerComm = nContextsTotal / backend->ginCommCount;
   INFO(NCCL_INIT,
        "devCommCreate: creating %d contexts: %d GIN connections with %d contexts each (%d contexts total requested)",


### PR DESCRIPTION
## Description

devComm->ginContextCount (returned to application) was set to the requested context count before being rounded up, so the rounded-up value of contexts actually allocated (a multiple of ginCommCount) was never reported back to the application. Move the assignment after ROUNDUP so devComm->ginContextCount reflects the rounded-up allocation, allowing the application to use the additional contexts

