### PR TITLE
profiler/inspector: report ring buffer drops instead of losing data silently

### DIFF
--- a/plugins/profiler/inspector/README.md
+++ b/plugins/profiler/inspector/README.md
@@ -86,6 +86,8 @@ export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
   Enables verbose output including event trace information.
 - `NCCL_INSPECTOR_PROM_DUMP=<0|1>` (default: `0`)
   Enables Prometheus format for textfile node exporter output instead of custom JSON.
+- `NCCL_INSPECTOR_PROM_DUMP_STATS=<0|1>` (default: `0`)
+  In Prometheus mode, additionally emit the per-device stats metrics (`nccl_collectives_total`, `nccl_collectives_dropped_total`, `nccl_p2p_total`, `nccl_p2p_dropped_total`). Off by default to keep the default Prometheus output minimal; enable it to plumb drop/rate signals to a dashboard. Has no effect on JSON mode (whose per-dump `dump_stats` record is always emitted) or OTLP mode (whose equivalent stats ride under `NCCL_INSPECTOR_OTEL_VERBOSE`).
 - `NCCL_INSPECTOR_OTEL_EXPORT=<0|1>` (default: `0`)
   Enables OTLP HTTP metrics export. Accepted values are `0` (disabled) and `1` (enabled). Default OTLP export emits aggregated bucket metrics.
 - `NCCL_INSPECTOR_OTEL_VERBOSE=<0|1>` (default: `0`)
@@ -108,6 +110,13 @@ export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
   Per-communicator completed-collective ring buffer capacity.
 - `NCCL_INSPECTOR_DUMP_P2P_RING_SIZE=<entries>` (default: `1024`)
   Per-communicator completed-P2P ring buffer capacity.
+
+  If operations complete faster than the dump thread drains the ring, the oldest
+  entries are overwritten before they can be dumped. When this happens the
+  Inspector logs a one-time warning and reports drop counts in the output
+  (`dropped_total` / `dropped_since_last_dump` in the JSON `dump_stats` record;
+  `nccl_collectives_dropped_total` / `nccl_p2p_dropped_total` in Prometheus/OTLP
+  stats). Increasing the ring size retains more entries under bursts.
 - `NCCL_INSPECTOR_COLL_POOL_SIZE=<entries>` (default: `256`)
   Collective pool initial size/stride.
 - `NCCL_INSPECTOR_P2P_POOL_SIZE=<entries>` (default: `256`)
@@ -184,9 +193,18 @@ Note: Prometheus mode enforces a minimum dump interval of 30 seconds (30,000,000
 
 When P2P tracking is enabled (`NCCL_INSPECTOR_ENABLE_P2P=1`), Prometheus output includes P2P metrics with a `p2p_operation` label (e.g., `Send`, `Recv`).
 
+**Opt-in per-device stats metrics** (emitted only when `NCCL_INSPECTOR_PROM_DUMP_STATS=1`):
+- `nccl_collectives_total` - Cumulative collectives enqueued into the ring buffer, per device (counter)
+- `nccl_collectives_dropped_total` - Cumulative collective records overwritten before being dumped, per device (counter)
+- `nccl_p2p_total` - Cumulative P2P operations enqueued into the ring buffer, per device (counter)
+- `nccl_p2p_dropped_total` - Cumulative P2P records overwritten before being dumped, per device (counter)
+
+These are cumulative counters (not per-window gauges), so `rate(nccl_collectives_dropped_total[$__rate_interval]) / rate(nccl_collectives_total[$__rate_interval])` gives the fraction of collectives being lost, robust to scrape/dump interval alignment. They are emitted for every known device each dump so the counters stay continuous.
+
 **Labels:**
 - Collectives: `version`, `slurm_job_id`, `node`, `gpu`, `comm_name`, `n_nodes`, `nranks`, `collective`, `message_size`, `algo_proto`
 - P2P: `version`, `slurm_job_id`, `node`, `gpu`, `comm_name`, `n_nodes`, `nranks`, `p2p_operation`, `message_size`
+- Per-device stats metrics: `version`, `slurm_job_id`, `node`, `gpu`
 
 `message_size` is a bucketed range string (for example `4-5GB`).
 
@@ -295,7 +313,7 @@ Each output file contains JSON objects with the following structure:
     "nnodes": 1
   },
   "metadata": {
-    "inspector_output_format_version": "v4.0",
+    "inspector_output_format_version": "v4.1",
     "git_rev": "",
     "rec_mechanism": "profiler_plugin",
     "dump_timestamp_us": 1748030377748202,
@@ -309,6 +327,39 @@ Each output file contains JSON objects with the following structure:
     "coll_exec_time_us": 61974,
     "coll_algobw_gbs": 277.210914,
     "coll_busbw_gbs": 485.119099
+  }
+}
+```
+
+### Per-Dump Stats Record
+
+Once per dump cycle, each communicator also emits a single stats record (identified by the `dump_stats` key) as a marker at the start of its dump. It reports how many records were written and how many were dropped — overwritten in the ring buffer before they could be dumped (see `NCCL_INSPECTOR_DUMP_COLL_RING_SIZE`). `dropped_total` is cumulative for the communicator; `dropped_since_last_dump` covers only the current dump. Non-zero drops mean the output is an incomplete sample and the ring should be enlarged.
+
+Because this record has no `coll_perf`/`p2p_perf` body, consumers that iterate per-collective should filter on the presence of `coll_perf`/`p2p_perf` and read `dump_stats` separately rather than assuming every record is an operation.
+
+```json
+{
+  "header": {
+    "id": "0x7f8c496ae9f661",
+    "rank": 2,
+    "n_ranks": 8,
+    "nnodes": 1
+  },
+  "metadata": {
+    "inspector_output_format_version": "v4.1",
+    "git_rev": "",
+    "rec_mechanism": "nccl_profiler_interface",
+    "dump_timestamp_us": 1748030377748202,
+    "hostname": "example-hostname",
+    "pid": 1639453
+  },
+  "dump_stats": {
+    "coll_records": 1024,
+    "coll_dropped_total": 4096,
+    "coll_dropped_since_last_dump": 512,
+    "p2p_records": 0,
+    "p2p_dropped_total": 0,
+    "p2p_dropped_since_last_dump": 0
   }
 }
 ```
@@ -332,7 +383,7 @@ This will include additional event trace information in the JSON output, showing
     "nnodes": 1
   },
   "metadata": {
-    "inspector_output_format_version": "v4.0",
+    "inspector_output_format_version": "v4.1",
     "git_rev": "9019a1912-dirty",
     "rec_mechanism": "nccl_profiler_interface",
     "dump_timestamp_us": 1752867229276385,

--- a/plugins/profiler/inspector/inspector.cc
+++ b/plugins/profiler/inspector/inspector.cc
@@ -49,6 +49,10 @@ static bool enableNcclInspectorDumpVerbose = false;
 // Global flag to control prometheus format dumping
 static bool enableNcclInspectorPromDump = false;
 static bool warnedOtelPromDumpConflict = false;
+// Opt-in flag for the extra per-device stats metrics (collectives/p2p totals
+// and drop counters) in Prometheus mode; kept off so the default Prometheus
+// output stays minimal. Non-static: read from inspector_prom.cc.
+bool enableNcclInspectorPromStats = false;
 // Per-communicator completed-collective ring buffer capacity
 static uint32_t ncclInspectorDumpCollRingSize = 1024;
 // Per-communicator completed-P2P ring buffer capacity
@@ -859,6 +863,7 @@ static void showInspectorEnvVars() {
     {"NCCL_INSPECTOR_DUMP_DIR", getenv("NCCL_INSPECTOR_DUMP_DIR"), "(auto-generated)", "Output directory for inspector logs"},
     {"NCCL_INSPECTOR_DUMP_VERBOSE", getenv("NCCL_INSPECTOR_DUMP_VERBOSE"), "0", "Enable/disable verbose dumping (event_trace)"},
     {"NCCL_INSPECTOR_PROM_DUMP", getenv("NCCL_INSPECTOR_PROM_DUMP"), "0", "Enable/disable Prometheus format output dump"},
+    {"NCCL_INSPECTOR_PROM_DUMP_STATS", getenv("NCCL_INSPECTOR_PROM_DUMP_STATS"), "0", "Enable/disable extra per-device Prometheus stats metrics (collectives/p2p totals and drop counters)"},
     {"NCCL_INSPECTOR_OTEL_EXPORT", getenv("NCCL_INSPECTOR_OTEL_EXPORT"), "0", "Enable/disable OTLP HTTP metrics export"},
     {"NCCL_INSPECTOR_OTEL_VERBOSE", getenv("NCCL_INSPECTOR_OTEL_VERBOSE"), "0", "Enable/disable high-cardinality per-operation OTLP metrics"},
     {"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"), "http://localhost:4318/v1/metrics", "OTLP HTTP metrics endpoint"},
@@ -1024,6 +1029,10 @@ static inspectorResult_t initDumpThreadFromEnv() {
   enable = str ? atoi(str) : 0;
   enableNcclInspectorPromDump = enable == 0 ? false : true;
   warnedOtelPromDumpConflict = false;
+
+  str = getenv("NCCL_INSPECTOR_PROM_DUMP_STATS");
+  enable = str ? atoi(str) : 0;
+  enableNcclInspectorPromStats = enable == 0 ? false : true;
 
   inspectorOtelInitFromEnv();
 

--- a/plugins/profiler/inspector/inspector.h
+++ b/plugins/profiler/inspector/inspector.h
@@ -326,6 +326,8 @@ inline int ncclTypeSize(ncclDataType_t type) {
 // Global flag to control P2P tracking
 extern bool enableNcclInspectorP2p;
 extern bool requireKernelTiming;
+// Opt-in flag for extra per-device Prometheus stats metrics (totals + drops)
+extern bool enableNcclInspectorPromStats;
 // Minimum message size (bytes) to be `tracked by inspector
 extern size_t ncclInspectorDumpMinSizeBytes;
 

--- a/plugins/profiler/inspector/inspector_json.cc
+++ b/plugins/profiler/inspector/inspector_json.cc
@@ -58,7 +58,7 @@ static inspectorResult_t inspectorCommInfoHeader(jsonFileOutput* jfo,
 static inspectorResult_t inspectorCommInfoMetaHeader(jsonFileOutput* jfo) {
   JSON_CHK(jsonStartObject(jfo));
   {
-    JSON_CHK(jsonKey(jfo, "inspector_output_format_version")); JSON_CHK(jsonStr(jfo, "v4.0"));
+    JSON_CHK(jsonKey(jfo, "inspector_output_format_version")); JSON_CHK(jsonStr(jfo, "v4.1"));
     JSON_CHK(jsonKey(jfo, "git_rev")); JSON_CHK(jsonStr(jfo, get_git_version_info()));
     JSON_CHK(jsonKey(jfo, "rec_mechanism")); JSON_CHK(jsonStr(jfo, "nccl_profiler_interface"));
     JSON_CHK(jsonKey(jfo, "dump_timestamp_us")); JSON_CHK(jsonUint64(jfo, inspectorGetTime()));
@@ -278,94 +278,117 @@ static inline inspectorResult_t inspectorCompletedP2p(jsonFileOutput* jfo,
  *   inspectorResult_t - success or error code.
  *
  */
-static inspectorResult_t inspectorCommInfoDumpColl(jsonFileOutput* jfo,
-                                                   inspectorCommInfo* commInfo,
-                                                   bool* needs_writing) {
-  if (commInfo == nullptr) {
-    return inspectorSuccess;
-  }
+// Per-dump statistics for one communicator: records written this dump and
+// cumulative / since-last-dump ring drop counts for each op type.
+struct inspectorCommDumpStats {
+  uint64_t collRecords = 0;
+  uint64_t collDroppedTotal = 0;
+  uint64_t collDroppedSinceLastDump = 0;
+  uint64_t p2pRecords = 0;
+  uint64_t p2pDroppedTotal = 0;
+  uint64_t p2pDroppedSinceLastDump = 0;
+};
 
-  thread_local std::vector<inspectorCompletedOpInfo> drainedColl;
-  drainedColl.clear();
+/*
+ * Description:
+ *   Snapshots a ring's drop counters and advances its reported watermark so the
+ *   next dump reports only newly dropped entries.
+ *
+ * Thread Safety:
+ *   Not thread-safe (caller must hold commInfo->guard).
+ */
+static inline void inspectorCommInfoUpdateDropStats(struct inspectorCompletedRing* ring,
+                                                    uint64_t* total,
+                                                    uint64_t* sinceLastDump) {
+  *total = ring->dropped;
+  *sinceLastDump = ring->dropped - ring->droppedReported;
+  ring->droppedReported = ring->dropped;
+}
 
+// Drains the collective ring under the comm guard (one lock hold for this ring)
+// and snapshots its drop stats. Records are appended to drained.
+static inspectorResult_t inspectorCommInfoDrainColl(inspectorCommInfo* commInfo,
+                                                    std::vector<inspectorCompletedOpInfo>& drained,
+                                                    inspectorCommDumpStats* stats) {
   inspectorLockWr(&commInfo->guard);
   if (commInfo->dump_coll) {
     // Make sure we won't allocate while draining (steady-state: no-op).
     if (commInfo->completedCollRing.size > 0
-        && drainedColl.capacity() < commInfo->completedCollRing.size) {
-      drainedColl.reserve(commInfo->completedCollRing.size);
+        && drained.capacity() < commInfo->completedCollRing.size) {
+      drained.reserve(commInfo->completedCollRing.size);
     }
     INS_CHK(inspectorRingDrain<inspectorCompletedOpInfo>(&commInfo->completedCollRing,
-                                                         drainedColl));
+                                                         drained));
     commInfo->dump_coll = inspectorRingNonEmpty(&commInfo->completedCollRing);
   }
+  inspectorCommInfoUpdateDropStats(&commInfo->completedCollRing,
+                                   &stats->collDroppedTotal,
+                                   &stats->collDroppedSinceLastDump);
   inspectorUnlockRWLock(&commInfo->guard);
-
-  if (!drainedColl.empty()) {
-    *needs_writing = true;
-    JSON_CHK(jsonLockOutput(jfo));
-    for (size_t i = 0; i < drainedColl.size(); i++) {
-      JSON_CHK(jsonStartObject(jfo));
-      {
-        JSON_CHK(jsonKey(jfo, "header"));
-        inspectorCommInfoHeader(jfo, commInfo);
-
-        JSON_CHK(jsonKey(jfo, "metadata"));
-        inspectorCommInfoMetaHeader(jfo);
-
-        JSON_CHK(jsonKey(jfo, "coll_perf"));
-        INS_CHK(inspectorCompletedColl(jfo, &drainedColl[i]));
-      }
-      JSON_CHK(jsonFinishObject(jfo));
-      JSON_CHK(jsonNewline(jfo));
-    }
-    JSON_CHK(jsonUnlockOutput(jfo));
-  }
+  stats->collRecords = drained.size();
   return inspectorSuccess;
 }
 
-static inspectorResult_t inspectorCommInfoDumpP2p(jsonFileOutput* jfo,
-                                                  inspectorCommInfo* commInfo,
-                                                  bool* needs_writing) {
-  if (commInfo == nullptr) {
-    return inspectorSuccess;
-  }
-
-  thread_local std::vector<inspectorCompletedOpInfo> drainedP2p;
-  drainedP2p.clear();
-
+// Drains the P2P ring under the comm guard (one lock hold for this ring)
+// and snapshots its drop stats.
+static inspectorResult_t inspectorCommInfoDrainP2p(inspectorCommInfo* commInfo,
+                                                   std::vector<inspectorCompletedOpInfo>& drained,
+                                                   inspectorCommDumpStats* stats) {
   inspectorLockWr(&commInfo->guard);
   if (commInfo->dump_p2p) {
     if (commInfo->completedP2pRing.size > 0
-        && drainedP2p.capacity() < commInfo->completedP2pRing.size) {
-      drainedP2p.reserve(commInfo->completedP2pRing.size);
+        && drained.capacity() < commInfo->completedP2pRing.size) {
+      drained.reserve(commInfo->completedP2pRing.size);
     }
     INS_CHK(inspectorRingDrain<inspectorCompletedOpInfo>(&commInfo->completedP2pRing,
-                                                        drainedP2p));
+                                                         drained));
     commInfo->dump_p2p = inspectorRingNonEmpty(&commInfo->completedP2pRing);
   }
+  inspectorCommInfoUpdateDropStats(&commInfo->completedP2pRing,
+                                   &stats->p2pDroppedTotal,
+                                   &stats->p2pDroppedSinceLastDump);
   inspectorUnlockRWLock(&commInfo->guard);
+  stats->p2pRecords = drained.size();
+  return inspectorSuccess;
+}
 
-  if (!drainedP2p.empty()) {
-    *needs_writing = true;
-    JSON_CHK(jsonLockOutput(jfo));
-    for (size_t i = 0; i < drainedP2p.size(); i++) {
-      JSON_CHK(jsonStartObject(jfo));
-      {
-        JSON_CHK(jsonKey(jfo, "header"));
-        inspectorCommInfoHeader(jfo, commInfo);
+/*
+ * Description:
+ *   Writes a single per-dump stats record for a communicator: a marker at the
+ *   start of the comm's dump cycle carrying records-written and drop counts.
+ *   Emitted once per dump per comm, so consumers must not assume every record
+ *   carries coll_perf/p2p_perf — the "dump_stats" key identifies this record.
+ *
+ * Thread Safety:
+ *   Not thread-safe (caller must hold the JSON output lock).
+ */
+static inspectorResult_t inspectorCommInfoDumpStats(jsonFileOutput* jfo,
+                                                    inspectorCommInfo* commInfo,
+                                                    const inspectorCommDumpStats* stats) {
+  JSON_CHK(jsonStartObject(jfo));
+  {
+    JSON_CHK(jsonKey(jfo, "header"));
+    inspectorCommInfoHeader(jfo, commInfo);
 
-        JSON_CHK(jsonKey(jfo, "metadata"));
-        inspectorCommInfoMetaHeader(jfo);
+    JSON_CHK(jsonKey(jfo, "metadata"));
+    inspectorCommInfoMetaHeader(jfo);
 
-        JSON_CHK(jsonKey(jfo, "p2p_perf"));
-        INS_CHK(inspectorCompletedP2p(jfo, &drainedP2p[i]));
-      }
-      JSON_CHK(jsonFinishObject(jfo));
-      JSON_CHK(jsonNewline(jfo));
+    JSON_CHK(jsonKey(jfo, "dump_stats"));
+    JSON_CHK(jsonStartObject(jfo));
+    {
+      JSON_CHK(jsonKey(jfo, "coll_records")); JSON_CHK(jsonUint64(jfo, stats->collRecords));
+      JSON_CHK(jsonKey(jfo, "coll_dropped_total")); JSON_CHK(jsonUint64(jfo, stats->collDroppedTotal));
+      JSON_CHK(jsonKey(jfo, "coll_dropped_since_last_dump"));
+      JSON_CHK(jsonUint64(jfo, stats->collDroppedSinceLastDump));
+      JSON_CHK(jsonKey(jfo, "p2p_records")); JSON_CHK(jsonUint64(jfo, stats->p2pRecords));
+      JSON_CHK(jsonKey(jfo, "p2p_dropped_total")); JSON_CHK(jsonUint64(jfo, stats->p2pDroppedTotal));
+      JSON_CHK(jsonKey(jfo, "p2p_dropped_since_last_dump"));
+      JSON_CHK(jsonUint64(jfo, stats->p2pDroppedSinceLastDump));
     }
-    JSON_CHK(jsonUnlockOutput(jfo));
+    JSON_CHK(jsonFinishObject(jfo));
   }
+  JSON_CHK(jsonFinishObject(jfo));
+  JSON_CHK(jsonNewline(jfo));
   return inspectorSuccess;
 }
 
@@ -373,9 +396,61 @@ static inspectorResult_t inspectorCommInfoDump(jsonFileOutput* jfo,
                                                inspectorCommInfo* commInfo,
                                                bool* needs_writing) {
   *needs_writing = false;
+  if (commInfo == nullptr) {
+    return inspectorSuccess;
+  }
 
-  INS_CHK(inspectorCommInfoDumpColl(jfo, commInfo, needs_writing));
-  INS_CHK(inspectorCommInfoDumpP2p(jfo, commInfo, needs_writing));
+  thread_local std::vector<inspectorCompletedOpInfo> drainedColl;
+  thread_local std::vector<inspectorCompletedOpInfo> drainedP2p;
+  drainedColl.clear();
+  drainedP2p.clear();
+
+  inspectorCommDumpStats stats;
+  // One guard hold per ring, matching the original per-ring locking.
+  INS_CHK(inspectorCommInfoDrainColl(commInfo, drainedColl, &stats));
+  INS_CHK(inspectorCommInfoDrainP2p(commInfo, drainedP2p, &stats));
+
+  // Emit only when this comm produced records or has newly dropped entries to
+  // report, so idle communicators don't generate empty stats records.
+  bool haveDrops = stats.collDroppedSinceLastDump != 0 || stats.p2pDroppedSinceLastDump != 0;
+  if (drainedColl.empty() && drainedP2p.empty() && !haveDrops) {
+    return inspectorSuccess;
+  }
+
+  *needs_writing = true;
+  JSON_CHK(jsonLockOutput(jfo));
+  INS_CHK(inspectorCommInfoDumpStats(jfo, commInfo, &stats));
+  for (size_t i = 0; i < drainedColl.size(); i++) {
+    JSON_CHK(jsonStartObject(jfo));
+    {
+      JSON_CHK(jsonKey(jfo, "header"));
+      inspectorCommInfoHeader(jfo, commInfo);
+
+      JSON_CHK(jsonKey(jfo, "metadata"));
+      inspectorCommInfoMetaHeader(jfo);
+
+      JSON_CHK(jsonKey(jfo, "coll_perf"));
+      INS_CHK(inspectorCompletedColl(jfo, &drainedColl[i]));
+    }
+    JSON_CHK(jsonFinishObject(jfo));
+    JSON_CHK(jsonNewline(jfo));
+  }
+  for (size_t i = 0; i < drainedP2p.size(); i++) {
+    JSON_CHK(jsonStartObject(jfo));
+    {
+      JSON_CHK(jsonKey(jfo, "header"));
+      inspectorCommInfoHeader(jfo, commInfo);
+
+      JSON_CHK(jsonKey(jfo, "metadata"));
+      inspectorCommInfoMetaHeader(jfo);
+
+      JSON_CHK(jsonKey(jfo, "p2p_perf"));
+      INS_CHK(inspectorCompletedP2p(jfo, &drainedP2p[i]));
+    }
+    JSON_CHK(jsonFinishObject(jfo));
+    JSON_CHK(jsonNewline(jfo));
+  }
+  JSON_CHK(jsonUnlockOutput(jfo));
   return inspectorSuccess;
 }
 

--- a/plugins/profiler/inspector/inspector_otel.cc
+++ b/plugins/profiler/inspector/inspector_otel.cc
@@ -111,6 +111,12 @@ struct inspectorOtelDevice {
   inspectorOtelCollBucketMap collBuckets;
   inspectorOtelP2pBucketMap p2pBuckets;
   bool hasData = false;
+  // Cumulative counts summed across this device's communicators: total ops
+  // ever enqueued and total dropped (overwritten before being dumped).
+  uint64_t collTotal = 0;
+  uint64_t collDroppedTotal = 0;
+  uint64_t p2pTotal = 0;
+  uint64_t p2pDroppedTotal = 0;
 };
 
 static const char* inspectorOtelFirstEnv(const char* name0,
@@ -530,6 +536,51 @@ static inspectorResult_t inspectorOtelBuildAggregatedPoints(
                                         p2pEntry.first,
                                         p2pEntry.second));
     }
+  }
+  return inspectorSuccess;
+}
+
+// Emits the per-device ring-buffer stats (cumulative op totals and drop
+// counters) for one device. Low-cardinality (node/gpu), and monotonic so
+// rate(dropped)/rate(total) yields the fraction of operations lost.
+static inspectorResult_t inspectorOtelAddDeviceTotals(
+    std::vector<inspectorOtelMetricPoint>& points,
+    const inspectorOtelDevice& device,
+    uint64_t timestampUsec) {
+  std::vector<inspectorOtelAttribute> attrs;
+  inspectorOtelAddAttr(attrs, "version",
+                       inspectorOtelFormatVersion(INSPECTOR_OTEL_DEFAULT_FORMAT_MINOR));
+  inspectorOtelAddAttr(attrs, "node", gOtelNodeName);
+  inspectorOtelAddAttr(attrs, "gpu",
+                       device.gpuName.empty() ? "unknown" : device.gpuName);
+
+  inspectorOtelAddMetricPoint(points, "nccl_collectives_total",
+                              "NCCL collectives enqueued into the inspector ring buffer",
+                              "1", attrs,
+                              static_cast<double>(device.collTotal), timestampUsec);
+  inspectorOtelAddMetricPoint(points, "nccl_collectives_dropped_total",
+                              "NCCL collectives overwritten in the ring buffer before being dumped",
+                              "1", attrs,
+                              static_cast<double>(device.collDroppedTotal), timestampUsec);
+  inspectorOtelAddMetricPoint(points, "nccl_p2p_total",
+                              "NCCL P2P operations enqueued into the inspector ring buffer",
+                              "1", attrs,
+                              static_cast<double>(device.p2pTotal), timestampUsec);
+  inspectorOtelAddMetricPoint(points, "nccl_p2p_dropped_total",
+                              "NCCL P2P operations overwritten in the ring buffer before being dumped",
+                              "1", attrs,
+                              static_cast<double>(device.p2pDroppedTotal), timestampUsec);
+  return inspectorSuccess;
+}
+
+// Emits per-device stats for every known device so the counters stay
+// continuous (usable with rate()) even across dumps with no new records.
+static inspectorResult_t inspectorOtelBuildDeviceStatsPoints(
+    const std::map<std::string, inspectorOtelDevice>& devices,
+    std::vector<inspectorOtelMetricPoint>& points,
+    uint64_t timestampUsec) {
+  for (const auto& entry : devices) {
+    INS_CHK(inspectorOtelAddDeviceTotals(points, entry.second, timestampUsec));
   }
   return inspectorSuccess;
 }
@@ -1040,6 +1091,8 @@ static inspectorResult_t inspectorOtelCommInfoDumpColl(
                                                         drainedColl));
     commInfo->dump_coll = inspectorRingNonEmpty(&commInfo->completedCollRing);
   }
+  device.collTotal += commInfo->completedCollRing.enqueued;
+  device.collDroppedTotal += commInfo->completedCollRing.dropped;
   inspectorUnlockRWLock(&commInfo->guard);
 
   if (!drainedColl.empty()) {
@@ -1100,6 +1153,8 @@ static inspectorResult_t inspectorOtelCommInfoDumpP2p(
                                                         drainedP2p));
     commInfo->dump_p2p = inspectorRingNonEmpty(&commInfo->completedP2pRing);
   }
+  device.p2pTotal += commInfo->completedP2pRing.enqueued;
+  device.p2pDroppedTotal += commInfo->completedP2pRing.dropped;
   inspectorUnlockRWLock(&commInfo->guard);
 
   if (!drainedP2p.empty()) {
@@ -1222,6 +1277,11 @@ inspectorResult_t inspectorOtelCommInfoListDump(struct inspectorCommInfoList* co
                  res, unlock);
     if (!verbose) {
       INS_CHK_GOTO(inspectorOtelBuildAggregatedPoints(devices, points),
+                   res, unlock);
+    } else {
+      // Per-device ring-buffer stats (totals + drops) ride under verbose mode
+      // so the default aggregated output stays minimal.
+      INS_CHK_GOTO(inspectorOtelBuildDeviceStatsPoints(devices, points, currentTime),
                    res, unlock);
     }
     shouldExport = true;

--- a/plugins/profiler/inspector/inspector_plugin.cc
+++ b/plugins/profiler/inspector/inspector_plugin.cc
@@ -186,19 +186,33 @@ static void inspectorPluginCollInfoCleanup(struct inspectorCollInfo *collInfo) {
   inspectorEventPoolReleaseColl(collInfo);
 }
 
+// Set once (per process) when the first ring overwrite is detected, so the
+// overflow condition is reported exactly once rather than per dropped entry.
+static bool ringDropWarned = false;
+
 static void inspectorUpdateCommOpInfo(struct inspectorCommInfo *commInfo,
                                       struct inspectorCompletedOpInfo *completedOp) {
   struct inspectorCompletedRing *ring =
     completedOp->isP2p ? &commInfo->completedP2pRing : &commInfo->completedCollRing;
   inspectorLockWr(&commInfo->guard);
   inspectorComputeOpBw(commInfo, completedOp);
+  uint64_t droppedBefore = ring->dropped;
   inspectorRingEnqueue(ring, completedOp);
+  bool overflowed = ring->dropped != droppedBefore;
   if (completedOp->isP2p) {
     commInfo->dump_p2p = inspectorRingNonEmpty(&commInfo->completedP2pRing);
   } else {
     commInfo->dump_coll = inspectorRingNonEmpty(&commInfo->completedCollRing);
   }
   inspectorUnlockRWLock(&commInfo->guard);
+  if (overflowed && !__atomic_exchange_n(&ringDropWarned, true, __ATOMIC_RELAXED)) {
+    WARN_INSPECTOR(
+      "NCCL Inspector: completed-op ring buffer overflowed on comm %s (%s ring size %u); "
+      "oldest entries are being dropped before they can be dumped. Increase "
+      "NCCL_INSPECTOR_DUMP_COLL_RING_SIZE/NCCL_INSPECTOR_DUMP_P2P_RING_SIZE to retain more. "
+      "Dropped counts are reported in the output.",
+      commInfo->commHashStr, completedOp->isP2p ? "p2p" : "coll", ring->size);
+  }
 }
 
 inspectorResult_t inspectorPluginP2pInfoRef(struct inspectorP2pInfo *p2pInfo) {

--- a/plugins/profiler/inspector/inspector_prom.cc
+++ b/plugins/profiler/inspector/inspector_prom.cc
@@ -28,6 +28,7 @@ extern inspectorResult_t inspectorCommInfoListFinalize(struct inspectorCommInfoL
 extern const char* inspectorTimingSourceToString(inspectorTimingSource_t timingSource);
 
 extern const char* ncclFuncToString(ncclFunc_t fn);
+extern bool enableNcclInspectorPromStats;
 
 struct inspectorPromBucketAgg {
   uint64_t count = 0;
@@ -87,6 +88,12 @@ struct inspectorPromDevice {
   inspectorPromCollBucketMap collBuckets;
   inspectorPromP2pBucketMap p2pBuckets;
   bool hasData = false;
+  // Cumulative counts summed across this device's communicators: total ops
+  // ever enqueued and total dropped (overwritten before being dumped).
+  uint64_t collTotal = 0;
+  uint64_t collDroppedTotal = 0;
+  uint64_t p2pTotal = 0;
+  uint64_t p2pDroppedTotal = 0;
 };
 static const int kInspectorPromFormatMinor = 1;
 
@@ -565,6 +572,8 @@ static inspectorResult_t inspectorPromCommInfoDumpColl(struct inspectorCommInfo*
                                                         drainedColl));
     commInfo->dump_coll = inspectorRingNonEmpty(&commInfo->completedCollRing);
   }
+  device.collTotal += commInfo->completedCollRing.enqueued;
+  device.collDroppedTotal += commInfo->completedCollRing.dropped;
   inspectorUnlockRWLock(&commInfo->guard);
 
   if (!drainedColl.empty()) {
@@ -616,6 +625,8 @@ static inspectorResult_t inspectorPromCommInfoDumpP2p(struct inspectorCommInfo* 
                                                         drainedP2p));
     commInfo->dump_p2p = inspectorRingNonEmpty(&commInfo->completedP2pRing);
   }
+  device.p2pTotal += commInfo->completedP2pRing.enqueued;
+  device.p2pDroppedTotal += commInfo->completedP2pRing.dropped;
   inspectorUnlockRWLock(&commInfo->guard);
 
   if (!drainedP2p.empty()) {
@@ -717,6 +728,78 @@ static inspectorResult_t inspectorPromFillDeviceBuckets(struct inspectorCommInfo
  * Thread Safety:
  *   Not thread-safe (caller must hold commList lock).
  */
+/*
+ * Description:
+ *   Formats device-level labels (node/gpu/version only, no bucket-key fields)
+ *   for the per-device Prometheus stats metrics.
+ *
+ * Thread Safety:
+ *   Not thread-safe. Onus of thread safety is on the caller.
+ */
+static inspectorResult_t inspectorPromGetLabelsDevice(char* labels,
+                                                      size_t labelSize,
+                                                      const char* nodeName,
+                                                      const char* gpuName,
+                                                      const char* version) {
+  const char* jobId = getenv("SLURM_JOB_ID");
+  int ret = snprintf(labels, labelSize,
+                     "version=\"%s\",slurm_job_id=\"%s\",node=\"%s\",gpu=\"%s\"",
+                     (version && version[0]) ? version : "unknown",
+                     jobId ? jobId : "unknown",
+                     (nodeName && nodeName[0]) ? nodeName : "unknown",
+                     (gpuName && gpuName[0]) ? gpuName : "unknown");
+  if (ret < 0 || (size_t)ret >= labelSize) {
+    return inspectorMemoryError;
+  }
+  return inspectorSuccess;
+}
+
+/*
+ * Description:
+ *   Writes the opt-in per-device stats metrics: cumulative op totals and
+ *   ring-buffer drop counters. Counters (not per-window gauges), so rate()
+ *   and rate(dropped)/rate(total) work.
+ *
+ * Thread Safety:
+ *   Not thread-safe. Onus of thread safety is on the caller/owner of the file.
+ */
+static inspectorResult_t inspectorPromWriteDeviceTotals(FILE* file,
+                                                        const inspectorPromDevice& device) {
+  if (!file) {
+    return inspectorFileOpenError;
+  }
+
+  char version[16];
+  inspectorPromGetVersion(version, sizeof(version));
+
+  char labels[1024];
+  memset(labels, 0, sizeof(labels));
+  INS_CHK(inspectorPromGetLabelsDevice(labels,
+                                       sizeof(labels),
+                                       device.nodeName.c_str(),
+                                       device.gpuName.c_str(),
+                                       version));
+
+  char buffer[2048];
+  int written = snprintf(buffer, sizeof(buffer),
+                         "nccl_collectives_total{%s} %llu\n"
+                         "nccl_collectives_dropped_total{%s} %llu\n"
+                         "nccl_p2p_total{%s} %llu\n"
+                         "nccl_p2p_dropped_total{%s} %llu\n",
+                         labels, (unsigned long long)device.collTotal,
+                         labels, (unsigned long long)device.collDroppedTotal,
+                         labels, (unsigned long long)device.p2pTotal,
+                         labels, (unsigned long long)device.p2pDroppedTotal);
+  if (written < 0 || (size_t)written >= sizeof(buffer)) {
+    return inspectorMemoryError;
+  }
+  if (fwrite(buffer, 1, written, file) != (size_t)written) {
+    return inspectorFileOpenError;
+  }
+  fflush(file);
+  return inspectorSuccess;
+}
+
 static inspectorResult_t inspectorPromWriteDeviceBuckets(std::map<std::string,
                                                          inspectorPromDevice>& devices,
                                                          const char* output_root,
@@ -724,7 +807,11 @@ static inspectorResult_t inspectorPromWriteDeviceBuckets(std::map<std::string,
                                                          struct inspectorDumpThread* dumpThread) {
   for (auto& entry : devices) {
     inspectorPromDevice& device = entry.second;
-    if (!device.hasData) {
+    // Per-device stats metrics are opt-in; when enabled they are emitted for
+    // every known device so the counters stay continuous (usable with rate())
+    // even across dumps where a GPU produced no new records.
+    bool writeStats = enableNcclInspectorPromStats;
+    if (!device.hasData && !writeStats) {
       continue;
     }
     FILE* file = nullptr;
@@ -747,6 +834,9 @@ static inspectorResult_t inspectorPromWriteDeviceBuckets(std::map<std::string,
                                           device,
                                           p2pEntry.first,
                                           p2pEntry.second));
+    }
+    if (writeStats) {
+      INS_CHK(inspectorPromWriteDeviceTotals(file, device));
     }
   }
   return inspectorSuccess;

--- a/plugins/profiler/inspector/inspector_ring.cc
+++ b/plugins/profiler/inspector/inspector_ring.cc
@@ -40,6 +40,9 @@ inspectorResult_t inspectorRingInit(struct inspectorCompletedRing* ring,
   ring->size = size;
   ring->head = 0;
   ring->tail = 0;
+  ring->enqueued = 0;
+  ring->dropped = 0;
+  ring->droppedReported = 0;
   return inspectorSuccess;
 }
 
@@ -64,6 +67,9 @@ void inspectorRingFinalize(struct inspectorCompletedRing* ring) {
   free(ring->entries);
   ring->entries = nullptr;
   ring->size = ring->head = ring->tail = 0;
+  ring->enqueued = 0;
+  ring->dropped = 0;
+  ring->droppedReported = 0;
 }
 
 /*
@@ -93,9 +99,11 @@ inspectorResult_t inspectorRingEnqueue(struct inspectorCompletedRing* ring,
   if ((ring->tail + 1) % bufSize == ring->head) {
     // Ring is full: advance head to overwrite the oldest entry
     ring->head = (ring->head + 1) % bufSize;
+    ring->dropped++;
   }
 
   memcpy(ringSlot(ring, ring->tail), entry, ring->entrySize);
   ring->tail = (ring->tail + 1) % bufSize;
+  ring->enqueued++;
   return inspectorSuccess;
 }

--- a/plugins/profiler/inspector/inspector_ring.h
+++ b/plugins/profiler/inspector/inspector_ring.h
@@ -26,6 +26,9 @@ struct inspectorCompletedRing {
   uint32_t size{0};     // user-visible capacity (size+1 slots are allocated)
   uint32_t head{0};     // index of oldest element
   uint32_t tail{0};     // index where next element will be written
+  uint64_t enqueued{0};         // cumulative entries ever enqueued (drained + dropped)
+  uint64_t dropped{0};          // cumulative entries overwritten before being drained
+  uint64_t droppedReported{0};  // value of 'dropped' at the last drain (for deltas)
 };
 
 /*


### PR DESCRIPTION

## Problem

The Inspector plugin stores completed collective/P2P records in a fixed-size
per-communicator ring buffer (`NCCL_INSPECTOR_DUMP_COLL_RING_SIZE`, default
1024) that a background thread drains every
`NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS`. When operations complete
faster than the ring is drained, `inspectorRingEnqueue` overwrites the oldest
unread entry — silently. Nothing is logged, no counter is incremented, and
nothing in the output indicates that data is missing, so downstream consumers
treat a biased sample as complete data.

This is easy to hit in practice. On a 2-node × 8 H100 run of nccl-tests
`all_reduce_perf` looping 256 MB messages (~770 collectives/s against 1024
ring slots per 3 s dump interval), the JSON output captured only **48.4%** of
collectives: 5,825,536 records out of a 12,036,596 `coll_sn` span across 16
ranks (6,211,060 lost). Per-rank record counts were exact multiples of 1024
(355×1024 / 356×1024) — the ring-overwrite fingerprint. Prometheus mode reads
the same ring, so its windowed aggregates are computed over the same biased
sample with no indication either.

Relatedly, the per-window operation count (`agg.count`) was already computed
for the exec-time mean in Prometheus mode but never emitted, so there was no
rate signal to notice the loss (or to use for straggler detection).

## Solution

Count the overwrites and surface them in every output mode, without changing
behavior for jobs that never overflow:

- `inspectorCompletedRing` gains `dropped` (cumulative) and `droppedReported`
  (snapshot at last drain). The enqueue path increments `dropped` in the
  existing overwrite branch — one increment under the already-held
  per-communicator write lock; no new locks or allocations.
- **JSON**: metadata gains `dropped_total` and `dropped_since_last_dump`
  (snapshotted under the same guard as the drain). Format version bumped
  v4.0 → v4.1.
- **Prometheus**: new metrics
  - `nccl_collective_count` / `nccl_p2p_count` — per-bucket operation count
    per dump window (the previously computed-but-unemitted `agg.count`);
  - `nccl_collectives_dropped_total` / `nccl_p2p_dropped_total` — cumulative
    drops with device-level labels (`version`, `slurm_job_id`, `node`, `gpu`),
    summed across the device's communicators.
  Format minor bumped → `version="v5.2"`.
- **One-time warning** (per process) via the existing logging macros on first
  overflow, suggesting a larger ring or shorter dump interval.

Design notes: the drop counters are kept device-level in Prometheus mode to
avoid adding per-bucket cardinality; per-communicator detail is available in
JSON mode. Summing cumulative per-communicator counters can decrease if a
communicator is destroyed mid-job; in practice communicators outlive the
scrape windows and the counter is monotonic.

## Validation

2 nodes × 8 H100, Slurm, nccl-tests `all_reduce_perf`, plugin built with the
standalone Makefile (gcc `-Wall -Wextra`, no warnings).

1. **Low-rate control** (1 GB messages, ~100 colls/s « ring capacity):
   `dropped_total` = 0 on all 16 ranks, `coll_sn` gap-free (span == records,
   e.g. 1826/1826) — no behavior change on the non-overflow path, and no
   warning logged.
2. **Overflow run** (256 MB looping, ~770 colls/s, 3 s interval, ~5 min,
   ~500k collectives/rank): on 15 of 16 ranks the final `dropped_total`
   equals the ground truth computed from the output itself,
   `(max(coll_sn) + 1) − records_written`, **exactly** — e.g. rank 0:
   222,208 records, max `coll_sn` 499,750 → 277,543 expected, 277,543
   reported. The 16th rank differed by exactly 1 record out of ~500k,
   consistent with a single event discarded by the default
   `NCCL_INSPECTOR_REQUIRE_KERNEL_TIMING` filter (which consumes a sequence
   number without entering the ring). On every rank the
   `dropped_since_last_dump` values across dumps sum to `dropped_total`.
   The overflow warning appeared exactly once per process (16 total).
   Notably, each rank's first ~770–800 records were overwritten before the
   first drain ever ran (first surviving `coll_sn` ≈ 770), so simple
   span-based gap analysis *undercounts* the loss — the counter sees it.
3. **Prometheus spot-check** (same workload, 30 s interval), sampled
   mid-run: `nccl_collective_count` = 1024 (exactly ring size per window
   while overflowing), `nccl_collectives_dropped_total` = 87,841 and
   growing, `nccl_p2p_dropped_total` = 0, all under `version="v5.2"`.

## Limitations

- Drop counts identify *how many* records were lost, not *which* windows they
  came from within a dump interval.
- In Prometheus mode drops are attributed to the device, not to individual
  communicators/buckets (deliberate, to bound label cardinality).
