### PR TITLE
Tune Blackwell symmetric ReduceScatter selection

### DIFF
--- a/src/include/sym_kernels.h
+++ b/src/include/sym_kernels.h
@@ -128,8 +128,9 @@ ncclResult_t ncclSymkFinalize(struct ncclComm* comm);
 bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
                        size_t nElts);
 ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
-                                size_t nEltsTotal, size_t nEltsMax, int nWorks, ncclSymRegType_t winRegType,
-                                float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks, int* nWarps, bool* forced);
+                                size_t nEltsTotal, size_t nEltsTotalRaw, size_t nEltsMax, int nWorks,
+                                ncclSymRegType_t winRegType, float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks,
+                                int* nWarps, bool* forced);
 
 ncclResult_t ncclSymkMakeDevWork(struct ncclComm* comm, struct ncclTaskColl* task, struct ncclSymkDevWork* outDevWork);
 

--- a/src/scheduler/symmetric_sched.cc
+++ b/src/scheduler/symmetric_sched.cc
@@ -123,7 +123,7 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
       int nWarps = 0;
       int nWorks = 0;
       float estTimeUs = 1.e18;
-      size_t countTotal = 0, countMax = 0;
+      size_t countTotal = 0, countTotalRaw = 0, countMax = 0;
       struct ncclTaskColl* headTask = task;
       size_t cellCount = NCCL_SYM_KERNEL_CELL_SIZE / ncclTypeSize(headTask->datatype);
       bool forced = false;
@@ -132,6 +132,7 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
       while (task != nullptr) {
         size_t count;
         nWorks++;
+        countTotalRaw += task->count;
         count = alignUp(task->count, cellCount);
         countTotal += count;
         if (count > countMax) countMax = count;
@@ -141,8 +142,9 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
         }
         task = task->next;
       }
-      NCCLCHECK(ncclSymkPickKernel(comm, headTask->func, symkOp, headTask->datatype, countTotal, countMax, nWorks,
-                                   headTask->winRegType, &estTimeUs, &kernelId, &nChannels, &nWarps, &forced));
+      NCCLCHECK(ncclSymkPickKernel(comm, headTask->func, symkOp, headTask->datatype, countTotal, countTotalRaw,
+                                   countMax, nWorks, headTask->winRegType, &estTimeUs, &kernelId, &nChannels, &nWarps,
+                                   &forced));
       task = headTask;
       bool isLLKernel = (1 << kernelId) & ncclSymkLLKernelMask();
       bool isOneThreadMultiGpus = comm->intraRanks > 1 && !ncclParamSingleProcMemRegEnable();

--- a/src/sym_kernels.cc
+++ b/src/sym_kernels.cc
@@ -166,18 +166,21 @@ static double model(double busBytes, double baseLat, int nSMs, double smBw, doub
 
 // Given the kernel and bytes, return the minimum number of blocks to run on such that
 // perf is 99% of running at max blocks, and return the estimate runtime for that
-// block count.
+// block count. If nBlocksOverride is nonzero, return the estimate for that block count.
 static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, float* timeUs, int* nBlocks);
-static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, float* timeUs, int* nBlocks);
+static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, int nBlocksOverride,
+                           float* timeUs, int* nBlocks);
 
-static void queryModel(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, float* timeUs, int* nBlocks) {
+static void queryModel(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, int nBlocksOverride, float* timeUs,
+                       int* nBlocks) {
   if (kernelMask_Gin >> k & 1) {
     queryModel_gin(comm, k, nBytes, timeUs, nBlocks);
   } else {
-    queryModel_lsa(comm, k, nBytes, timeUs, nBlocks);
+    queryModel_lsa(comm, k, nBytes, nBlocksOverride, timeUs, nBlocks);
   }
 }
 
+// GB200/GB300 measurements show LD at the 64-CTA limit winning from these output-per-rank sizes.
 static int blackwellRsLdBlocks(struct ncclComm* comm, size_t nBytes) {
   if (comm->cudaArch < 1000 || comm->cudaArch >= 1100 || comm->nNodes != 1) return 0;
   if (comm->nRanks == 2 && nBytes >= (size_t(2) << 20)) return ncclSymkMaxBlocks;
@@ -342,7 +345,8 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
   }
 }
 
-static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, float* timeUs, int* nBlocks) {
+static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, int nBlocksOverride,
+                           float* timeUs, int* nBlocks) {
   constexpr double LL_BusFactor = 9; // 2X the bytes, plus some processing, plus no unrolling
 
   int nRanks = comm->nRanks;
@@ -410,6 +414,7 @@ static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
 
   int nUserCTAs = std::min<int>(ncclSymkMaxBlocks, ncclParamSymCTAs());
   if (nUserCTAs > 0) nMinBlocks = nMaxBlocks = nUserCTAs;
+  if (nBlocksOverride > 0) nMinBlocks = nMaxBlocks = nBlocksOverride;
 
   bool isLL = kernelMask_LL >> k & 1;
   bool isAG = kernelMask_AG >> k & 1;
@@ -643,15 +648,13 @@ ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*nc
     ncclSymkKernelId k = (ncclSymkKernelId)popFirstOneBit(&kmaskRemain);
     float kTime;
     int kBlocks;
-    queryModel(comm, k, nBytes, &kTime, &kBlocks);
+    queryModel(comm, k, nBytes, preferRsLd ? rsLdBlocks : 0, &kTime, &kBlocks);
     if (kTime * (1.0f + smPenalty * kBlocks) < bestTime * (1.0f + smPenalty * bestBlocks)) {
       bestKernel = k;
       bestTime = kTime;
       bestBlocks = kBlocks;
     }
   }
-  if (preferRsLd) bestBlocks = rsLdBlocks;
-
   *kernelId = bestKernel;
   *estTimeUs = kmask == 0 || kernelMask_user() == (1 << ncclSymkKernelId_Count) - 1 ? bestTime : 0.0f;
   *nBlocks = bestBlocks;

--- a/src/sym_kernels.cc
+++ b/src/sym_kernels.cc
@@ -178,6 +178,13 @@ static void queryModel(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes,
   }
 }
 
+static int blackwellRsLdBlocks(struct ncclComm* comm, size_t nBytes) {
+  if (comm->cudaArch < 1000 || comm->cudaArch >= 1100 || comm->nNodes != 1) return 0;
+  if (comm->nRanks == 2 && nBytes >= (size_t(2) << 20)) return ncclSymkMaxBlocks;
+  if (comm->nRanks == 4 && nBytes >= (size_t(4) << 20)) return ncclSymkMaxBlocks;
+  return 0;
+}
+
 #define NCCL_NVLINK_BW_IDX_HOPPER 0
 #define NCCL_NVLINK_BW_IDX_BLACKWELL 1
 #define NCCL_NVLINK_BW_IDX_NUM 2
@@ -597,11 +604,23 @@ bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedO
 }
 
 ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
-                                size_t nEltsTotal, size_t nEltsMax, int nWorks, ncclSymRegType_t winRegType,
-                                float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks, int* nWarps, bool* forced) {
+                                size_t nEltsTotal, size_t nEltsTotalRaw, size_t nEltsMax, int nWorks,
+                                ncclSymRegType_t winRegType, float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks,
+                                int* nWarps, bool* forced) {
   uint32_t kmask = ncclSymkMask(comm, coll, red, ty, nEltsMax);
 
   *forced = !(kernelMask_user() == (1 << (int)ncclSymkKernelId_Count) - 1);
+  size_t nBytes = nEltsTotal * ncclTypeSize(ty);
+  // Scheduler cells are rounded up; use the raw size so padding cannot cross a measured threshold early.
+  size_t nBytesRaw = nEltsTotalRaw * ncclTypeSize(ty);
+  uint32_t rsLdMask = 1 << ncclSymkKernelId_ReduceScatter_LD;
+  bool hasRegisteredRsInput = winRegType == ncclSymSendRegRecvReg || winRegType == ncclSymSendRegRecvNonreg;
+  int rsLdBlocks = blackwellRsLdBlocks(comm, nBytesRaw);
+  bool preferRsLd = comm->config.CTAPolicy == NCCL_CTA_POLICY_DEFAULT && !*forced && ncclParamSymCTAs() <= 0 &&
+                    hasRegisteredRsInput && nWorks == 1 && coll == ncclFuncReduceScatter && red == ncclDevSum &&
+                    rsLdBlocks > 0 && comm->config.minCTAs <= rsLdBlocks && rsLdBlocks <= comm->config.maxCTAs &&
+                    (kmask & rsLdMask);
+  if (preferRsLd) kmask = rsLdMask;
   // We currently don't support grouping for LL kernels.
   if (nWorks > 1) kmask &= ~kernelMask_LL;
 
@@ -617,7 +636,6 @@ ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*nc
   ncclSymkKernelId bestKernel = ncclSymkKernelId_Count;
   float bestTime = 1.e30f;
   int bestBlocks = 999;
-  size_t nBytes = nEltsTotal * ncclTypeSize(ty);
 
   constexpr float smPenalty = .025f; // 2.5% percent increase in time per SM
   uint32_t kmaskRemain = kmask;
@@ -632,6 +650,7 @@ ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*nc
       bestBlocks = kBlocks;
     }
   }
+  if (preferRsLd) bestBlocks = rsLdBlocks;
 
   *kernelId = bestKernel;
   *estTimeUs = kmask == 0 || kernelMask_user() == (1 << ncclSymkKernelId_Count) - 1 ? bestTime : 0.0f;


### PR DESCRIPTION
## Description

On one-node Blackwell systems, the symmetric ReduceScatter model under-parallelizes the existing direct-load (LD) kernel at two ranks and selects LDMC after LD becomes faster at four ranks.

For a registered-input, single-work ReduceScatter SUM under the default CTA policy, select the existing LD kernel at the 64-CTA symmetric limit from these measured output-per-rank crossovers:

```text
2 ranks: 2 MiB
4 ranks: 4 MiB
```

The scheduler currently passes cell-rounded counts to the selector. This change also passes the raw count so padding cannot cross a measured threshold early. When the override is active, the model evaluates the same fixed 64-CTA launch returned to the scheduler, keeping `estTimeUs` and `nBlocks` consistent. It changes host-side selection only; it adds no kernel, collective algorithm, public API, or ABI.

Merged [vLLM #46703](https://github.com/vllm-project/vllm/pull/46703) is a concrete consumer: it adds opt-in NCCL symmetric AllGather/ReduceScatter for MoE dispatch/combine. This PR makes a primitive-level claim once the producer input is directly registered; it does not claim an end-to-end vLLM result.

## Related Issues

Fixes #2305.

Related: #2280 and #2293.

## Changes & Impact

The override requires all of the following:

- Blackwell (`cudaArch` 1000-1099), one node, and exactly 2 or 4 ranks.
- ReduceScatter SUM with one work item and a registered send window.
- Default CTA policy, no explicit `NCCL_SYM_KERNEL` or `NCCL_SYM_CTAS`.
- CTA bounds that permit 64 CTAs and an available LD kernel.
- At least 2 MiB/rank at DP2 or 4 MiB/rank at DP4, using raw bytes.

Other architectures, node/rank counts, reductions, multi-work batches, EFFICIENCY/ZERO policies, explicit controls, and incompatible CTA bounds retain the current selector. Avg/`SumPostDiv` and one-node 8-rank selection intentionally remain on the existing model because their crossovers were not measured.

## Performance Impact

Direct NCCL ReduceScatter harness, FP32, one process per rank, NCCL `master` at `5067397c`, six independent exclusive allocations, balanced variant order, and 30 samples of 100 calls per allocation. Latencies are means of allocation medians; deltas are paired geometric ratios.

Issue #2305 uses a quick BF16 upstream `nccl-tests` reproducer with one process controlling the local GPUs. Its absolute timings are not directly comparable to this table; the paired campaign below is the statistical performance claim.

| GPU | Ranks | Output/rank | Current symmetric | This PR | Ring/LL | PR/current | PR/Ring |
|---|---:|---:|---:|---:|---:|---:|---:|
| GB200 | 2 | 2 MiB | 28.20 us | 20.21 us | 20.57 us | -28.36% | -1.80% |
| GB200 | 2 | 32 MiB | 204.83 us | 62.70 us | 97.33 us | -69.39% | -35.58% |
| GB200 | 4 | 4 MiB | 39.85 us | 31.00 us | 55.73 us | -22.20% | -44.38% |
| GB200 | 4 | 32 MiB | 256.26 us | 169.51 us | 201.21 us | -33.85% | -15.74% |
| GB300 | 2 | 2 MiB | 27.91 us | 18.55 us | 20.18 us | -33.54% | -8.07% |
| GB300 | 2 | 32 MiB | 199.74 us | 62.41 us | 96.37 us | -68.75% | -35.24% |
| GB300 | 4 | 4 MiB | 39.30 us | 30.86 us | 55.17 us | -21.46% | -44.05% |
| GB300 | 4 | 32 MiB | 251.06 us | 169.19 us | 197.98 us | -32.60% | -14.54% |

All PR/current 95% confidence intervals at these points exclude parity. At the GB200 DP2 gate, PR/Ring is statistical parity (-1.80%, 95% CI -4.11% to +0.57%); all other displayed PR/Ring comparisons favor this PR with intervals excluding parity.

Additional validation:

- BF16, FP16, FP32, FP8 E4M3, and FP8 E5M2 all improve at the gates and at 32 MiB/rank on both GPUs and both rank counts (40/40 comparisons, 20.6-76.5%).
- A 4-byte sweep covered 769 sizes around each gate on each GPU/rank case. All 1,028 active points improved. Below the raw gates, where selection is unchanged, mean deltas were within 0.014% and maximum absolute deviation was 0.45%.
- Exact-candidate upstream `nccl-tests`: 52/52 sections completed with zero wrong or out-of-bounds values, covering all datatypes/operations, in-place/out-of-place, CUDA Graph, unaligned buffers, CTA policies, explicit controls, and bounds.
- Three paired 2-node/8-rank and 4-node/16-rank controls at 2 and 8 MiB/rank: all candidate/current 95% confidence intervals include parity.
- Fresh exact-head (`a70774e1f`) ABBA spot checks at 256 MiB and 1 GiB/rank on GB200/GB300 with 2/4 ranks passed correctness; all 8 candidate/current comparisons improved by 36.0-72.2%.

Nsight Systems attributes the improvement to selection, not staging:

```text
DP2 gate: current LD11  -> LD64
DP4 gate: current LDMC6 -> LD64
```

Current and candidate symmetric profiles have identical memcpy summaries and contain no D2D or P2P payload copy.