### PR TITLE
Add IB active-standby failover

### DIFF
--- a/src/transport/net_ib/common.cc
+++ b/src/transport/net_ib/common.cc
@@ -57,6 +57,9 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
     memset(&baseComm->qps[i].rtsAttr, 0, sizeof(baseComm->qps[i].rtsAttr));
   }
   baseComm->nqps = -1;
+  baseComm->dataPathPolicy = ncclIbDataPathActiveActive;
+  baseComm->primaryDevIndex = -1;
+  baseComm->standbyDevIndex = -1;
   baseComm->splitDataOnQps = ncclParamIbSplitDataOnQps();
   baseComm->nDataQps = -1;
   baseComm->isSend = isSend;

--- a/src/transport/net_ib/common.h
+++ b/src/transport/net_ib/common.h
@@ -57,8 +57,31 @@ struct ncclIbMrCache {
 extern int ncclNMergedIbDevs;
 #define NCCL_IB_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC
 #define MAX_MERGED_DEV_NAME (MAXNAMESIZE * NCCL_IB_MAX_DEVS_PER_NIC) + NCCL_IB_MAX_DEVS_PER_NIC
+
+enum ncclIbDataPathPolicy {
+  ncclIbDataPathActiveActive = 0,
+  ncclIbDataPathActiveStandby = 1,
+};
+
+#define NCCL_IB_DATA_PATH_INFO_VERSION 1
+struct ncclIbDataPathInfo {
+  uint8_t version;
+  uint8_t policy;
+  uint8_t primaryDevIndex;
+  uint8_t standbyDevIndex;
+  uint16_t qpsPerDevice;
+};
+
 struct alignas(64) ncclIbMergedDev {
+  // vProps is the runtime view used for QP/CQ/MR creation. In active-standby
+  // mode it is normalized as [primary, standby]. topoVProps is reported to
+  // NCCL core and contains only the primary device.
   ncclNetVDeviceProps_t vProps;
+  ncclNetVDeviceProps_t topoVProps;
+  enum ncclIbDataPathPolicy dataPathPolicy;
+  int primaryDevIndex;
+  int standbyDevIndex;
+  bool containsHcaPairMember;
   int speed;
   int16_t railId;
   int16_t planeId;
@@ -339,6 +362,9 @@ struct ncclIbResiliency;
 
 struct alignas(32) ncclIbNetCommBase {
   ncclNetVDeviceProps_t vProps;
+  enum ncclIbDataPathPolicy dataPathPolicy;
+  int primaryDevIndex;
+  int standbyDevIndex;
   bool isSend;
   struct ncclIbRequest reqs[NET_IB_MAX_REQUESTS];
   struct ncclIbQp qps[NCCL_IB_MAX_QPS];
@@ -379,6 +405,10 @@ static inline ncclResult_t ncclIbCommBaseGetQpByIndex(struct ncclIbNetCommBase* 
 static inline int ncclIbCommBaseGetNqpsPerRequest(struct ncclIbNetCommBase* baseComm) {
   assert(baseComm->nDataQps != -1);
   assert(baseComm->nqps != -1);
+  if (baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    assert(baseComm->vProps.ndevs == 2);
+    return (baseComm->splitDataOnQps == 1) ? baseComm->nqps / baseComm->vProps.ndevs : 1;
+  }
   return (baseComm->splitDataOnQps == 1) ? baseComm->nqps : baseComm->nDataQps;
 }
 
@@ -393,7 +423,15 @@ static inline int ncclIbCommBaseGetNqpsPerRequest(struct ncclIbNetCommBase* base
 static inline ncclResult_t ncclIbCommBaseGetQpForRequest(struct ncclIbNetCommBase* baseComm, const uint64_t id,
                                                          const uint8_t qpIndex, ncclIbQp** outQp, int* outQpIndex) {
   int nQps = ncclIbCommBaseGetNqpsPerRequest(baseComm);
-  *outQpIndex = (id * nQps + qpIndex) % baseComm->nqps;
+  if (baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    int qpsPerDevice = baseComm->nqps / baseComm->vProps.ndevs;
+    assert(qpsPerDevice > 0);
+    assert(qpIndex < nQps);
+    int lane = baseComm->splitDataOnQps == 1 ? qpIndex : id % qpsPerDevice;
+    *outQpIndex = lane * baseComm->vProps.ndevs + baseComm->primaryDevIndex;
+  } else {
+    *outQpIndex = (id * nQps + qpIndex) % baseComm->nqps;
+  }
   *outQp = baseComm->activeQps[*outQpIndex];
   assert(*outQp != NULL);
   return ncclSuccess;

--- a/src/transport/net_ib/connect.cc
+++ b/src/transport/net_ib/connect.cc
@@ -25,7 +25,60 @@ extern int64_t ncclParamIbOooRq();
 
 struct ncclIbDevExtraProps {
   bool oooRq;
+  struct ncclIbDataPathInfo dataPathInfo;
 };
+
+static struct ncclIbDataPathInfo ncclIbGetDataPathInfo(const struct ncclIbNetCommBase* base) {
+  struct ncclIbDataPathInfo info = {NCCL_IB_DATA_PATH_INFO_VERSION, (uint8_t)base->dataPathPolicy, UINT8_MAX,
+                                    UINT8_MAX, 0};
+  if (base->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    info.primaryDevIndex = base->primaryDevIndex;
+    info.standbyDevIndex = base->standbyDevIndex;
+  }
+  if (base->nqps > 0 && base->vProps.ndevs > 0) info.qpsPerDevice = base->nqps / base->vProps.ndevs;
+  return info;
+}
+
+static ncclResult_t ncclIbSetDataPathPolicy(struct ncclIbNetCommBase* base, const struct ncclIbMergedDev* mergedDev) {
+  if (mergedDev->containsHcaPairMember && mergedDev->dataPathPolicy != ncclIbDataPathActiveStandby) {
+    WARN("NET/IB: Configured HCA pair member reached connect without its partner in the virtual device");
+    return ncclInvalidUsage;
+  }
+  base->dataPathPolicy = mergedDev->dataPathPolicy;
+  base->primaryDevIndex = mergedDev->primaryDevIndex;
+  base->standbyDevIndex = mergedDev->standbyDevIndex;
+  if (base->dataPathPolicy == ncclIbDataPathActiveStandby &&
+      (base->vProps.ndevs != 2 || base->primaryDevIndex != 0 || base->standbyDevIndex != 1 ||
+       base->resiliency == NULL)) {
+    WARN("NET/IB: Invalid active-standby runtime configuration (ndevs=%d primary=%d standby=%d resiliency=%p)",
+         base->vProps.ndevs, base->primaryDevIndex, base->standbyDevIndex, base->resiliency);
+    return ncclInvalidUsage;
+  }
+  if (base->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    int primary = base->vProps.devs[base->primaryDevIndex];
+    int standby = base->vProps.devs[base->standbyDevIndex];
+    INFO(NCCL_NET, "NET/IB: Active-standby direction selected: primary=%s:%d standby=%s:%d",
+         ncclIbDevs[primary].devName, ncclIbDevs[primary].portNum, ncclIbDevs[standby].devName,
+         ncclIbDevs[standby].portNum);
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclIbValidateDataPathInfo(const struct ncclIbNetCommBase* base,
+                                               const struct ncclIbDataPathInfo* remote) {
+  struct ncclIbDataPathInfo local = ncclIbGetDataPathInfo(base);
+  if (remote->version != NCCL_IB_DATA_PATH_INFO_VERSION || remote->policy != local.policy ||
+      remote->primaryDevIndex != local.primaryDevIndex || remote->standbyDevIndex != local.standbyDevIndex ||
+      (local.qpsPerDevice != 0 && remote->qpsPerDevice != 0 &&
+       remote->qpsPerDevice != local.qpsPerDevice)) {
+    WARN("NET/IB: Data path mismatch: local(version=%u policy=%u primary=%u standby=%u lanes=%u) "
+         "remote(version=%u policy=%u primary=%u standby=%u lanes=%u)",
+         local.version, local.policy, local.primaryDevIndex, local.standbyDevIndex, local.qpsPerDevice, remote->version,
+         remote->policy, remote->primaryDevIndex, remote->standbyDevIndex, remote->qpsPerDevice);
+    return ncclInvalidUsage;
+  }
+  return ncclSuccess;
+}
 
 enum ncclIbCommState {
   ncclIbCommStateStart = 0,
@@ -648,7 +701,8 @@ static ncclResult_t ncclIbSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
-  qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS +
+                                     (comm->base.dataPathPolicy == ncclIbDataPathActiveStandby ? 1 : 0);
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -799,10 +853,15 @@ ncclResult_t ncclIbConnectImpl(void* ctx, int dev, void* opaqueHandle, void** se
   // Subnet-aware device selection: use the listener's GIDs (embedded in the
   // handle) to find a local NIC on the same subnet as the remote peer.
   // For single-subnet or IB deployments, all GIDs are zero → dev stays unchanged.
-  if (ncclParamIbSubnetAwareRouting()) NCCLCHECK(ncclIbFindDevBySubnet(handle->listenGids, 2, dev, &dev));
+  if (ncclParamIbSubnetAwareRouting() &&
+      (dev < 0 || dev >= ncclNMergedIbDevs ||
+       ncclIbMergedDevs[dev].dataPathPolicy != ncclIbDataPathActiveStandby)) {
+    NCCLCHECK(ncclIbFindDevBySubnet(handle->listenGids, 2, dev, &dev));
+  }
 
   struct ncclIbCommStage* stage = &handle->stage;
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)stage->comm;
+  struct ncclIbDataPathInfo remoteDataPathInfo;
   int ready;
 
   uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
@@ -843,6 +902,7 @@ ib_connect_check:
 
   mergedDev = ncclIbMergedDevs + dev;
   comm->base.vProps = mergedDev->vProps;
+  NCCLCHECKGOTO(ncclIbSetDataPathPolicy(&comm->base, mergedDev), ret, fail);
   stage->state = ncclIbCommStateSendDevList;
   stage->offset = 0;
   struct ncclIbConnectionMetadata meta;
@@ -851,6 +911,8 @@ ib_connect_check:
 
   struct ncclIbDevExtraProps exProps;
   exProps.oooRq = true;
+  exProps.dataPathInfo = ncclIbGetDataPathInfo(&comm->base);
+  exProps.dataPathInfo.qpsPerDevice = nQpsPerDev;
   for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
     int ibDevN = mergedDev->vProps.devs[i];
     exProps.oooRq = exProps.oooRq && ncclIbDevs[ibDevN].oooRqSize;
@@ -878,6 +940,8 @@ ib_recv_dev_list:
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   memcpy(&exProps, (char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
   comm->base.remOooRq = exProps.oooRq;
+  remoteDataPathInfo = exProps.dataPathInfo;
+  NCCLCHECKGOTO(ncclIbValidateDataPathInfo(&comm->base, &exProps.dataPathInfo), ret, fail);
 
   mergedDev = ncclIbMergedDevs + dev;
   comm->base.vProps = mergedDev->vProps;
@@ -887,6 +951,7 @@ ib_recv_dev_list:
   comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
+  NCCLCHECKGOTO(ncclIbValidateDataPathInfo(&comm->base, &remoteDataPathInfo), ret, fail);
 
   if (comm->base.resiliency) {
     NCCLCHECK(ncclIbResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
@@ -912,6 +977,7 @@ ib_recv_dev_list:
 
   memset(&meta, 0, sizeof(meta));
   meta.ndevs = comm->base.vProps.ndevs;
+  meta.dataPathInfo = ncclIbGetDataPathInfo(&comm->base);
 
   // Create QPs on the sender side
   NCCLCHECKGOTO(ncclIbSenderQpsCreate(comm, &meta), ret, fail);
@@ -936,6 +1002,10 @@ ib_recv_dev_list:
                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
                   ret, fail);
     devInfo->rkey = commDev->ctsFifoMr->rkey;
+    if (comm->base.resiliency && comm->base.dataPathPolicy == ncclIbDataPathActiveStandby) {
+      meta.healthProbeAddr = (uint64_t)&comm->base.resiliency->healthProbeScratchpad;
+      meta.healthProbeRkeys[i] = comm->base.resiliency->devs[i].healthProbeMr->rkey;
+    }
 
     // Pack local GID info
     devInfo->link_layer = commDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
@@ -1024,6 +1094,7 @@ ib_connect:
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
+  NCCLCHECKGOTO(ncclIbValidateDataPathInfo(&comm->base, &remMeta.dataPathInfo), ret, fail);
 
   // ensure that the remote devices have the same link layer than the local devices used in the connection.
   if (comm->base.vProps.ndevs > 0) {
@@ -1059,6 +1130,11 @@ ib_connect:
                                                                comm->remCmplsRecords.addr, i),
                     ret, fail);
     }
+    if (comm->base.resiliency && comm->base.dataPathPolicy == ncclIbDataPathActiveStandby) {
+      NCCLCHECKGOTO(ncclIbResiliencyHealthProbeRemoteSet(comm->base.resiliency, remMeta.healthProbeRkeys[i],
+                                                         remMeta.healthProbeAddr, i),
+                    ret, fail);
+    }
   }
 
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -1071,6 +1147,7 @@ ib_connect:
   }
 
   NCCLCHECKGOTO(ncclIbSenderQpsToRts(comm, &remMeta), ret, fail);
+  NCCLCHECKGOTO(ncclIbResiliencyDataQpsReady(comm->base.resiliency), ret, fail);
 
   comm->base.ready = 1;
   stage->state = ncclIbCommStateConnected;
@@ -1161,7 +1238,12 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // size needs to be double the number of max requests.
   // When resiliency is enabled, the number of send work requests is as the
   // number of max requests because every CTS message is signaled.
-  qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
+  qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2) +
+                                     (rComm->base.dataPathPolicy == ncclIbDataPathActiveStandby ? 1 : 0);
+  if (rComm->base.dataPathPolicy == ncclIbDataPathActiveStandby) {
+    INFO(NCCL_NET, "NET/IB: Active-standby receive data-QP SQ reserve enabled (maxSendWr=%u, healthProbeReserve=1, "
+         "comm=%p)", qpCreateAttrs.maxSendWorkRequest, rComm);
+  }
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1419,6 +1501,8 @@ ib_recv_dev_list:
   mergedDev = ncclIbMergedDevs + lComm->dev;
   NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
   rComm->base.vProps = mergedDev->vProps;
+  NCCLCHECKGOTO(ncclIbSetDataPathPolicy(&rComm->base, mergedDev), ret, fail);
+  NCCLCHECKGOTO(ncclIbValidateDataPathInfo(&rComm->base, &exProps.dataPathInfo), ret, fail);
   memcpy(stage->buffer, &rComm->base.vProps, sizeof(ncclNetVDeviceProps_t));
   int localNqps, remoteNqps;
   localNqps = nQpsPerDev * rComm->base.vProps.ndevs; // We must have at least 1 qp per-device
@@ -1426,6 +1510,7 @@ ib_recv_dev_list:
   rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
 
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remoteVProps.ndevs);
+  NCCLCHECKGOTO(ncclIbValidateDataPathInfo(&rComm->base, &exProps.dataPathInfo), ret, fail);
 
   if (rComm->base.resiliency) {
     NCCLCHECK(ncclIbResiliencyDeviceNumSet(rComm->base.resiliency, rComm->base.vProps.ndevs, remoteVProps.ndevs));
@@ -1435,6 +1520,7 @@ ib_recv_dev_list:
   stage->state = ncclIbCommStateSendDevList;
 
   exProps.oooRq = true;
+  exProps.dataPathInfo = ncclIbGetDataPathInfo(&rComm->base);
   for (int i = 0; i < mergedDev->vProps.ndevs; i++) {
     int ibDevN = mergedDev->vProps.devs[i];
     exProps.oooRq = exProps.oooRq && ncclIbDevs[ibDevN].oooRqSize;
@@ -1458,11 +1544,13 @@ ib_recv:
 
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
+  NCCLCHECKGOTO(ncclIbValidateDataPathInfo(&rComm->base, &remMeta.dataPathInfo), ret, fail);
 
   // Subnet-aware device selection: use the remote sender's GIDs to find a local
   // NIC on the same subnet. Override lComm->dev and update vProps if a
   // better device is found.
-  if (ncclParamIbSubnetAwareRouting() && remMeta.ndevs > 0) {
+  if (ncclParamIbSubnetAwareRouting() && rComm->base.dataPathPolicy != ncclIbDataPathActiveStandby &&
+      remMeta.ndevs > 0) {
     union ibv_gid remoteGids[NCCL_IB_MAX_DEVS_PER_NIC];
     int nRemoteGids = 0;
     for (int i = 0; i < remMeta.ndevs && i < NCCL_IB_MAX_DEVS_PER_NIC; i++) {
@@ -1494,6 +1582,7 @@ ib_recv:
   // Metadata to send back to requestor (sender)
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
+  meta.dataPathInfo = ncclIbGetDataPathInfo(&rComm->base);
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
@@ -1548,6 +1637,11 @@ ib_recv:
     rComm->base.remDevs[i] = remMeta.devs[i];
     rComm->base.remDevs[i].remoteGid.global.interface_id = rComm->base.remDevs[i].gid.global.interface_id;
     rComm->base.remDevs[i].remoteGid.global.subnet_prefix = rComm->base.remDevs[i].gid.global.subnet_prefix;
+    if (rComm->base.resiliency && rComm->base.dataPathPolicy == ncclIbDataPathActiveStandby) {
+      NCCLCHECKGOTO(ncclIbResiliencyHealthProbeRemoteSet(rComm->base.resiliency, remMeta.healthProbeRkeys[i],
+                                                         remMeta.healthProbeAddr, i),
+                    ret, fail);
+    }
   }
 
   // Determine if Flush is enabled for this Comm. Must be done before creating
@@ -1583,6 +1677,10 @@ ib_recv:
                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
                   ret, fail);
     meta.devs[i].rkey = rCommDev->cmplsRecordsMr->rkey;
+    if (rComm->base.resiliency && rComm->base.dataPathPolicy == ncclIbDataPathActiveStandby) {
+      meta.healthProbeAddr = (uint64_t)&rComm->base.resiliency->healthProbeScratchpad;
+      meta.healthProbeRkeys[i] = rComm->base.resiliency->devs[i].healthProbeMr->rkey;
+    }
   }
   if (ncclParamIbUseInline()) rComm->remCtsFifo.flags = IBV_SEND_INLINE;
 
@@ -1638,6 +1736,7 @@ ib_recv_ready:
                                    &stage->offset),
                 ret, fail);
   if (stage->offset != sizeof(int)) return ncclSuccess;
+  NCCLCHECKGOTO(ncclIbResiliencyDataQpsReady(rComm->base.resiliency), ret, fail);
 
   *recvComm = rComm;
 exit:

--- a/src/transport/net_ib/connect.h
+++ b/src/transport/net_ib/connect.h
@@ -52,6 +52,7 @@ struct ncclIbConnectionMetadata {
   struct ncclIbQpInfo qpInfo[NCCL_IB_MAX_QPS];
   struct ncclIbResiliencyInfo resiliencyInfo;
   struct ncclIbDevInfo devs[NCCL_IB_MAX_DEVS_PER_NIC];
+  struct ncclIbDataPathInfo dataPathInfo;
   char devName[MAX_MERGED_DEV_NAME];
   // An address for a registered memory to be accessed by the peer. The address
   // can be accessed using RDMA using the key specified in ncclIbDevInfo::rkey.
@@ -61,6 +62,10 @@ struct ncclIbConnectionMetadata {
   // The receiver side gets in this member, from the sender, the address of the
   // memory to which the receiver writes the CTS messages.
   uint64_t addr;
+  // Registered per-communicator heartbeat scratchpad used by the peer to
+  // validate an active-standby data QP without touching user buffers.
+  uint64_t healthProbeAddr;
+  uint32_t healthProbeRkeys[NCCL_IB_MAX_DEVS_PER_NIC];
   int ndevs;
   int tc;
   int sl;

--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -30,6 +30,168 @@ NCCL_PARAM(IbMergeNics, "IB_MERGE_NICS", 1);
 NCCL_PARAM(IbDevicePciOrder, "IB_DEVICE_PCI_ORDER", 1);
 
 extern int64_t ncclParamIbArThreshold();
+extern int ncclParamIbResiliencyPortFailover();
+
+struct ncclIbHcaPair {
+  int devs[2];
+  int directionalDevs[2];
+  bool created;
+};
+
+static struct ncclIbHcaPair ncclIbHcaPairs[MAX_IB_DEVS / 2];
+static int ncclIbNHcaPairs;
+
+static ncclResult_t ncclIbParsePairEndpoint(char* endpoint, int* devIndex) {
+  char* separator = strrchr(endpoint, ':');
+  if (separator == NULL || separator == endpoint || strchr(endpoint, ':') != separator) return ncclInvalidUsage;
+  *separator = '\0';
+  char* end = NULL;
+  long port = strtol(separator + 1, &end, 10);
+  if (endpoint[0] == '\0' || end == separator + 1 || *end != '\0' || port <= 0 || port > UINT8_MAX) {
+    return ncclInvalidUsage;
+  }
+
+  int found = -1;
+  for (int d = 0; d < ncclNIbDevs; d++) {
+    if (strcmp(endpoint, ncclIbDevs[d].devName) == 0 && port == ncclIbDevs[d].portNum) {
+      if (found != -1) return ncclInvalidUsage;
+      found = d;
+    }
+  }
+  if (found == -1) return ncclInvalidUsage;
+  *devIndex = found;
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclIbParseHcaPairs(void) {
+  const char* env = ncclGetEnv("NCCL_IB_RESILIENCY_HCA_PAIRS");
+  ncclIbNHcaPairs = 0;
+  if (env == NULL || env[0] == '\0') return ncclSuccess;
+  if (ncclParamIbResiliencyPortFailover() != 1) {
+    WARN("NET/IB: NCCL_IB_RESILIENCY_HCA_PAIRS requires NCCL_IB_RESILIENCY_PORT_FAILOVER=1");
+    return ncclInvalidUsage;
+  }
+
+  char* pairs = strdup(env);
+  if (pairs == NULL) return ncclSystemError;
+  ncclResult_t ret = ncclSuccess;
+  bool used[MAX_IB_DEVS] = {false};
+  char* savePair = NULL;
+  for (char* pair = strtok_r(pairs, ";", &savePair); pair != NULL; pair = strtok_r(NULL, ";", &savePair)) {
+    if (ncclIbNHcaPairs == MAX_IB_DEVS / 2) {
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    char* comma = strchr(pair, ',');
+    if (comma == NULL || comma == pair || comma[1] == '\0' || strchr(comma + 1, ',') != NULL) {
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    *comma = '\0';
+    int first = -1, second = -1;
+    if (ncclIbParsePairEndpoint(pair, &first) != ncclSuccess ||
+        ncclIbParsePairEndpoint(comma + 1, &second) != ncclSuccess || first == second || used[first] ||
+        used[second] || ncclIbDevs[first].link != ncclIbDevs[second].link) {
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    used[first] = used[second] = true;
+    if (second < first) {
+      int tmp = first;
+      first = second;
+      second = tmp;
+    }
+    struct ncclIbHcaPair* hcaPair = ncclIbHcaPairs + ncclIbNHcaPairs++;
+    hcaPair->devs[0] = first;
+    hcaPair->devs[1] = second;
+    hcaPair->directionalDevs[0] = -1;
+    hcaPair->directionalDevs[1] = -1;
+    hcaPair->created = false;
+  }
+  if (ncclIbNHcaPairs == 0 || env[0] == ';' || env[strlen(env) - 1] == ';' || strstr(env, ";;") != NULL) {
+    ret = ncclInvalidUsage;
+  }
+
+fail:
+  free(pairs);
+  if (ret != ncclSuccess) {
+    WARN("NET/IB: Invalid NCCL_IB_RESILIENCY_HCA_PAIRS='%s'; expected exact active device:port pairs", env);
+    ncclIbNHcaPairs = 0;
+    return ret;
+  }
+
+  const char* forceMerge = ncclGetEnv("NCCL_NET_FORCE_MERGE");
+  if (forceMerge == NULL || forceMerge[0] == '\0') {
+    WARN("NET/IB: NCCL_IB_RESILIENCY_HCA_PAIRS requires matching NCCL_NET_FORCE_MERGE groups");
+    ncclIbNHcaPairs = 0;
+    return ncclInvalidUsage;
+  }
+  char* groups = strdup(forceMerge);
+  if (groups == NULL) return ncclSystemError;
+  bool pairSeen[MAX_IB_DEVS / 2] = {false};
+  int nGroups = 0;
+  char* saveGroup = NULL;
+  for (char* group = strtok_r(groups, ";", &saveGroup); group != NULL; group = strtok_r(NULL, ";", &saveGroup)) {
+    char* comma = strchr(group, ',');
+    if (comma == NULL || comma == group || comma[1] == '\0' || strchr(comma + 1, ',') != NULL) {
+      ret = ncclInvalidUsage;
+      break;
+    }
+    *comma = '\0';
+    int first = -1, second = -1;
+    if (ncclIbParsePairEndpoint(group, &first) != ncclSuccess ||
+        ncclIbParsePairEndpoint(comma + 1, &second) != ncclSuccess) {
+      ret = ncclInvalidUsage;
+      break;
+    }
+    int matchedPair = -1;
+    for (int p = 0; p < ncclIbNHcaPairs; p++) {
+      if ((first == ncclIbHcaPairs[p].devs[0] && second == ncclIbHcaPairs[p].devs[1]) ||
+          (second == ncclIbHcaPairs[p].devs[0] && first == ncclIbHcaPairs[p].devs[1])) {
+        matchedPair = p;
+        break;
+      }
+    }
+    if (matchedPair == -1 || pairSeen[matchedPair]) {
+      ret = ncclInvalidUsage;
+      break;
+    }
+    pairSeen[matchedPair] = true;
+    nGroups++;
+  }
+  if (nGroups != ncclIbNHcaPairs || forceMerge[0] == ';' || forceMerge[strlen(forceMerge) - 1] == ';' ||
+      strstr(forceMerge, ";;") != NULL) {
+    ret = ncclInvalidUsage;
+  }
+  free(groups);
+  if (ret != ncclSuccess) {
+    WARN("NET/IB: NCCL_NET_FORCE_MERGE='%s' must contain exactly the configured HCA pair member sets", forceMerge);
+    ncclIbNHcaPairs = 0;
+    return ret;
+  }
+  INFO(NCCL_NET | NCCL_ENV, "NCCL_IB_RESILIENCY_HCA_PAIRS set to %s", env);
+  return ncclSuccess;
+}
+
+static int ncclIbFindHcaPair(const ncclNetVDeviceProps_t* props) {
+  if (props->ndevs != 2) return -1;
+  for (int i = 0; i < ncclIbNHcaPairs; i++) {
+    int first = ncclIbHcaPairs[i].devs[0];
+    int second = ncclIbHcaPairs[i].devs[1];
+    if ((props->devs[0] == first && props->devs[1] == second) ||
+        (props->devs[0] == second && props->devs[1] == first)) return i;
+  }
+  return -1;
+}
+
+static bool ncclIbContainsHcaPairMember(const ncclNetVDeviceProps_t* props) {
+  for (int i = 0; i < props->ndevs; i++) {
+    for (int p = 0; p < ncclIbNHcaPairs; p++) {
+      if (props->devs[i] == ncclIbHcaPairs[p].devs[0] || props->devs[i] == ncclIbHcaPairs[p].devs[1]) return true;
+    }
+  }
+  return false;
+}
 
 // Returns 0 if this is the path of two VFs of the same physical device
 static int ncclIbMatchVfPath(char* path1, char* path2) {
@@ -194,7 +356,8 @@ fail:
   return ncclInternalError;
 }
 
-ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
+static ncclResult_t ncclIbBuildVDevice(int vDev, ncclNetVDeviceProps_t* props, int hcaPair,
+                                       int directionalPrimary) {
   if (ncclParamIbMergeNics() == 0 && props->ndevs > 1) {
     INFO(NCCL_NET, "NET/IB : Skipping makeVDevice, NCCL_IB_MERGE_NICS=0");
     return ncclInvalidUsage;
@@ -204,24 +367,54 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     WARN("NET/IB : Can't make virtual NIC with 0 devices");
     return ncclInvalidUsage;
   }
+  for (int i = 0; i < props->ndevs; i++) {
+    if (props->devs[i] < 0 || props->devs[i] >= ncclNIbDevs) {
+      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
+      return ncclInvalidUsage;
+    }
+  }
 
-  if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
+  if (vDev < 0 || vDev >= MAX_IB_VDEVS) {
     WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
     return ncclInvalidUsage;
   }
 
-  // Always count up number of merged devices
-  ncclIbMergedDev* mDev = ncclIbMergedDevs + ncclNMergedIbDevs;
+  ncclIbMergedDev* mDev = ncclIbMergedDevs + vDev;
+  memset(mDev, 0, sizeof(*mDev));
   mDev->vProps.ndevs = 0;
-  mDev->speed = 0;
-  mDev->railId = ncclIbDevs[props->devs[0]].railId;
-  // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
-  mDev->planeId = (props->ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : ncclIbDevs[props->devs[0]].planeId;
+  mDev->topoVProps.ndevs = 0;
+  mDev->dataPathPolicy = ncclIbDataPathActiveActive;
+  mDev->primaryDevIndex = -1;
+  mDev->standbyDevIndex = -1;
+  mDev->containsHcaPairMember = ncclIbContainsHcaPairMember(props);
+  if (mDev->containsHcaPairMember && props->ndevs > 1 && hcaPair == -1) {
+    WARN("NET/IB: Virtual device containing a configured HCA pair member must contain exactly that complete pair");
+    return ncclInvalidUsage;
+  }
 
-  for (int i = 0; i < props->ndevs; i++) {
-    ncclIbDev* dev = ncclIbDevs + props->devs[i];
+  ncclNetVDeviceProps_t runtimeProps = *props;
+  if (hcaPair != -1) {
+    struct ncclIbHcaPair* pair = ncclIbHcaPairs + hcaPair;
+    if (directionalPrimary != pair->devs[0] && directionalPrimary != pair->devs[1]) {
+      WARN("NET/IB: Invalid directional primary device %d for HCA pair {%d,%d}", directionalPrimary,
+           pair->devs[0], pair->devs[1]);
+      return ncclInvalidUsage;
+    }
+    runtimeProps.devs[0] = directionalPrimary;
+    runtimeProps.devs[1] = directionalPrimary == pair->devs[0] ? pair->devs[1] : pair->devs[0];
+    mDev->dataPathPolicy = ncclIbDataPathActiveStandby;
+    mDev->primaryDevIndex = 0;
+    mDev->standbyDevIndex = 1;
+  }
+  mDev->speed = 0;
+  mDev->railId = ncclIbDevs[runtimeProps.devs[0]].railId;
+  // Set the virtual bit on to avoid collision with physical planes when multiple planes are merged.
+  mDev->planeId = (runtimeProps.ndevs > 1) ? NCCL_IB_PLANE_VIRT_BIT : ncclIbDevs[runtimeProps.devs[0]].planeId;
+
+  for (int i = 0; i < runtimeProps.ndevs; i++) {
+    ncclIbDev* dev = ncclIbDevs + runtimeProps.devs[i];
     if (mDev->vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
-    mDev->vProps.devs[mDev->vProps.ndevs++] = props->devs[i];
+    mDev->vProps.devs[mDev->vProps.ndevs++] = runtimeProps.devs[i];
     mDev->speed += dev->speed;
     // rail ID of a fused device with different rails is undefined.
     if (dev->railId == NCCL_NET_ID_UNDEF || mDev->railId != dev->railId) mDev->railId = NCCL_NET_ID_UNDEF;
@@ -238,33 +431,94 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     }
   }
 
+  mDev->topoVProps = mDev->vProps;
+  if (mDev->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    int primary = mDev->vProps.devs[mDev->primaryDevIndex];
+    struct ncclIbHcaPair* pair = ncclIbHcaPairs + hcaPair;
+    mDev->topoVProps.ndevs = 1;
+    mDev->topoVProps.devs[0] = primary;
+    mDev->speed = ncclIbDevs[primary].speed;
+    mDev->railId = ncclIbDevs[primary].railId;
+    mDev->planeId = ncclIbDevs[primary].planeId;
+    snprintf(mDev->devName, sizeof(mDev->devName), "%s:%d+%s:%d@%s:%d",
+             ncclIbDevs[pair->devs[0]].devName, ncclIbDevs[pair->devs[0]].portNum,
+             ncclIbDevs[pair->devs[1]].devName, ncclIbDevs[pair->devs[1]].portNum,
+             ncclIbDevs[primary].devName, ncclIbDevs[primary].portNum);
+  }
+
   // Check link layers
-  ncclIbDev* dev0 = ncclIbDevs + props->devs[0];
-  for (int i = 1; i < props->ndevs; i++) {
-    if (props->devs[i] >= ncclNIbDevs) {
-      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
+  ncclIbDev* dev0 = ncclIbDevs + runtimeProps.devs[0];
+  for (int i = 1; i < runtimeProps.ndevs; i++) {
+    if (runtimeProps.devs[i] >= ncclNIbDevs) {
+      WARN("NET/IB : Cannot use physical device %d, max %d", runtimeProps.devs[i], ncclNIbDevs);
       return ncclInvalidUsage;
     }
-    ncclIbDev* dev = ncclIbDevs + props->devs[i];
+    ncclIbDev* dev = ncclIbDevs + runtimeProps.devs[i];
     if (dev->link != dev0->link) {
       WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
-           props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName,
+           runtimeProps.devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), runtimeProps.devs[i], dev->devName,
            dev->portNum, NCCL_IB_LLSTR(dev->link));
       return ncclInvalidUsage;
     }
   }
 
-  *d = ncclNMergedIbDevs++;
-  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d rail=%d plane=%d", *d, mDev->devName,
-       mDev->speed, mDev->vProps.ndevs, mDev->railId, mDev->planeId);
+  INFO(NCCL_NET,
+       "NET/IB : Made virtual device [%d] name=%s speed=%d runtimeNdevs=%d topoNdevs=%d primary=%d standby=%d "
+       "rail=%d plane=%d",
+       vDev, mDev->devName, mDev->speed, mDev->vProps.ndevs, mDev->topoVProps.ndevs, mDev->primaryDevIndex,
+       mDev->standbyDevIndex, mDev->railId, mDev->planeId);
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
+  int vDev = ncclNMergedIbDevs;
+  NCCLCHECK(ncclIbBuildVDevice(vDev, props, -1, -1));
+  *d = vDev;
+  ncclNMergedIbDevs++;
   return ncclSuccess;
 }
 
 ncclResult_t ncclIbMakeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   std::lock_guard<std::mutex> lock(ncclIbMutex);
-  ncclResult_t res = ncclIbMakeVDeviceInternal(d, props);
-  return res;
+  int hcaPair = ncclIbFindHcaPair(props);
+  if (hcaPair == -1) return ncclIbMakeVDeviceInternal(d, props);
+
+  struct ncclIbHcaPair* pair = ncclIbHcaPairs + hcaPair;
+  if (pair->created) {
+    *d = pair->directionalDevs[0];
+    INFO(NCCL_NET, "NET/IB : Reusing directional virtual devices [%d,%d] for HCA pair {%s:%d,%s:%d}",
+         pair->directionalDevs[0], pair->directionalDevs[1], ncclIbDevs[pair->devs[0]].devName,
+         ncclIbDevs[pair->devs[0]].portNum, ncclIbDevs[pair->devs[1]].devName,
+         ncclIbDevs[pair->devs[1]].portNum);
+    return ncclSuccess;
+  }
+  if (ncclNMergedIbDevs > MAX_IB_VDEVS - 2) {
+    WARN("NET/IB : Cannot allocate two directional virtual devices, %d of %d slots are already used",
+         ncclNMergedIbDevs, MAX_IB_VDEVS);
+    return ncclInvalidUsage;
+  }
+
+  int first = ncclNMergedIbDevs;
+  int second = first + 1;
+  ncclResult_t ret = ncclIbBuildVDevice(first, props, hcaPair, pair->devs[0]);
+  if (ret == ncclSuccess) ret = ncclIbBuildVDevice(second, props, hcaPair, pair->devs[1]);
+  if (ret != ncclSuccess) {
+    memset(ncclIbMergedDevs + first, 0, 2 * sizeof(struct ncclIbMergedDev));
+    pair->directionalDevs[0] = pair->directionalDevs[1] = -1;
+    pair->created = false;
+    return ret;
+  }
+
+  pair->directionalDevs[0] = first;
+  pair->directionalDevs[1] = second;
+  pair->created = true;
+  ncclNMergedIbDevs += 2;
+  *d = first;
+  INFO(NCCL_NET, "NET/IB : HCA pair {%s:%d,%s:%d} created directional virtual devices [%d,%d]",
+       ncclIbDevs[pair->devs[0]].devName, ncclIbDevs[pair->devs[0]].portNum,
+       ncclIbDevs[pair->devs[1]].devName, ncclIbDevs[pair->devs[1]].portNum, first, second);
+  return ncclSuccess;
 }
 
 ncclResult_t ncclIbSetNetAttr(void* ctx, ncclNetAttr_t* netAttr) {
@@ -482,6 +736,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
     }
     // sort devices to ensure a consistent order across nodes
     if (ncclParamIbDevicePciOrder()) qsort(ncclIbDevs, ncclNIbDevs, sizeof(struct ncclIbDev), ncclIbCompareDevs);
+    NCCLCHECKGOTO(ncclIbParseHcaPairs(), ret, fail);
     // Once sorted, get the realPort ID, the plane index, and create the virtual devices.
     // Doing it after sorting ensures that devices will have consistent realPort IDs and plane indexes accross ranks.
     char line[2048] = "";
@@ -576,12 +831,12 @@ ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
   }
   struct ncclIbMergedDev* mergedDev = ncclIbMergedDevs + dev;
   // Take the rest of the properties from an arbitrary sub-device (should be the same)
-  NCCLCHECK(ncclIbGetPhysProperties(mergedDev->vProps.devs[0], props));
+  NCCLCHECK(ncclIbGetPhysProperties(mergedDev->topoVProps.devs[0], props));
   props->name = mergedDev->devName;
   props->speed = mergedDev->speed;
   props->railId = mergedDev->railId;
   props->planeId = mergedDev->planeId;
-  memcpy(&props->vProps, &mergedDev->vProps, sizeof(ncclNetVDeviceProps_t));
+  memcpy(&props->vProps, &mergedDev->topoVProps, sizeof(ncclNetVDeviceProps_t));
   return ncclSuccess;
 }
 

--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -102,7 +102,8 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
     wr->wr.rdma.remote_addr = slots[r].addr;
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
-    wr->wr_id = wr_id;
+    // Reserve the high bit for the isolated standby health-probe namespace.
+    wr->wr_id = wr_id & ~NCCL_IB_HEALTH_PROBE_WR_ID_TAG;
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif
@@ -140,13 +141,14 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       lastWr->num_sge = 1;
     }
   }
-  lastWr->wr_id = wr_id;
+  lastWr->wr_id = wr_id & ~NCCL_IB_HEALTH_PROBE_WR_ID_TAG;
   lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
   lastWr->imm_data = htobe32(immData);
   lastWr->next = NULL;
   lastWr->send_flags = IBV_SEND_SIGNALED;
 
   uint32_t sendOffsets[NCCL_NET_IB_MAX_RECVS] = {0};
+  bool primaryPayloadPosted = false;
   int qpIndex = -1;
   ncclIbQp* qp = NULL;
   for (int i = 0; i < nqps; i++) {
@@ -250,7 +252,16 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
             __func__, reqs[r], reqs[0]->base, reqs[r]->id, slot, nreqs, r, comm->wrs[r].wr_id,
             comm->wrs[r].sg_list->length, qpIndex, devIndex, qp->qp->qp_num, sendOffsets[r], reqs[r]->send.size);
       reqs[r]->send.sentData[qpIndex] = true;
+      if (comm->base.dataPathPolicy == ncclIbDataPathActiveStandby &&
+          qpIndex % comm->base.vProps.ndevs == comm->base.primaryDevIndex && comm->wrs[r].sg_list->length > 0) {
+        primaryPayloadPosted = true;
+      }
     }
+  }
+
+  if (comm->base.resiliency) {
+    bool replay = ((struct ncclIbResiliencySend*)comm->base.resiliency)->failedRequests[slot].request != NULL;
+    NCCLCHECK(ncclIbResiliencyHealthProbePost(comm->base.resiliency, primaryPayloadPosted && !replay));
   }
 
   TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
@@ -314,6 +325,11 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
     req->send.data = data;
     if (comm->base.resiliency) {
       memset(req->send.sentData, 0, sizeof(req->send.sentData));
+      // Health probes complete on the standby data CQ and are independent of
+      // request event counts. Let any active request progress every data CQ.
+      for (int devIndex = 0; devIndex < comm->base.vProps.ndevs; devIndex++) {
+        req->devBases[devIndex] = ncclIbGetNetCommDevBase(&comm->base, devIndex);
+      }
     }
 #ifdef NCCL_ENABLE_NET_PROFILING
     req->pInfo[0].pHandle = phandle;
@@ -361,7 +377,8 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot) {
+ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot,
+                           bool triggerHealthProbe) {
   ncclIbQp* ctsQp = NULL;
   NCCLCHECK(ncclIbRecvCommGetQpForCts(comm, req->id, &ctsQp));
 
@@ -413,16 +430,22 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
 
   TRACE(NCCL_NET,
         "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
-        "qp_num=%u)",
-        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+        "qp_num=%u, devIndex=%d)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num,
+        ctsQp->devIndex);
 
   struct ibv_send_wr* bad_wr;
   NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
 
+  if (comm->base.resiliency) {
+    NCCLCHECK(ncclIbResiliencyHealthProbePost(comm->base.resiliency, triggerHealthProbe));
+  }
+
   TRACE(NCCL_NET,
         "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
-        "qp_num=%u)",
-        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+        "qp_num=%u, devIndex=%d)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num,
+        ctsQp->devIndex);
 
   return ncclSuccess;
 }
@@ -514,7 +537,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
 
   // Post to FIFO to notify sender
   TIME_START(2);
-  NCCLCHECK(ncclIbPostFifo(comm, req, slot));
+  NCCLCHECK(ncclIbPostFifo(comm, req, slot, true));
   comm->base.fifoHead++;
   TIME_STOP(2);
 
@@ -818,7 +841,7 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
   struct ncclIbRequest* r = (struct ncclIbRequest*)request;
   *done = 0;
 
-  if (r->base->resiliency && r->base->resiliency->inProgress) {
+  if (r->base->resiliency) {
     NCCLCHECK(ncclIbResiliencyProgress(r->base->resiliency));
   }
 
@@ -849,6 +872,10 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
       totalWrDone += wrDone;
       for (int w = 0; w < wrDone; w++) {
         struct ibv_wc* wc = wcs + w;
+        if (r->base->resiliency && ncclIbResiliencyIsHealthProbeCompletion(r->base->resiliency, wc, i)) {
+          NCCLCHECK(ncclIbResiliencyHealthProbeHandleCompletion(r->base->resiliency, wc, i));
+          continue;
+        }
         if (wc->status != IBV_WC_SUCCESS) {
           if (r->base->resiliency == NULL) {
             WARN("NET/IB: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", i, r, r->base,

--- a/src/transport/net_ib/p2p.h
+++ b/src/transport/net_ib/p2p.h
@@ -11,16 +11,20 @@
 #include "common.h"
 
 #define NCCL_IB_FLUSH_REQ_WR_ID_OFFSET 0x1000
+#define NCCL_IB_HEALTH_PROBE_WR_ID_TAG (1ULL << 63)
+#define NCCL_IB_HEALTH_PROBE_WR_ID_GENERATION_MASK (~NCCL_IB_HEALTH_PROBE_WR_ID_TAG)
 static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET > NET_IB_MAX_REQUESTS,
               "wr_id offset for flush requests must be greater than NET_IB_MAX_REQUESTS");
 static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET <= UINT64_MAX - NET_IB_MAX_REQUESTS,
               "wr_id for flush requests must fit in 64 bits since ibv_send_wr::wr_id is 64 bits");
 
-ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot);
+ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot,
+                           bool triggerHealthProbe);
 ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot);
 
 static inline ncclResult_t ncclIbRecvCommGetQpForCts(struct ncclIbRecvComm* recvComm, uint32_t id, ncclIbQp** qp) {
-  int devIndex = id % recvComm->base.vProps.ndevs;
+  int devIndex = recvComm->base.dataPathPolicy == ncclIbDataPathActiveStandby ? recvComm->base.primaryDevIndex :
+                                                                               id % recvComm->base.vProps.ndevs;
   // CTS message is always posted the first QP on the device
   int qpIndex = 0;
   ncclIbCommBaseGetQpByIndex(&recvComm->base, devIndex, qpIndex, qp);

--- a/src/transport/net_ib/p2p_resiliency.cc
+++ b/src/transport/net_ib/p2p_resiliency.cc
@@ -10,9 +10,12 @@
 #include "connect.h" // For ncclIbQpCreate()
 #include "p2p_resiliency_recovery.h"
 
+#include <cerrno>
+
 NCCL_PARAM(IbResiliencyPortFailover, "IB_RESILIENCY_PORT_FAILOVER", 0);
 NCCL_PARAM(IbResiliencyPortFailoverMaxAttempts, "IB_RESILIENCY_PORT_FAILOVER_MAX_ATTEMPTS", 1);
 NCCL_PARAM(IbResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_PROBE_DELAY", 10); // In milliseconds
+NCCL_PARAM(IbResiliencyStandbyHealthInterval, "IB_RESILIENCY_STANDBY_HEALTH_INTERVAL", 1000); // In milliseconds
 
 extern int64_t ncclParamIbPkey();
 extern int64_t ncclParamIbRetryCnt();
@@ -79,6 +82,44 @@ static ncclResult_t ncclIbResiliencyReplaceQps(struct ncclIbResiliency* resCtx, 
     // Find the failed QP's index in the baseComm.qps[] array
     int failedQpIndex = failedQp - resCtx->baseComm->qps;
     assert(failedQpIndex >= 0 && failedQpIndex < resCtx->baseComm->nqps);
+
+    if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+      int ndevs = resCtx->baseComm->vProps.ndevs;
+      // Only the primary logical QPs are part of the active-standby data
+      // path. Standby logical entries remain bound to their own QPs so a
+      // later primary recovery cannot make them an unintended active path.
+      if (qpIndex % ndevs != resCtx->baseComm->primaryDevIndex) continue;
+      int replacementDevIndex = failedDevIndex == resCtx->baseComm->primaryDevIndex ?
+                                  resCtx->baseComm->standbyDevIndex :
+                                  resCtx->baseComm->primaryDevIndex;
+      if (resCtx->devs[replacementDevIndex].state.load(std::memory_order_acquire) != ncclIbResiliencyDevStateOk) {
+        WARN("NET/IB: Cannot replace active-standby QP on failed device %d: peer device %d is not healthy",
+             failedDevIndex, replacementDevIndex);
+        return ncclRemoteError;
+      }
+      enum ncclIbResiliencyHealthState replacementHealth =
+        resCtx->devs[replacementDevIndex].healthState.load(std::memory_order_acquire);
+      if (replacementHealth == ncclIbHealthDown) {
+        WARN("NET/IB: Cannot replace active-standby QP on failed device %d: peer device %d health state=%d",
+             failedDevIndex, replacementDevIndex, replacementHealth);
+        return ncclRemoteError;
+      }
+      int lane = failedQpIndex / ndevs;
+      int newQpIndex = lane * ndevs + replacementDevIndex;
+      INFO(NCCL_NET,
+           "NET/IB: %s: Replacing active-standby QP: logicalIndex=%d failedIndex=%d (devIndex=%d) "
+           "with same-lane index=%d (devIndex=%d) on %s communicator (comm=%p)",
+           __func__, qpIndex, failedQpIndex, failedDevIndex, newQpIndex, replacementDevIndex,
+           resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+      activeQps[qpIndex] = &resCtx->baseComm->qps[newQpIndex];
+      INFO(NCCL_NET,
+           "NET/IB: %s: Active-standby generation=%llu state=%d oldQp=%u newQp=%u oldDev=%d newDev=%d",
+           __func__, (unsigned long long)resCtx->activeStandbyGeneration, resCtx->activeStandbyState,
+           resCtx->baseComm->qps[failedQpIndex].qp ? resCtx->baseComm->qps[failedQpIndex].qp->qp_num : 0,
+           resCtx->baseComm->qps[newQpIndex].qp ? resCtx->baseComm->qps[newQpIndex].qp->qp_num : 0, failedDevIndex,
+           replacementDevIndex);
+      continue;
+    }
 
     // After finding a failed QP, iterate over the QPs to find a replacement QP
     // that is not associated with a failed device.
@@ -257,7 +298,7 @@ static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request)
   } else if (request->type == NCCL_NET_IB_REQ_RECV) {
     INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request,
          request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
-    NCCLCHECK(ncclIbPostFifo((struct ncclIbRecvComm*)request->base, request, slot));
+    NCCLCHECK(ncclIbPostFifo((struct ncclIbRecvComm*)request->base, request, slot, false));
   } else {
     WARN("NET/IB: Unsupported type of request reposting (type=%d, id=%ld).", request->type, request->id);
     return ncclInternalError;
@@ -371,31 +412,242 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorSender(struct ncclIbRes
 // Mark the device as failed and replace its QPs.
 static ncclResult_t ncclIbResiliencyHandleDeviceFailure(struct ncclIbResiliency* resCtx, int devIndex) {
   ncclResult_t res = ncclSuccess;
-  enum ncclIbResiliencyDevState devState = resCtx->devs[devIndex].state.load(std::memory_order_acquire);
-  if (devState == ncclIbResiliencyDevStateOk) {
-    WARN("NET/IB: Device %d marked as failed. Initiating recovery? %s (%s comm=%p, outstandingRecovery=%d)", devIndex,
-         resCtx->recoveryEnabled ? "Yes" : "No", resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
+  struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
+  enum ncclIbResiliencyDevState expected = ncclIbResiliencyDevStateOk;
+  if (!resDev->state.compare_exchange_strong(expected, ncclIbResiliencyDevStateError, std::memory_order_acq_rel,
+                                             std::memory_order_acquire)) {
+    INFO(NCCL_NET,
+         "NET/IB: %s: Device failure merged with existing owner (devIndex=%d, state=%d, %s comm=%p, "
+         "outstandingRecovery=%d)",
+         __func__, devIndex, expected, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
          resCtx->outstandingRecovery);
-    resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateError, std::memory_order_release);
-    NCCLCHECK(ncclIbResiliencyReplaceQps(resCtx, devIndex));
-    if (resCtx->recoveryEnabled) {
-      resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateRecoveryInProgress, std::memory_order_release);
-      res = ncclIbPortRecoveryHandleFailure(resCtx, devIndex);
-      if (res == ncclSuccess) {
-        resCtx->outstandingRecovery++;
-        resCtx->inProgress = true;
-      } else {
-        for (int i = 0; i < resCtx->ndevs; i++) {
-          if (i != devIndex) continue;
-          INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i,
-               resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
-          resCtx->devs[i].state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
-        }
-      }
-    }
-  } else {
-    INFO(NCCL_NET, "NET/IB: %s: Device %d was already marked as failed.", __func__, devIndex);
+    return ncclSuccess;
   }
+
+  WARN("NET/IB: Device %d failure CAS ownership acquired. Initiating recovery? %s (%s comm=%p, "
+       "outstandingRecovery=%d)",
+       devIndex, resCtx->recoveryEnabled ? "Yes" : "No", resCtx->baseComm->isSend ? "send" : "recv",
+       resCtx->baseComm, resCtx->outstandingRecovery);
+  if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    resDev->healthState.store(ncclIbHealthDown, std::memory_order_release);
+    if (devIndex == resCtx->baseComm->primaryDevIndex) {
+      resCtx->activeStandbyState = ncclIbAsSwitchingToStandby;
+      resCtx->activeStandbyGeneration++;
+    } else if (devIndex == resCtx->baseComm->standbyDevIndex &&
+               resCtx->activeStandbyState == ncclIbAsStandbyActive) {
+      resCtx->activeStandbyState = ncclIbAsPrimaryRecovering;
+      resCtx->activeStandbyGeneration++;
+    }
+  }
+  res = ncclIbResiliencyReplaceQps(resCtx, devIndex);
+  if (res != ncclSuccess) {
+    if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+      resCtx->activeStandbyState = ncclIbAsFailed;
+      resCtx->activeStandbyGeneration++;
+    }
+    return res;
+  }
+  if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby &&
+      devIndex == resCtx->baseComm->primaryDevIndex) {
+    resCtx->activeStandbyState = ncclIbAsStandbyActive;
+  }
+  if (resCtx->recoveryEnabled) {
+    resDev->state.store(ncclIbResiliencyDevStateRecoveryInProgress, std::memory_order_release);
+    res = ncclIbPortRecoveryHandleFailure(resCtx, devIndex);
+    if (res == ncclSuccess) {
+      resCtx->outstandingRecovery++;
+      resCtx->inProgress = true;
+    } else {
+      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, devIndex,
+           resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+      resDev->healthState.store(ncclIbHealthDown, std::memory_order_release);
+      resDev->state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
+    }
+  }
+  return ncclSuccess;
+}
+
+static const char* ncclIbHealthProbeResultSourceStr(enum ncclIbHealthProbeResultSource source) {
+  switch (source) {
+  case ncclIbHealthProbeResultCqe: return "CQE";
+  case ncclIbHealthProbeResultPostFailure: return "POST_FAILURE";
+  default: return "NONE";
+  }
+}
+
+static void ncclIbResiliencyHealthProbeDiagSetCqe(struct ncclIbResiliency* resCtx, const struct ibv_wc* wc,
+                                                  int devIndex, uint64_t generation) {
+  struct ncclIbResiliencyHealthProbeDiag* diag = &resCtx->healthProbe.diag;
+  diag->source = ncclIbHealthProbeResultCqe;
+  diag->wcStatus = wc->status;
+  diag->vendorErr = wc->vendor_err;
+  diag->postResult = ncclSuccess;
+  diag->postErrno = 0;
+  diag->devIndex = devIndex;
+  diag->qpIndex = resCtx->healthProbe.qpIndex;
+  diag->lane = resCtx->healthProbe.qpIndex / resCtx->baseComm->vProps.ndevs;
+  diag->qpNum = wc->qp_num;
+  diag->generation = generation;
+  diag->timestamp = clockNano();
+}
+
+static void ncclIbResiliencyHealthProbeDiagSetPostFailure(struct ncclIbResiliency* resCtx, int devIndex,
+                                                          ncclResult_t postResult, int postErrno) {
+  struct ncclIbResiliencyHealthProbeDiag* diag = &resCtx->healthProbe.diag;
+  diag->source = ncclIbHealthProbeResultPostFailure;
+  diag->wcStatus = IBV_WC_SUCCESS;
+  diag->vendorErr = 0;
+  diag->postResult = postResult;
+  diag->postErrno = postErrno;
+  diag->devIndex = devIndex;
+  diag->qpIndex = resCtx->healthProbe.qpIndex;
+  diag->lane = resCtx->healthProbe.qpIndex / resCtx->baseComm->vProps.ndevs;
+  diag->qpNum = resCtx->healthProbe.qpNum;
+  diag->generation = resCtx->healthProbe.generation;
+  diag->timestamp = clockNano();
+}
+
+static ncclResult_t ncclIbResiliencyHealthProbeHandleFailure(struct ncclIbResiliency* resCtx, int devIndex) {
+  struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
+  resCtx->healthProbe.outstanding = false;
+  struct ncclIbResiliencyHealthProbeDiag* diag = &resCtx->healthProbe.diag;
+  resDev->healthState.store(ncclIbHealthDown, std::memory_order_release);
+  if (diag->source == ncclIbHealthProbeResultCqe) {
+    WARN("NET/IB: Standby data-QP health probe failed (comm=%p, diagSource=%s, devIndex=%d, lane=%d, qpIndex=%d, "
+         "qp_num=%u, generation=%llu, status=%s(%d), vendorErr=%u, timestamp=%llu, health=Down). Trying existing "
+         "port recovery.",
+         resCtx->baseComm, ncclIbHealthProbeResultSourceStr(diag->source), devIndex, diag->lane, diag->qpIndex,
+         diag->qpNum, (unsigned long long)diag->generation, ibvWcStatusStr(diag->wcStatus), diag->wcStatus,
+         diag->vendorErr, (unsigned long long)diag->timestamp);
+  } else {
+    WARN("NET/IB: Standby data-QP health probe failed (comm=%p, diagSource=%s, devIndex=%d, lane=%d, qpIndex=%d, "
+         "qp_num=%u, generation=%llu, postResult=%d, postErrno=%d, timestamp=%llu, health=Down). Trying existing "
+         "port recovery.",
+         resCtx->baseComm, ncclIbHealthProbeResultSourceStr(diag->source), devIndex, diag->lane, diag->qpIndex,
+         diag->qpNum, (unsigned long long)diag->generation, diag->postResult, diag->postErrno,
+         (unsigned long long)diag->timestamp);
+  }
+  NCCLCHECK(ncclIbResiliencyHandleDeviceFailure(resCtx, devIndex));
+  return ncclSuccess;
+}
+
+bool ncclIbResiliencyIsHealthProbeCompletion(struct ncclIbResiliency* resCtx, const struct ibv_wc* wc, int devIndex) {
+  (void)devIndex;
+  return resCtx != NULL && resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby &&
+         wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY &&
+         (wc->wr_id & NCCL_IB_HEALTH_PROBE_WR_ID_TAG) != 0;
+}
+
+ncclResult_t ncclIbResiliencyHealthProbeHandleCompletion(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                         int devIndex) {
+  uint64_t generation = wc->wr_id & NCCL_IB_HEALTH_PROBE_WR_ID_GENERATION_MASK;
+  if (!resCtx->healthProbe.outstanding || generation != resCtx->healthProbe.generation ||
+      devIndex != resCtx->healthProbe.devIndex || wc->qp_num != resCtx->healthProbe.qpNum) {
+    INFO(NCCL_NET,
+         "NET/IB: Ignoring stale standby health-probe CQE (comm=%p, devIndex=%d/%d, qp_num=%u/%u, "
+         "generation=%llu/%llu, outstanding=%d, status=%s(%d))",
+         resCtx->baseComm, devIndex, resCtx->healthProbe.devIndex, wc->qp_num, resCtx->healthProbe.qpNum,
+         (unsigned long long)generation, (unsigned long long)resCtx->healthProbe.generation,
+         resCtx->healthProbe.outstanding, ibvWcStatusStr(wc->status), wc->status);
+    return ncclSuccess;
+  }
+
+  if (wc->status != IBV_WC_SUCCESS) {
+    ncclIbResiliencyHealthProbeDiagSetCqe(resCtx, wc, devIndex, generation);
+    return ncclIbResiliencyHealthProbeHandleFailure(resCtx, devIndex);
+  }
+
+  ncclIbResiliencyHealthProbeDiagSetCqe(resCtx, wc, devIndex, generation);
+  resCtx->healthProbe.outstanding = false;
+  resCtx->healthProbe.lastSuccess = clockNano();
+  INFO(NCCL_NET,
+       "NET/IB: Standby data-QP health probe completed (comm=%p, diagSource=CQE, devIndex=%d, lane=%d, qpIndex=%d, "
+       "qp_num=%u, generation=%llu, status=%s(%d), vendorErr=%u, timestamp=%llu, health=Healthy)",
+       resCtx->baseComm, devIndex, resCtx->healthProbe.diag.lane, resCtx->healthProbe.qpIndex, wc->qp_num,
+       (unsigned long long)resCtx->healthProbe.generation, ibvWcStatusStr(wc->status), wc->status, wc->vendor_err,
+       (unsigned long long)resCtx->healthProbe.diag.timestamp);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbResiliencyHealthProbePost(struct ncclIbResiliency* resCtx, bool primaryTrafficPosted) {
+  if (resCtx == NULL || !primaryTrafficPosted ||
+      resCtx->baseComm->dataPathPolicy != ncclIbDataPathActiveStandby ||
+      resCtx->activeStandbyState != ncclIbAsPrimaryActive || resCtx->healthProbe.outstanding) {
+    return ncclSuccess;
+  }
+  int64_t intervalMs = ncclParamIbResiliencyStandbyHealthInterval();
+  if (intervalMs <= 0) return ncclSuccess;
+  uint64_t now = clockNano();
+  if (resCtx->healthProbe.lastSubmit != 0 &&
+      now - resCtx->healthProbe.lastSubmit < (uint64_t)intervalMs * MSEC_TO_NSEC) {
+    return ncclSuccess;
+  }
+
+  int devIndex = resCtx->baseComm->standbyDevIndex;
+  struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
+  if (resDev->state.load(std::memory_order_acquire) != ncclIbResiliencyDevStateOk ||
+      resDev->healthState.load(std::memory_order_acquire) == ncclIbHealthDown || resDev->healthProbeMr == NULL) {
+    return ncclSuccess;
+  }
+
+  int ndevs = resCtx->baseComm->vProps.ndevs;
+  int qpsPerDevice = resCtx->baseComm->nqps / ndevs;
+  if (qpsPerDevice <= 0) return ncclInternalError;
+  int lane = resCtx->healthProbe.nextLane % qpsPerDevice;
+  int qpIndex = lane * ndevs + devIndex;
+  struct ncclIbQp* qp = &resCtx->baseComm->qps[qpIndex];
+  if (qp->qp == NULL || qp->remDevIdx < 0 || qp->remDevIdx >= resCtx->baseComm->nRemDevs) {
+    WARN("NET/IB: Invalid standby data QP for health probe (comm=%p, devIndex=%d, lane=%d, qpIndex=%d, remDevIdx=%d)",
+         resCtx->baseComm, devIndex, lane, qpIndex, qp->remDevIdx);
+    return ncclInternalError;
+  }
+
+  struct ncclIbResiliencyRemoteCompletionRecordsInfo* remote = &resCtx->remHealthProbeInfo[qp->remDevIdx];
+  if (remote->addr == 0 || remote->rkey == 0) {
+    WARN("NET/IB: Missing remote heartbeat scratchpad for health probe (comm=%p, remDevIdx=%d)", resCtx->baseComm,
+         qp->remDevIdx);
+    return ncclInternalError;
+  }
+
+  uint64_t generation = (resCtx->healthProbe.generation + 1) & NCCL_IB_HEALTH_PROBE_WR_ID_GENERATION_MASK;
+  if (generation == 0 || generation == NCCL_IB_HEALTH_PROBE_WR_ID_GENERATION_MASK) generation = 1;
+  resCtx->healthProbeScratchpad = generation;
+  struct ibv_sge sge = {};
+  sge.addr = (uint64_t)&resCtx->healthProbeScratchpad;
+  sge.length = sizeof(resCtx->healthProbeScratchpad);
+  sge.lkey = resDev->healthProbeMr->lkey;
+  struct ibv_send_wr wr = {};
+  wr.wr_id = NCCL_IB_HEALTH_PROBE_WR_ID_TAG | generation;
+  assert(wr.wr_id != NCCL_IB_RECV_WR_ID_DUMMY);
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.wr.rdma.remote_addr = remote->addr;
+  wr.wr.rdma.rkey = remote->rkey;
+
+  resCtx->healthProbe.generation = generation;
+  resCtx->healthProbe.devIndex = devIndex;
+  resCtx->healthProbe.qpIndex = qpIndex;
+  resCtx->healthProbe.qpNum = qp->qp->qp_num;
+  struct ibv_send_wr* badWr = NULL;
+  ncclResult_t res = wrap_ibv_post_send(qp->qp, &wr, &badWr);
+  if (res != ncclSuccess) {
+    int postErrno = errno;
+    ncclIbResiliencyHealthProbeDiagSetPostFailure(resCtx, devIndex, res, postErrno);
+    NCCLCHECK(ncclIbResiliencyHealthProbeHandleFailure(resCtx, devIndex));
+    return ncclSuccess;
+  }
+
+  resCtx->healthProbe.outstanding = true;
+  resCtx->healthProbe.lastSubmit = now;
+  resCtx->healthProbe.nextLane = (lane + 1) % qpsPerDevice;
+  INFO(NCCL_NET,
+       "NET/IB: Posted %s standby data-QP health probe (comm=%p, devIndex=%d, lane=%d, qpIndex=%d, qp_num=%u, "
+       "generation=%llu, remoteAddr=0x%llx, rkey=0x%x)",
+       resCtx->baseComm->isSend ? "forward" : "reverse", resCtx->baseComm, devIndex, lane, qpIndex, qp->qp->qp_num,
+       (unsigned long long)generation,
+       (unsigned long long)remote->addr, remote->rkey);
   return ncclSuccess;
 }
 
@@ -611,6 +863,16 @@ ncclResult_t ncclIbResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncc
   struct ncclIbResiliency* baseCtx = *resCtx;
   baseCtx->baseComm = baseComm;
   baseCtx->inProgress = false;
+  baseCtx->activeStandbyState = ncclIbAsPrimaryActive;
+  baseCtx->activeStandbyGeneration = 0;
+  baseCtx->healthProbeScratchpad = 0;
+  baseCtx->healthProbe = {};
+  baseCtx->healthProbe.devIndex = -1;
+  baseCtx->healthProbe.qpIndex = -1;
+  baseCtx->healthProbe.diag.devIndex = -1;
+  baseCtx->healthProbe.diag.qpIndex = -1;
+  baseCtx->healthProbe.diag.lane = -1;
+  memset(baseCtx->remHealthProbeInfo, 0, sizeof(baseCtx->remHealthProbeInfo));
   if (baseComm->isSend) {
     struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)baseCtx;
     memset(sendResCtx->failedRequests, 0, sizeof(sendResCtx->failedRequests));
@@ -649,6 +911,17 @@ ncclResult_t ncclIbResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIn
   assert(devIndex < resCtx->ndevs);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   resDev->state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
+  resDev->healthState.store(ncclIbHealthDown, std::memory_order_release);
+  resDev->probingCq = NULL;
+  resDev->nOutstandingProbes = 0;
+  resDev->probingResultMr = NULL;
+  resDev->portRecoveryCq = NULL;
+  resDev->healthProbeMr = NULL;
+  if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+    struct ncclIbNetCommDevBase* devBase = ncclIbGetNetCommDevBase(resCtx->baseComm, devIndex);
+    NCCLCHECK(wrap_ibv_reg_mr(&resDev->healthProbeMr, devBase->pd, &resCtx->healthProbeScratchpad,
+                              sizeof(resCtx->healthProbeScratchpad), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+  }
   void* cqContext = (void*)&resCtx->baseComm->stats;
   int cqSize = -1;
   if (resCtx->baseComm->isSend) {
@@ -676,6 +949,16 @@ ncclResult_t ncclIbResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIn
   return ncclSuccess;
 }
 
+ncclResult_t ncclIbResiliencyDataQpsReady(struct ncclIbResiliency* resCtx) {
+  if (resCtx == NULL || resCtx->baseComm->dataPathPolicy != ncclIbDataPathActiveStandby) return ncclSuccess;
+  for (int devIndex = 0; devIndex < resCtx->ndevs; devIndex++) {
+    resCtx->devs[devIndex].healthState.store(ncclIbHealthHealthy, std::memory_order_release);
+    INFO(NCCL_NET, "NET/IB: Active-standby data QPs ready (health=Healthy, devIndex=%d, %s comm=%p)", devIndex,
+         resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t ncclIbResiliencyDevDestroy(struct ncclIbResiliency* resCtx, uint devIndex) {
   assert(resCtx != NULL);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
@@ -698,6 +981,10 @@ ncclResult_t ncclIbResiliencyDevDestroy(struct ncclIbResiliency* resCtx, uint de
            __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
     }
   }
+  if (resDev->healthProbeMr) {
+    NCCLCHECK(wrap_ibv_dereg_mr(resDev->healthProbeMr));
+    resDev->healthProbeMr = NULL;
+  }
   return ncclSuccess;
 }
 
@@ -719,6 +1006,7 @@ ncclResult_t ncclIbResiliencyDataCqSizeGet(struct ncclIbResiliency* resCtx, uint
   // completions of all other requests.
   assert(resCtx->ndevs > 0);
   *cqSize = (*cqSize) * resCtx->ndevs;
+  if (baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) *cqSize += 1;
   INFO(NCCL_NET, "NET/IB: %s: CQ size should be %d on device %d for %s communicator (comm=%p)", __func__, *cqSize,
        devIndex, baseComm->isSend ? "send" : "recv", baseComm);
   return ncclSuccess;
@@ -995,6 +1283,15 @@ ncclResult_t ncclIbResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency*
   return ncclSuccess;
 }
 
+ncclResult_t ncclIbResiliencyHealthProbeRemoteSet(struct ncclIbResiliency* resCtx, uint32_t rkey, uint64_t addr,
+                                                  uint devIndex) {
+  assert(resCtx != NULL);
+  assert(devIndex < NCCL_IB_MAX_DEVS_PER_NIC);
+  resCtx->remHealthProbeInfo[devIndex].rkey = rkey;
+  resCtx->remHealthProbeInfo[devIndex].addr = addr;
+  return ncclSuccess;
+}
+
 ncclResult_t ncclIbResiliencyRequestIsComplete(struct ncclIbRequest* request, bool* isComplete) {
   assert(isComplete != NULL);
 
@@ -1046,6 +1343,14 @@ ncclResult_t ncclIbResiliencyHandleCompletionError(struct ncclIbResiliency* resC
        "wc->qp_num=%u, wc->byte_len=%d)",
        __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
        wc->qp_num, wc->byte_len);
+  // A real data-QP error on the standby path is stronger evidence than a
+  // successful port query. Publish the standby as unavailable before the
+  // common device replacement/recovery path runs.
+  if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby &&
+      (devIndex == resCtx->baseComm->primaryDevIndex || devIndex == resCtx->baseComm->standbyDevIndex)) {
+    resCtx->devs[devIndex].healthState.store(ncclIbHealthDown, std::memory_order_release);
+  }
+
   NCCLCHECK(ncclIbResiliencyCheckErrorNotFatal(resCtx, wc, devIndex));
 
   // Before handling the request that got an error, first the device is
@@ -1062,14 +1367,30 @@ ncclResult_t ncclIbResiliencyHandleCompletionError(struct ncclIbResiliency* resC
 }
 
 static ncclResult_t ncclIbResiliencyActiveQpsRestore(struct ncclIbResiliency* resCtx, int restoredDevIndex) {
+  if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby &&
+      restoredDevIndex != resCtx->baseComm->primaryDevIndex) {
+    return ncclSuccess;
+  }
   for (int qpIndex = 0; qpIndex < resCtx->baseComm->nqps; qpIndex++) {
     ncclIbQp* qpToRestore = &resCtx->baseComm->qps[qpIndex];
     if (qpToRestore->devIndex != restoredDevIndex) {
       continue;
     }
+    if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby &&
+        qpIndex % resCtx->baseComm->vProps.ndevs != resCtx->baseComm->primaryDevIndex) {
+      continue;
+    }
+    struct ncclIbQp* oldQp = resCtx->baseComm->activeQps[qpIndex];
     INFO(NCCL_NET, "NET/IB: %s: Restoring QP (index=%d, qp_num=%u) on device %d (comm=%p)", __func__, qpIndex,
          qpToRestore->qp->qp_num, restoredDevIndex, resCtx->baseComm);
     resCtx->baseComm->activeQps[qpIndex] = qpToRestore;
+    if (resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby) {
+      INFO(NCCL_NET,
+           "NET/IB: %s: Active-standby failback generation=%llu logicalQp=%d oldQp=%u newQp=%u oldDev=%d newDev=%d",
+           __func__, (unsigned long long)(resCtx->activeStandbyGeneration + 1), qpIndex,
+           oldQp && oldQp->qp ? oldQp->qp->qp_num : 0, qpToRestore->qp ? qpToRestore->qp->qp_num : 0,
+           oldQp ? oldQp->devIndex : -1, restoredDevIndex);
+    }
   }
   return ncclSuccess;
 }
@@ -1115,8 +1436,25 @@ ncclResult_t ncclIbResiliencyProgress(struct ncclIbResiliency* resCtx) {
              "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d)",
              __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
              resCtx->outstandingRecovery);
-        ncclIbResiliencyActiveQpsRestore(resCtx, devIndex);
+        bool primaryFailback = resCtx->baseComm->dataPathPolicy == ncclIbDataPathActiveStandby &&
+                               devIndex == resCtx->baseComm->primaryDevIndex;
+        if (primaryFailback) {
+          resCtx->activeStandbyState = ncclIbAsPrimaryRecovering;
+        }
+        NCCLCHECK(ncclIbResiliencyActiveQpsRestore(resCtx, devIndex));
+        resCtx->devs[devIndex].healthState.store(ncclIbHealthHealthy, std::memory_order_release);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
+        if (primaryFailback) {
+          resCtx->activeStandbyState = ncclIbAsPrimaryActive;
+          resCtx->activeStandbyGeneration++;
+        }
+        struct ncclIbResiliencyHealthProbeDiag* diag = &resCtx->healthProbe.diag;
+        INFO(NCCL_NET,
+             "NET/IB: %s: Device %d recovery published health=Healthy state=Ok (%s comm=%p, generation=%llu, "
+             "lastProbeSource=%s, lastProbeGeneration=%llu, lastProbeTimestamp=%llu)",
+             __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
+             (unsigned long long)resCtx->activeStandbyGeneration, ncclIbHealthProbeResultSourceStr(diag->source),
+             (unsigned long long)diag->generation, (unsigned long long)diag->timestamp);
       }
       if (devState == ncclIbResiliencyDevStateRecoveryFailed) {
         resCtx->outstandingRecovery--;
@@ -1125,6 +1463,7 @@ ncclResult_t ncclIbResiliencyProgress(struct ncclIbResiliency* resCtx) {
           "NET/IB: %s: Device %d will not be attempted to be recovered any more (%s comm=%p, outstandingRecovery=%d).",
           __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
           resCtx->outstandingRecovery);
+        resCtx->devs[devIndex].healthState.store(ncclIbHealthDown, std::memory_order_release);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
         continue;
       }

--- a/src/transport/net_ib/p2p_resiliency.h
+++ b/src/transport/net_ib/p2p_resiliency.h
@@ -26,9 +26,29 @@ enum ncclIbResiliencyDevState {
   ncclIbResiliencyDevStateErrorPermanent
 };
 
+enum ncclIbActiveStandbyState {
+  ncclIbAsPrimaryActive = 0,
+  ncclIbAsSwitchingToStandby,
+  ncclIbAsStandbyActive,
+  ncclIbAsPrimaryRecovering,
+  ncclIbAsFailed,
+};
+
+enum ncclIbResiliencyHealthState {
+  ncclIbHealthDown = 0,
+  ncclIbHealthHealthy,
+};
+
+enum ncclIbHealthProbeResultSource {
+  ncclIbHealthProbeResultNone = 0,
+  ncclIbHealthProbeResultCqe,
+  ncclIbHealthProbeResultPostFailure,
+};
+
 struct ncclIbResiliencyDev {
   // Atomic to allow lock-free access from multiple threads (main + recovery).
   std::atomic<ncclIbResiliencyDevState> state;
+  std::atomic<ncclIbResiliencyHealthState> healthState;
   // CQ to get CQEs on the sender side for probing operations.
   // Receiver side is not expected to get any CQEs on the this CQ but Verbs
   // requires a CQ to be associated with a QP.
@@ -41,6 +61,40 @@ struct ncclIbResiliencyDev {
   struct ibv_mr* probingResultMr;
   // CQ to get CQEs for recovery protocol messages.
   struct ibv_cq* portRecoveryCq;
+  // Registration of the communicator-owned heartbeat scratchpad on this
+  // device. It is both a local probe source and a remote-write target.
+  struct ibv_mr* healthProbeMr;
+};
+
+struct ncclIbResiliencyHealthProbeDiag {
+  enum ncclIbHealthProbeResultSource source;
+  enum ibv_wc_status wcStatus;
+  uint32_t vendorErr;
+  ncclResult_t postResult;
+  int postErrno;
+  int devIndex;
+  int qpIndex;
+  int lane;
+  uint32_t qpNum;
+  uint64_t generation;
+  uint64_t timestamp;
+};
+
+struct ncclIbResiliencyHealthProbe {
+  bool outstanding;
+  uint64_t generation;
+  uint64_t lastSubmit;
+  uint64_t lastSuccess;
+  uint32_t qpNum;
+  int devIndex;
+  int qpIndex;
+  int nextLane;
+  struct ncclIbResiliencyHealthProbeDiag diag;
+};
+
+struct ncclIbResiliencyRemoteCompletionRecordsInfo {
+  uint64_t addr;
+  uint32_t rkey;
 };
 
 struct ncclIbResiliency {
@@ -78,6 +132,16 @@ struct ncclIbResiliency {
 
   // Number of outstanding devices that are currently undergoing recovery.
   int outstandingRecovery;
+
+  // Active-standby state is published by the main progress thread after QP
+  // mappings are updated. The generation makes transitions diagnosable.
+  enum ncclIbActiveStandbyState activeStandbyState;
+  uint64_t activeStandbyGeneration;
+  uint64_t healthProbeScratchpad;
+  struct ncclIbResiliencyHealthProbe healthProbe;
+  // Remote heartbeat targets are needed by both send and receive
+  // communicators for bidirectional standby data-QP probing.
+  struct ncclIbResiliencyRemoteCompletionRecordsInfo remHealthProbeInfo[NCCL_IB_MAX_DEVS_PER_NIC];
 };
 
 enum ncclIbResiliencyRequestSendState {
@@ -112,13 +176,6 @@ struct ncclIbResiliencyRequestSend {
   // incrementing "generation ID" used to make sure that the CQE belongs to
   // a request that was already handled so the CQE can be ignored.
   uint64_t id;
-};
-
-struct ncclIbResiliencyRemoteCompletionRecordsInfo {
-  // The address of the completion records structure on the receiver side.
-  uint64_t addr;
-  // For accessing the completion records structure on the receiver side.
-  uint32_t rkey;
 };
 
 struct ncclIbResiliencySend {
@@ -167,6 +224,16 @@ ncclResult_t ncclIbResiliencyHandleCompletionError(struct ncclIbResiliency* resC
 // Progresses all operations on the resiliency context.
 ncclResult_t ncclIbResiliencyProgress(struct ncclIbResiliency* resCtx);
 
+// Post a rate-limited health probe on an actual standby data QP after the
+// primary path successfully accepted payload or CTS traffic.
+ncclResult_t ncclIbResiliencyHealthProbePost(struct ncclIbResiliency* resCtx, bool primaryTrafficPosted);
+// Publish data-QP readiness after the complete connection handshake.
+ncclResult_t ncclIbResiliencyDataQpsReady(struct ncclIbResiliency* resCtx);
+// Health probe CQEs share the data CQ but have an isolated wr_id namespace.
+bool ncclIbResiliencyIsHealthProbeCompletion(struct ncclIbResiliency* resCtx, const struct ibv_wc* wc, int devIndex);
+ncclResult_t ncclIbResiliencyHealthProbeHandleCompletion(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                         int devIndex);
+
 // -----------------------------
 // Control path APIs
 // -----------------------------
@@ -213,5 +280,7 @@ ncclResult_t ncclIbResiliencyClose(struct ncclIbResiliency* resCtx);
 // structure on the receiver side.
 ncclResult_t ncclIbResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey,
                                                         uint64_t cmplsRecordsAddr, uint devIndex);
+ncclResult_t ncclIbResiliencyHealthProbeRemoteSet(struct ncclIbResiliency* resCtx, uint32_t rkey, uint64_t addr,
+                                                  uint devIndex);
 
 #endif // NET_IB_P2P_RESILIENCY_H_

--- a/src/transport/net_ib/p2p_resiliency_recovery.cc
+++ b/src/transport/net_ib/p2p_resiliency_recovery.cc
@@ -217,6 +217,50 @@ static ncclResult_t ncclIbPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPort
   return ncclSuccess;
 }
 
+// Helper function to drain and discard all the CQEs pending on the recovery CQ
+// without posting new receive WQEs. Used after the recovery QP work queues were
+// flushed, where a pending CQE refers to a WQE that no longer exists.
+static ncclResult_t ncclIbPortRecoveryDiscardCqes(struct ncclIbPortRecoveryContext* recoveryContext) {
+  struct ibv_cq* cq = recoveryContext->recoveryCq;
+  int wrDone = 0;
+  struct ibv_wc wcs[NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE];
+  do {
+    NCCLCHECK(wrap_ibv_poll_cq(cq, NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE, wcs, &wrDone));
+    if (wrDone > 0) {
+      INFO(NCCL_NET, "NET/IB: %s: Discarded %d CQEs from recovery CQ %p for device %d (comm=%p)", __func__, wrDone, cq,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    }
+  } while (wrDone > 0);
+  return ncclSuccess;
+}
+
+// The recovery QPs live as long as the communicator and are reused by every
+// recovery cycle on their device, but their work queues are not empty when a
+// cycle completes: the receiver consumes the final "ack" without re-posting a
+// receive WQE, and the sender may leave send WQEs behind after retransmitting
+// "alive" messages. Those leftovers accumulate across cycles until
+// ncclIbPortRecoveryContextInit() can no longer post its initial batch of
+// receive WQEs (ibv_post_recv() fails with ENOMEM), which marks the device as
+// permanently failed and prevents any further recovery of that device.
+// Transitioning the QP to RESET flushes both work queues without generating
+// completions, and re-arming it to RTS (using the attributes cached on the QP at
+// connection time) hands a pristine QP to the next cycle. Both peers do this at
+// the end of a successful cycle, so their PSNs remain in sync.
+static ncclResult_t ncclIbPortRecoveryQpRearm(struct ncclIbPortRecoveryContext* recoveryContext) {
+  struct ncclIbQp* recoveryQp = &recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex];
+  if (recoveryQp->qp == NULL) return ncclSuccess;
+  INFO(NCCL_NET, "NET/IB: %s: Re-arming recovery QP on device %d (%s comm=%p, qp_num=%u)", __func__,
+       recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+       recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
+  NCCLCHECK(ncclIbQpReset(recoveryQp));
+  NCCLCHECK(ncclIbQpInit(recoveryQp));
+  NCCLCHECK(ncclIbQpRtr(recoveryQp));
+  NCCLCHECK(ncclIbQpRts(recoveryQp));
+  // CQEs generated before the work queues were flushed are stale for the next cycle.
+  NCCLCHECK(ncclIbPortRecoveryDiscardCqes(recoveryContext));
+  return ncclSuccess;
+}
+
 static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency* resCtx, int failedDevIndex,
                                                          ncclIbPortRecoveryContext** outRecoveryCtx) {
   ncclResult_t res = ncclSuccess;
@@ -1192,6 +1236,15 @@ static inline ncclResult_t ncclIbPortRecoveryContextProgress(ncclIbPortRecoveryC
     INFO(NCCL_NET, "NET/IB: %s: Port recovery succeeded for devIndex=%d (%s comm=%p)", __func__,
          recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
          recoveryContext->resCtx->baseComm);
+    // Hand a clean recovery QP to the next recovery cycle on this device. The
+    // recovery that just completed remains valid even if this fails, so the
+    // failure is only reported.
+    if (ncclIbPortRecoveryQpRearm(recoveryContext) != ncclSuccess) {
+      WARN("NET/IB: Failed to re-arm the recovery QP on device %d (%s comm=%p). Subsequent recovery attempts on this "
+           "device may fail",
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+           recoveryContext->resCtx->baseComm);
+    }
     for (int i = 0; i < recoveryContext->resCtx->ndevs; i++) {
       if (i != recoveryContext->devIndex) continue;
       INFO(NCCL_NET, "NET/IB: %s: Marking device %d as recovered (%s comm=%p)", __func__, i,


### PR DESCRIPTION
## Description

Add an opt-in active-standby data path for fused Net IB devices. An unordered HCA pair now produces two topology-directed virtual NICs so NCCL can select the PCIe-nearest primary for each GPU while keeping the other device connected as a standby.

Normal payload and CTS traffic use only the selected primary. If that device fails, logical QPs are mapped to the same lane on the standby, existing completion probing drives selective retransmission, and successful port recovery automatically restores the primary path.

## Related Issues

Closes #2310

## Changes & Impact

- Parse and validate `NCCL_IB_RESILIENCY_HCA_PAIRS` with matching `NCCL_NET_FORCE_MERGE` groups.
- Separate topology properties from runtime properties and create both primary directions for each HCA pair.
- Exchange and validate active-standby policy, logical device roles, and QP lane counts during connection setup.
- Keep standby data QPs ready while selecting only primary QPs for payload and CTS traffic.
- Probe standby data QPs in both directions with rate-limited, signaled RDMA writes.
- Isolate health-probe completions from user request completion accounting.
- Fail over to the same QP lane, recover through the existing port recovery protocol, and automatically fail back to the topology-selected primary.
- Re-arm recovery QPs after successful recovery so repeated cycles do not accumulate stale work requests.

There are no public API changes. Existing Active-Active behavior is unchanged unless HCA pairs are explicitly configured with port failover enabled. The current implementation handles one failed device at a time, and standby health probes are driven by primary payload or CTS progress.

## Performance Impact

Normal active-standby traffic uses only the topology-selected primary NIC, avoiding concurrent PIX and PHB data paths for the same GPU. The standby carries only rate-limited health probes until failover. Configurations without `NCCL_IB_RESILIENCY_HCA_PAIRS` retain the existing behavior.

Validation performed:

- Clean builds on two NCCL nodes.
- Core non-destructive active-standby functional cases.
- Dual-GPU PIX/PHB topology direction selection and pair-order equivalence.
- Real IB port down/up failover, recovery, and automatic failback.
