### PR TITLE
EFA GDA : per-thread WQE publish and acq_rel doorbell ordering

### DIFF
--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -293,17 +293,6 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
     group.sync();   /* all members' WQE writes for this chunk are done */
 
     if (is_leader) {
-      /* Publish this group's WQE writes to system scope before handing off,
-       * so they are visible to the NIC whenever any doorbell (this group's or
-       * a later draining group's) rings a slot in this range.
-       * Each group must publish its own writes: __threadfence_system()
-       * orders only the calling thread's writes, and the handoff (base_ref)
-       * is device/block scope, so a later thread's fence cannot publish this
-       * group's writes for it. Runs on both the ring and the defer path.
-       *
-       * Use acq_rel (MEMBAR.ALL.SYS) instead of __threadfence_system
-       * (MEMBAR.SC.SYS). */
-      cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
       /* Doorbell-order rendezvous: take the turn in strict slot order. */
       while (base_ref.load(cuda::memory_order_acquire) != chunk_base) {
         /* spin */
@@ -319,6 +308,15 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
       bool must_ring = (!aggregate) || (chunk_next - db_rung >= max_batch);
       if (must_ring) {
         ringDoorbell<mode>(qp, submitted_count_ptr, dbrung_ref, db_rung, chunk_next);
+      } else {
+        /* Publish this group's WQE writes to system scope before handing off,
+         * so they are visible to the NIC whenever any doorbell (this group's or
+         * a later draining group's) rings a slot in this range.
+         * Each group must publish its own writes: __threadfence_system()
+         * orders only the calling thread's writes, and the handoff (base_ref)
+         * is device/block scope, so a later thread's fence cannot publish this
+         * group's writes for it. Runs only on the defer path. */
+        cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
       }
       base_ref.store(chunk_next, cuda::memory_order_release);   /* hand off to next group */
     }

--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -106,7 +106,9 @@ NCCL_DEVICE_INLINE static void ringDoorbell(efa_cuda_qp* qp, uint64_t* submitted
                                             cuda::atomic_ref<uint32_t, ncclGinScope<mode>>& dbrung_ref,
                                             uint32_t db_rung, uint32_t target) {
   *qp->sq.wq.db = target;
-  __threadfence_system();   /* order the doorbell MMIO write */
+  /* Order the doorbell MMIO write. Use acq_rel (MEMBAR.ALL.SYS) instead of
+   * __threadfence_system (MEMBAR.SC.SYS). */
+  cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
   scopedAtomicAdd<ncclGinScope<mode>, cuda::memory_order_relaxed>(submitted_count_ptr, (uint64_t)(target - db_rung));
   dbrung_ref.store(target, cuda::memory_order_release);
 }
@@ -294,8 +296,11 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
        * Each group must publish its own writes: __threadfence_system()
        * orders only the calling thread's writes, and the handoff (base_ref)
        * is device/block scope, so a later thread's fence cannot publish this
-       * group's writes for it. Runs on both the ring and the defer path. */
-      __threadfence_system();
+       * group's writes for it. Runs on both the ring and the defer path.
+       *
+       * Use acq_rel (MEMBAR.ALL.SYS) instead of __threadfence_system
+       * (MEMBAR.SC.SYS). */
+      cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
       /* Doorbell-order rendezvous: take the turn in strict slot order. */
       while (base_ref.load(cuda::memory_order_acquire) != chunk_base) {
         /* spin */

--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -286,6 +286,9 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
       uint64_t* src = (uint64_t*)&wr;
       uint64_t* dst = (uint64_t*)(qp->sq.wq.buf + sq_idx * sizeof(efa_io_tx_wqe));
       for (int i = 0; i < 8; i++) dst[i] = src[i];
+      /* Publish this group's WQE writes to system scope so they are visible
+       * to the NIC whenever any doorbell rings a slot in this range. */
+      cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
     }
     group.sync();   /* all members' WQE writes for this chunk are done */
 


### PR DESCRIPTION
## Description

  Two memory-ordering changes to the EFA GDA GIN post path:

  1. Replace `__threadfence_system()` (MEMBAR.SC.SYS) with `cuda::atomic_thread_fence(memory_order_acq_rel, thread_scope_system)` (MEMBAR.ALL.SYS) at the doorbell-MMIO and WQE-publish sites.
  2. Move the WQE publish from a single leader fence to each WQE-writing thread.
  3. The leader now fences only on the defer path, where it hands off without ringing.

## Related Issues

None

## Changes & Impact

None

## Performance Impact

No performance regression on `p5en` and `p6-b200`.

