### PR TITLE
EFA GDA: re-read submitted_count while draining in flush

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,89 @@
+name: clang-format
+
+# Runs clang-format in check mode on the C/C++/CUDA files changed by a pull
+# request (and by pushes to the listed branches). Only files under src/ with a
+# .cc/.cu/.cuh/.h extension are checked; clang-format additionally skips any path
+# listed in the top-level .clang-format-ignore. Files that a change does not
+# touch are not checked, so pre-existing formatting elsewhere never blocks the
+# change.
+#
+# NCCL upstream (NVIDIA/nccl) does not run any GitHub Actions; this check is
+# specific to the amazon-contributing fork. To format locally, run
+# ./maint/run-clang-format.sh (see --diff / --check modes).
+
+on:
+  pull_request:
+    branches: [master, dev, staging]
+  push:
+    branches: [master, dev, staging]
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the PR base / previous push.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install clang-format
+        # Keep this pinned in lockstep with MIN_VERSION in run-clang-format.sh.
+        # The pip package vends a self-contained clang-format binary per LLVM
+        # release, so the CI version is deterministic and independent of the
+        # runner image.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "clang-format==22.1.2"
+
+      - name: Show clang-format version
+        run: clang-format --version
+
+      - name: Check formatting of changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            # New branch / first push reports an all-zero "before"; fall back to
+            # the parent commit when one exists, otherwise nothing to diff.
+            if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base="$(git rev-parse -q --verify "${head}^" || echo "$head")"
+            fi
+          fi
+
+          # Added/Copied/Modified/Renamed files under src/ with C/C++ extensions.
+          mapfile -t files < <(
+            git diff --name-only --diff-filter=ACMR "$base" "$head" \
+              | grep -E '^src/.*\.(cc|cu|cuh|h)$' || true
+          )
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No changed C/C++ source files under src/; nothing to check."
+            exit 0
+          fi
+
+          echo "Checking ${#files[@]} changed file(s):"
+          printf '  %s\n' "${files[@]}"
+
+          # clang-format honors .clang-format-ignore even for explicitly listed
+          # files, so vendored/ignored paths are skipped automatically.
+          if ! clang-format --dry-run --Werror --style=file "${files[@]}"; then
+            echo "ERROR: Some changed files are not correctly formatted." >&2
+            echo "Run './maint/run-clang-format.sh <file>' locally to fix, then commit." >&2
+            exit 1
+          fi
+          echo "All changed files are correctly formatted."

--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -624,22 +624,26 @@ NCCL_DEVICE_INLINE static ncclResult_t flushImplMode(ncclGinCtx ctx, Coop coop, 
     if NCCL_IF_CONSTEXPR (HasTimeout) startCycle = clock64();
     else (void)startCycle; // referenced only when HasTimeout is true
 
-    /* For each endpoint with outstanding work, snapshot submitted_count
-     * (scoped atomic load matching the relaxed bumps from the post
-     * path), then spin on the NIC-written FI_WRITE counter until it
-     * reaches the snapshot. The HW counter is read with system-scope
-     * acquire so the GPU bypasses caches and observes the latest NIC
-     * update through PCIe-coherent memory. */
+    /* For each endpoint with outstanding work, spin on the NIC-written
+     * FI_WRITE counter until it catches up with submitted_count.
+     * submitted_count is re-read (scoped relaxed atomic load matching the
+     * relaxed bumps from the post path) on every iteration rather than
+     * snapshotted once: another thread may keep posting on this context
+     * while we drain, and completions passing a stale snapshot would leave
+     * the masked difference permanently non-zero. The HW counter is read
+     * with system-scope acquire so the GPU bypasses caches and observes the
+     * latest NIC update through PCIe-coherent memory. */
     auto wait_for_endpoint = [abortFlag, startCycle,
                               timeoutCycles](nccl_ofi_gin_gdaki_dev_endpoint_handle& ep) -> ncclResult_t {
-      uint64_t target = scopedAtomicLoad<ncclGinScope<mode>, cuda::memory_order_relaxed>(&ep.submitted_count);
+      cuda::atomic_ref<uint64_t, ncclGinScope<mode>> target_ref(ep.submitted_count);
 
       /* Drain-to-zero: outstanding = (submitted - completed) reduced to
        * 31 bits, since the NIC FI_WRITE counter wraps at 2^31. Wait until
        * no work is outstanding. Outstanding is bounded by sq_size « 2^31,
        * so the masked difference is exact and cannot be fooled by a
        * counter wrap. */
-      while (((((uint32_t)target) - (uint32_t)hwCounterLoad(ep.local_cntr_value)) & EFA_CNTR_MASK) != 0) {
+      while (((((uint32_t)target_ref.load(cuda::memory_order_relaxed)) - (uint32_t)hwCounterLoad(ep.local_cntr_value)) &
+              EFA_CNTR_MASK) != 0) {
         if NCCL_IF_CONSTEXPR (HasTimeout) {
           if (clock64() - startCycle >= timeoutCycles) return ncclTimeout;
         }


### PR DESCRIPTION
flushImplMode snapshotted submitted_count and spun until the NIC FI_WRITE counter matched it exactly, so concurrent posting on the same context could push completions past the stale target and hang the flush. Re-read it with a scoped relaxed atomic load on each iteration instead.