### PR TITLE
GDAKI/DOCA: balance QPs across LAG ports with explicit TX port affinity

### DIFF
--- a/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_gpunetio_high_level.cpp
+++ b/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_gpunetio_high_level.cpp
@@ -378,7 +378,14 @@ static doca_error_t create_qp(
     enum doca_gpu_dev_verbs_nic_handler req_nic_handler, bool set_core_direct,
     enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext, struct doca_verbs_qp **verbs_qp,
     enum doca_gpu_dev_verbs_nic_handler *out_nic_handler) {
+    static std::atomic<uint32_t> dataQpIndex{0};
+    static std::atomic<uint32_t> companionQpIndex{0};
     doca_error_t status = DOCA_SUCCESS, tmp_status = DOCA_SUCCESS;
+    uint32_t qpAffinityIndex = 0;
+    uint32_t rawQpAffinityIndex = 0;
+    uint32_t lagGroupSize = 1;
+    const char* lagGroupEnv = nullptr;
+    int parsedLagGroupSize = 0;
     struct doca_verbs_qp_init_attr *verbs_qp_init_attr = NULL;
     struct doca_verbs_qp *new_qp = NULL;
     uint32_t external_umem_size = 0;
@@ -396,6 +403,20 @@ static doca_error_t create_qp(
     status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr, external_uar);
     if (status != DOCA_SUCCESS) {
         DOCA_LOG(LOG_ERR, "Failed to set receive_max_sges");
+        goto destroy_resources;
+    }
+
+    // Main and companion QPs need independent indices because each sequence is context-major.
+    rawQpAffinityIndex = set_core_direct ? companionQpIndex.fetch_add(1) : dataQpIndex.fetch_add(1);
+    lagGroupEnv = getenv("DOCA_LAG_TX_PORT_AFFINITY_GROUP_SIZE");
+    parsedLagGroupSize = lagGroupEnv != nullptr ? atoi(lagGroupEnv) : 0;
+    if (parsedLagGroupSize > 0) lagGroupSize = (uint32_t)parsedLagGroupSize;
+    // Collapse the remote-rank QPs in one context to a shared index before selecting a LAG port.
+    qpAffinityIndex = rawQpAffinityIndex / lagGroupSize;
+
+    status = doca_verbs_qp_init_attr_set_user_index(verbs_qp_init_attr, qpAffinityIndex);
+    if (status != DOCA_SUCCESS) {
+        DOCA_LOG(LOG_ERR, "Failed to set QP affinity index");
         goto destroy_resources;
     }
 

--- a/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_qp.cpp
+++ b/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_qp.cpp
@@ -91,6 +91,17 @@ constexpr uint32_t sc_verbs_mac_addr_len = 6;
 constexpr uint32_t sc_verbs_mac_addr_2msbytes_len = 2;
 constexpr uint32_t sc_verbs_log_msg_max = 30;
 
+static int docaGetLagTxPortAffinityMode() {
+    const char* affinityEnv = getenv("DOCA_LAG_TX_PORT_AFFINITY");
+    const int affinityMode = affinityEnv != nullptr ? atoi(affinityEnv) : 0;
+    return affinityMode >= 1 && affinityMode <= 3 ? affinityMode : 0;
+}
+
+static uint32_t docaGetLagTxPort(int affinityMode, uint32_t userIndex) {
+    // Modes 1 and 2 pin a QP; mode 3 alternates contexts between both LAG ports.
+    return affinityMode == 3 ? (userIndex % 2) + 1 : (uint32_t)affinityMode;
+}
+
 using create_qp_in = uint32_t[MLX5_ST_SZ_DW(create_qp_in)];
 using create_qp_out = uint32_t[MLX5_ST_SZ_DW(create_qp_out)];
 
@@ -691,6 +702,14 @@ doca_error_t doca_verbs_qp::create_qp_obj(
     DEVX_SET(qpc, qpc, pd, dvpd.pdn);
 
     DEVX_SET(qpc, qpc, user_index, verbs_qp_init_attr.user_index);
+    const int lagAffinityMode = docaGetLagTxPortAffinityMode();
+    if (lagAffinityMode != 0) {
+        const uint32_t lagPort = docaGetLagTxPort(lagAffinityMode, verbs_qp_init_attr.user_index);
+        // Set affinity during creation for devices that honor the CREATE_QP field.
+        DEVX_SET(qpc, qpc, lag_tx_port_affinity, lagPort);
+        DOCA_LOG(LOG_INFO, "Set LAG tx port affinity = %u (mode=%d user_index=%u)", lagPort,
+                 lagAffinityMode, verbs_qp_init_attr.user_index);
+    }
     DEVX_SET(qpc, qpc, uar_page, uar_id);
 
     if (m_sq_size_wqebb > 0) {
@@ -1033,6 +1052,16 @@ doca_error_t doca_verbs_qp::rtr2rts(struct doca_verbs_qp_attr &verbs_qp_attr,
 
     m_current_state = DOCA_VERBS_QP_STATE_RTS;
 
+    const int lagAffinityMode = docaGetLagTxPortAffinityMode();
+    if (lagAffinityMode != 0) {
+        // Some firmware applies LAG affinity only after the QP has reached RTS.
+        doca_error_t affinityStatus = rts2rts(verbs_qp_attr, 0);
+        if (affinityStatus != DOCA_SUCCESS) {
+            DOCA_LOG(LOG_ERR, "Failed to apply QP LAG tx port affinity after RTS");
+            return affinityStatus;
+        }
+    }
+
     DOCA_LOG(LOG_INFO, "DOCA IB Verbs QP %p: has been successfully moved to RTS state", this);
 
     return DOCA_SUCCESS;
@@ -1093,6 +1122,15 @@ doca_error_t doca_verbs_qp::rts2rts(struct doca_verbs_qp_attr &verbs_qp_attr,
     int mlx5_opt_param_mask{0};
     convert_doca_verbs_qp_attr_mask_to_legal_mlx5_qp_opt_param_mask(attr_mask, mlx5_opt_param_mask,
                                                                     DOCA_VERBS_QP_RTS2RTS);
+
+    const int lagAffinityMode = docaGetLagTxPortAffinityMode();
+    if (lagAffinityMode != 0) {
+        const uint32_t lagPort = docaGetLagTxPort(lagAffinityMode, m_init_attr.user_index);
+        DEVX_SET(qpc, qpc, lag_tx_port_affinity, lagPort);
+        mlx5_opt_param_mask |= MLX5_QPC_OPT_MASK_RTS2RTS_LAG_TX_PORT_AFFINITY;
+        DOCA_LOG(LOG_INFO, "RTS2RTS LAG tx port affinity = %u (mode=%d user_index=%u)", lagPort,
+                 lagAffinityMode, m_init_attr.user_index);
+    }
 
     DEVX_SET(rts2rts_qp_in, in, opt_param_mask, mlx5_opt_param_mask);
 


### PR DESCRIPTION
## Summary

This change adds opt-in LAG TX-port affinity to the DOCA GPUNetIO QP path used by GDAKI. It addresses a local LAG imbalance observed on queue-affinity RoCE bonds: many GDAKI QPs can be assigned to the same physical member, saturating one 200 Gb/s link while the other member of the 400 Gb/s bond remains underutilized.

The implementation:

- assigns independent sequence indices to data QPs and companion QPs;
- converts the context-major QP creation sequence into a context index;
- supports pinning to LAG port 1 or 2, or alternating contexts across both ports;
- programs `lag_tx_port_affinity` at QP creation time; and
- re-applies the field with an RTS-to-RTS DevX modify after the QP reaches RTS, which is required by the firmware tested here.

The feature is disabled unless `DOCA_LAG_TX_PORT_AFFINITY` is set. It only changes the GDAKI/DOCA QP path.

## Motivation

The affected systems expose four logical RDMA devices per node. Each logical device is a two-member 802.3ad bond, and two GPU ranks share that logical RDMA device. The physical members use the mlx5 `queue_affinity` LAG selection mode.

GDAKI bypasses the normal Linux bond transmit path. Consequently, the Linux `layer3+4` transmit hash policy does not select the local physical member for these GPUDirect RDMA QPs. Randomizing the RoCE UDP source port adds entropy for switch ECMP, but it does not guarantee local balance between the two members of an mlx5 queue-affinity bond.

Without an explicit QPC affinity, we observed approximately 75/25 traffic splits within some bonds. Once one 200 Gb/s member becomes the hot link, the slowest EP rank determines collective latency even though the other member still has spare bandwidth.

Commit [a93cc03](https://github.com/NVIDIA/nccl/commit/a93cc034b7faf4200f24d3721a65bb9d5f5fb67c) (`fix load balance problem when nic is a lag port with queue affinity`) correctly exchanges QP connection information per context and fixes the self-loop connection. It provides a modest improvement in this test, but it does not program the local QPC `lag_tx_port_affinity`, so it does not fully solve the physical-port imbalance.

## Implementation

### Context-level port selection

GDAKI creates QPs in context-major order, with one QP for each scale-out rank in a context. Selecting a port from the raw QP index would therefore place peer QPs from the same context on different ports and did not produce the intended balance in this topology.

The high-level QP creation path now computes:

```text
context_index = raw_qp_sequence_index / qps_per_context
```

Data and companion QPs use separate atomic sequence counters because they are separate context-major sequences. `context_index` is passed through the existing DOCA QP `user_index` field.

`DOCA_LAG_TX_PORT_AFFINITY_GROUP_SIZE` supplies `qps_per_context`. It must match the number of scale-out/RDMA ranks represented in each context. For this two-node test it is `2`.

### QPC programming

`DOCA_LAG_TX_PORT_AFFINITY` accepts:

| Value | Behavior |
|---:|---|
| unset or `0` | Do not request LAG TX-port affinity |
| `1` | Pin QPs to LAG port 1 |
| `2` | Pin QPs to LAG port 2 |
| `3` | Alternate context indices between LAG ports 1 and 2 |

For mode `3`, the selected port is:

```text
lag_port = (context_index % 2) + 1
```

The patch writes `lag_tx_port_affinity` in two places:

1. `CREATE_QP`, for devices/firmware that honor the field at creation time.
2. An RTS-to-RTS `MODIFY_QP`, with `MLX5_QPC_OPT_MASK_RTS2RTS_LAG_TX_PORT_AFFINITY`, after the normal RTR-to-RTS transition.

On the tested firmware, setting only the `CREATE_QP` field did not change physical-port selection. The post-RTS modify produced deterministic single-port placement in pinning tests and approximately 50/50 traffic distribution in alternating mode.

The modified files are:

```text
src/transport/net_ib/gdaki/doca-gpunetio/src/doca_gpunetio_high_level.cpp
src/transport/net_ib/gdaki/doca-gpunetio/src/doca_verbs_qp.cpp
```

## Test system

Both nodes have the same topology and software/firmware configuration.

| Component | Configuration per node |
|---|---|
| GPU | 8 x NVIDIA H20; driver 570.133.20 |
| GPU fabric | NV18 connectivity between every GPU pair |
| CPU topology | Two NUMA nodes; GPUs 0-3 on NUMA 0 and GPUs 4-7 on NUMA 1 |
| RDMA devices | 4 logical RoCE devices: `mlx5_bond_0` through `mlx5_bond_3` |
| NIC/controller | NVIDIA/Mellanox MT43244 BlueField-3 integrated ConnectX-7 network controller; PCI ID `15b3:a2dc` |
| Physical links | 8 x 200,000 Mb/s Ethernet links, `reth0` through `reth7` |
| Bonding | 4 x two-member IEEE 802.3ad bonds; nominal 400 Gb/s per bond |
| Bond policy | Linux `xmit_hash_policy=layer3+4`; mlx5 `lag_port_select_mode=queue_affinity` |
| Link state | Active RoCE/Ethernet, active MTU 4096 |
| NIC firmware | 32.39.3920, PSID `MT_0000001093` |
| mlx5 driver | `mlx5_core` 23.10-3.2.2.2 (reported on node 0) |
| Kernel | 5.10.134-16.3.al8.x86_64 |
| NCCL | 2.30.7+cuda12.8, GDAKI transport |

The Linux bond, physical netdev, PCI function, logical RDMA device, and GPU-rank placement are:

| GPU ranks | Logical RDMA device | Linux bond members | PCI functions |
|---|---|---|---|
| 0-1 | `mlx5_bond_0` | `bond0 = reth0 + reth1` | `0000:7f:00.0`, `0000:7f:00.1` |
| 2-3 | `mlx5_bond_1` | `bond1 = reth2 + reth3` | `0000:c7:00.0`, `0000:c7:00.1` |
| 4-5 | `mlx5_bond_2` | `bond2 = reth4 + reth5` | `0001:08:00.0`, `0001:08:00.1` |
| 6-7 | `mlx5_bond_3` | `bond3 = reth6 + reth7` | `0001:a2:00.0`, `0001:a2:00.1` |

Thus, this system does have two GPU ranks sharing each logical RDMA/IB device. The topology has only four logical HCAs for eight GPUs. Within each pair, one GPU has the closest PIX path and the other reaches the same HCA through a longer path in the same NUMA domain.

<details>
<summary><code>nvidia-smi topo -m</code> (same on both nodes)</summary>

```text
	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	NIC2	NIC3	CPU Affinity	NUMA Affinity
GPU0	 X 	NV18	NV18	NV18	NV18	NV18	NV18	NV18	NODE	NODE	SYS	SYS	0-47,96-143	0
GPU1	NV18	 X 	NV18	NV18	NV18	NV18	NV18	NV18	PIX	NODE	SYS	SYS	0-47,96-143	0
GPU2	NV18	NV18	 X 	NV18	NV18	NV18	NV18	NV18	NODE	NODE	SYS	SYS	0-47,96-143	0
GPU3	NV18	NV18	NV18	 X 	NV18	NV18	NV18	NV18	NODE	PIX	SYS	SYS	0-47,96-143	0
GPU4	NV18	NV18	NV18	NV18	 X 	NV18	NV18	NV18	SYS	SYS	PIX	NODE	48-95,144-191	1
GPU5	NV18	NV18	NV18	NV18	NV18	 X 	NV18	NV18	SYS	SYS	NODE	NODE	48-95,144-191	1
GPU6	NV18	NV18	NV18	NV18	NV18	NV18	 X 	NV18	SYS	SYS	NODE	PIX	48-95,144-191	1
GPU7	NV18	NV18	NV18	NV18	NV18	NV18	NV18	 X 	SYS	SYS	NODE	NODE	48-95,144-191	1
NIC0	NODE	PIX	NODE	NODE	SYS	SYS	SYS	SYS	 X 	NODE	SYS	SYS
NIC1	NODE	NODE	NODE	PIX	SYS	SYS	SYS	SYS	NODE	 X 	SYS	SYS
NIC2	SYS	SYS	SYS	SYS	PIX	NODE	NODE	NODE	SYS	SYS	 X 	NODE
NIC3	SYS	SYS	SYS	SYS	NODE	NODE	PIX	NODE	SYS	SYS	NODE	 X

NIC0: mlx5_bond_0
NIC1: mlx5_bond_1
NIC2: mlx5_bond_2
NIC3: mlx5_bond_3
```

</details>

## Benchmark

The workload is DeepEP v2 elastic EP across two nodes and 16 total GPU ranks:

```text
tests/elastic/test_ep.py
  --num-processes 8
  --num-tokens 8192
  --hidden 6144
  --num-topk 8
  --num-experts 512
  --num-sms 12
  --num-allocated-qps 49
  --num-qps 49
  --allow-hybrid-mode 1
```

Common communication settings were GDAKI, `NCCL_CROSS_NIC=0`, and randomized RoCE UDP source ports. The UDP source-port fix was present in all three variants, so the comparison below isolates the community QP-exchange fix and this LAG-affinity change.

The proposed configuration adds:

```bash
export DOCA_LAG_TX_PORT_AFFINITY=3
export DOCA_LAG_TX_PORT_AFFINITY_GROUP_SIZE=2
```

The comparison uses the first identical benchmark case in all three launches:

```text
do_handle_copy=1
expert_alignment=128
use_fp8_dispatch=1
num_bias=0
with_previous_event=0
async_with_compute_stream=0
allocate_on_comm_stream=0
```

Each row is one two-node launch and contains measurements from all 16 ranks. `SO` is the scale-out throughput reported by DeepEP. Throughput is printed as an integer by the benchmark, so percentage changes are approximate. For cached dispatch, the table reports min/mean/max rank throughput and mean rank latency. For combine, the slowest rank gates the collective, so the table also reports minimum rank throughput and maximum rank latency.

| Variant | `a93cc03` | LAG affinity | Cached dispatch SO, min/mean/max (GB/s) | Cached mean latency (us) | Combine SO, min/mean/max (GB/s) | Combine worst latency (us) |
|---|---:|---:|---:|---:|---:|---:|
| Community fix reverted | No | Off | 34 / 35.00 / 36 | 3003.5 | 34 / 37.25 / 41 | 5887 |
| NCCL 2.30.7 branch with community fix | Yes | Off | 37 / 37.00 / 37 | 2864.0 | 36 / 37.00 / 40 | 5630 |
| Community fix + proposed LAG affinity | Yes | Mode 3, group 2 | 42 / 42.00 / 42 | 2496.4 | 41 / 41.69 / 42 | 4848 |

Relative to the branch with [a93cc03](https://github.com/NVIDIA/nccl/commit/a93cc034b7faf4200f24d3721a65bb9d5f5fb67c) enabled but LAG affinity disabled, the proposed change provides:

- cached dispatch mean throughput: 37 to 42 GB/s, approximately **+13.5%**;
- cached dispatch mean latency: 2864.0 to 2496.4 us, approximately **-12.8%**;
- combine minimum-rank throughput: 36 to 41 GB/s, approximately **+13.9%**; and
- combine worst-rank latency: 5630 to 4848 us, approximately **-13.9%**.

Relative to the run with [a93cc03](https://github.com/NVIDIA/nccl/commit/a93cc034b7faf4200f24d3721a65bb9d5f5fb67c) reverted, cached dispatch improves by approximately 20%, and combine worst-rank latency decreases by approximately 17.6%.

The improvement is also more uniform across ranks: cached dispatch changes from a 34-36 GB/s or 37 GB/s distribution to 42 GB/s on every rank, while combine narrows from 36-40 GB/s in the community-fix baseline to 41-42 GB/s.

In a separate five-run stability check with the same SM12/QP49 affinity configuration, cached dispatch was 42 GB/s in every run and combine remained between 41.75 and 42 GB/s. Physical-port counters showed approximately 50/50 traffic within every `reth` pair, instead of the approximately 75/25 worst cases seen without explicit affinity.

network traffic monitor:

<img width="4100" height="8888" alt="localhost_5001_" src="https://github.com/user-attachments/assets/32e38d94-8fa2-4d76-8500-51005a222faa" />


## Validation

- Built successfully with `make -j16 src.build`.
- Verified that leaving `DOCA_LAG_TX_PORT_AFFINITY` unset does not request a LAG-affinity QPC modification.
- Verified that the post-RTS affinity changes physical-interface selection, including deterministic 100/0 behavior in a deliberately unbalanced mapping.
- Verified alternating mode produces an approximately 50/50 split for all four two-member bonds.
- Verified the measured two-node DeepEP case and performance across all 16 ranks.

## Scope and limitations

- This is an opt-in change for the GDAKI/DOCA path; other NCCL transports are not affected.
- Mode `3` currently targets a two-member mlx5 LAG.
- `DOCA_LAG_TX_PORT_AFFINITY_GROUP_SIZE` must match the number of peer QPs created per context. A future cleanup could pass the GIN communicator rank count directly into the DOCA QP creation layer and remove this deployment-specific parameter.
- The UDP source-port randomization remains useful for fabric ECMP and should be retained. It solves a different layer of load balancing and does not replace local QPC LAG affinity.
