### PR TITLE
fix: avoid indefinite hang in gin gdaki init

### DIFF
--- a/src/transport/net_ib/gin.cc
+++ b/src/transport/net_ib/gin.cc
@@ -45,7 +45,19 @@ static ncclResult_t ncclGinIbGdrGpuSupport(bool gdaki) {
 
 NCCL_PARAM(GinType, "GIN_TYPE", -1);
 NCCL_PARAM(GinIbTc, "GIN_IB_TC", -1);
+NCCL_PARAM(GinIbAllGatherTimeoutSec, "GIN_IB_ALLGATHER_TIMEOUT_SEC", 180);
 extern int64_t ncclParamIbTc();
+
+// Break out of the GIN ring allgather if a ring neighbor never responds (e.g. when NICs on
+// disjoint rails are not mutually reachable over RDMA).
+static ncclResult_t ncclGinIbAllGatherCheckDeadline(struct ncclGinIbCollComm* cComm, uint64_t deadline) {
+  if (ncclParamGinIbAllGatherTimeoutSec() <= 0 || clockNano() < deadline) return ncclSuccess;
+  WARN("NET/IB GIN: ring allgather timed out after %llds (rank %d/%d). "
+       "Ring-neighbor NICs are likely not reachable over RDMA, e.g., due to cross-rail disconnectivity. "
+       "Check fabric connectivity, or increase NCCL_GIN_IB_ALLGATHER_TIMEOUT_SEC.",
+       (long long)ncclParamGinIbAllGatherTimeoutSec(), cComm->rank, cComm->nranks);
+  return ncclRemoteError;
+}
 
 static std::mutex ncclGinIbGdakiLockMutex;
 static int ncclGinIbGdakiNDevs = -1;
@@ -115,7 +127,9 @@ static ncclResult_t ncclGinIbAllGather(struct ncclGinIbCollComm* cComm, void* sr
   memcpy((void*)((uintptr_t)recvBuf + speer * len), srcBuf, len);
   for (int i = 0; i < cComm->nranks - 1; i++) {
     rpeer = (speer - 1 + cComm->nranks) % cComm->nranks;
+    uint64_t deadline = clockNano() + (uint64_t)ncclParamGinIbAllGatherTimeoutSec() * 1000000000ull;
     while (srequest == NULL || rrequest == NULL) {
+      NCCLCHECKGOTO(ncclGinIbAllGatherCheckDeadline(cComm, deadline), status, out);
       rbuf = (void*)((uintptr_t)recvBuf + rpeer * len);
       tag = NCCL_GIN_IB_ALLGATHER_TAG;
       if (srequest == NULL) {
@@ -128,6 +142,7 @@ static ncclResult_t ncclGinIbAllGather(struct ncclGinIbCollComm* cComm, void* sr
       }
     }
     while (srequest || rrequest) {
+      NCCLCHECKGOTO(ncclGinIbAllGatherCheckDeadline(cComm, deadline), status, out);
       if (rrequest) NCCLCHECKGOTO(ncclNetIb.test(rrequest, &done, NULL), status, out);
       if (done) rrequest = NULL;
       if (srequest) NCCLCHECKGOTO(ncclNetIb.test(srequest, &done, NULL), status, out);


### PR DESCRIPTION
## Description

Fix indefinite hang in GIN GDAKI init when ring-neighbor NICs are unreachable

**Problem:** `ncclGinIbAllGather` spins forever if the RDMA fabric between neighboring
ranks is disconnected (e.g., NICs on disjoint rails). The receiver's CTS write never
lands, and the loop has no timeout, error CQE, or abort flag, so jobs hang silently in
`ncclDevCommCreate` until killed externally.

**Solution:** This PR adds a per-ring-step deadline checked in both the post and completion
loops, gated by `NCCL_GIN_IB_ALLGATHER_TIMEOUT_SEC` (default 180s, <=0 disables).
On expiry, it issues a WARN with ring-neighbor rank info and returns
`ncclRemoteError` through existing cleanup paths. This works for all IB collectives during
devComm setup since they call this allgather underneath (allToAll, rkey exchanges, P2P barrier).

## Related Issues

None

## Changes & Impact

No change of any public or internal NCCL APIs

Changes:
- Adds `NCCL_PARAM(GinIbAllGatherTimeoutSec, "GIN_IB_ALLGATHER_TIMEOUT_SEC", 180)`
- Adds `ncclGinIbAllGatherCheckDeadline()` helper
- Inserts deadline checks into both while loops of `ncclGinIbAllGather()`
- No API changes, no breaking changes
- Backward compatible: set `NCCL_GIN_IB_ALLGATHER_TIMEOUT_SEC=0` to disable this check

## Performance Impact

- `clockNano()` is called once per ncclNetIb.isend/irecv in `ncclGinIbAllGather()` - negligible
- No measurable overhead in the normal (connected) path
- Tested: verified fail-fast behavior on cross-rail disconnected NICs

