### PR TITLE
EFA GDA : make store to mmio explicit and spin with relaxed loads

### DIFF
--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -70,16 +70,16 @@ NCCL_DEVICE_INLINE static void scopedAtomicAdd(uint64_t* ptr, uint64_t val) {
 
 /* ── NIC-written hardware counter (FI_WRITE / FI_REMOTE_WRITE) ────── */
 
-/* Read a NIC-written hardware counter from GPU memory. Uses system-scope
- * acquire so the load is coherent with the NIC's PCIe writes (bypasses
- * GPU caches) and subsequent operations on this thread cannot be
- * reordered to before the load. The acquire matches libfabric's
- * local-completion contract: when this load observes the counter has
- * reached a target, the NIC's prior side effects (e.g. source-buffer
- * DMA-reads complete) are ordered-before whatever this thread does
- * next (e.g. overwriting that source buffer or reusing the slot). */
+/* Read a NIC-written hardware counter from GPU memory. System scope makes
+ * the load coherent with the NIC's PCIe writes (bypasses GPU caches).
+ * Acquire is the default and matches libfabric's local-completion contract:
+ * when this load observes the counter has reached a target, the NIC's prior
+ * side effects (e.g. source-buffer DMA-reads complete) are ordered-before
+ * whatever this thread does next (e.g. overwriting that source buffer or
+ * reusing the slot). */
+template <cuda::memory_order Order = cuda::memory_order_acquire>
 NCCL_DEVICE_INLINE static uint64_t hwCounterLoad(uint64_t* ptr) {
-  return scopedAtomicLoad<cuda::thread_scope_system, cuda::memory_order_acquire>(ptr);
+  return scopedAtomicLoad<cuda::thread_scope_system, Order>(ptr);
 }
 
 /* ── ringDoorbell: shared doorbell-ring used by the post-path ring sites ─
@@ -238,7 +238,7 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
        * <= max_batch, so one doorbell drains it. If we do not yet hold the
        * turn, a lower group does and will either ring (advancing db_rung) or
        * hand off (advancing base_ref); keep checking until our chunk fits. */
-      while (chunk_next - dbrung_ref.load(cuda::memory_order_acquire) > max_batch) {
+      while (chunk_next - dbrung_ref.load(cuda::memory_order_relaxed) > max_batch) {
         if (base_ref.load(cuda::memory_order_acquire) == chunk_base) {
           uint32_t db_rung = dbrung_ref.load(cuda::memory_order_relaxed);
           if (chunk_base != db_rung) {   /* deferred, already-written batch */
@@ -247,8 +247,7 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
         }
       }
       /* SQ ring-overflow backpressure on the chunk's high-water slot.
-       * System-scope acquire so we see the latest NIC FI_WRITE update
-       * and the WQE stores below can't hoist above this load.
+       * Poll the NIC FI_WRITE counter with system-scope relaxed loads.
        *
        * In-flight count is computed as a 31-bit modular difference
        * (producer chunk_next minus the NIC FI_WRITE counter): the HW
@@ -256,7 +255,8 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
        * widened subtraction would underflow once either side wraps.
        * The true in-flight depth is bounded by sq_size (4096) « 2^31,
        * so the masked difference is exact. */
-      while (((chunk_next - (uint32_t)hwCounterLoad(local_cntr_ptr)) & EFA_CNTR_MASK) > sq_size_val) {
+      while (((chunk_next - (uint32_t)hwCounterLoad<cuda::memory_order_relaxed>(local_cntr_ptr)) & EFA_CNTR_MASK) >
+             sq_size_val) {
         /* spin */
       }
     }
@@ -305,7 +305,7 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
 
     if (is_leader) {
       /* Doorbell-order rendezvous: take the turn in strict slot order. */
-      while (base_ref.load(cuda::memory_order_acquire) != chunk_base) {
+      while (base_ref.load(cuda::memory_order_relaxed) != chunk_base) {
         /* spin */
       }
 

--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -105,7 +105,8 @@ template <ncclGinResourceSharingMode mode>
 NCCL_DEVICE_INLINE static void ringDoorbell(efa_cuda_qp* qp, uint64_t* submitted_count_ptr,
                                             cuda::atomic_ref<uint32_t, ncclGinScope<mode>>& dbrung_ref,
                                             uint32_t db_rung, uint32_t target) {
-  *qp->sq.wq.db = target;
+  uint64_t dbAddr = (uint64_t)__cvta_generic_to_global(qp->sq.wq.db);
+  asm volatile("st.mmio.relaxed.sys.global.b32 [%0], %1;" : : "l"(dbAddr), "r"(target) : "memory");
   /* Order the doorbell MMIO write. Use acq_rel (MEMBAR.ALL.SYS) instead of
    * __threadfence_system (MEMBAR.SC.SYS). */
   cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
@@ -285,7 +286,17 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
       EFA_SET(&wr.meta.ctrl2, EFA_IO_TX_META_DESC_PHASE, wqe_phase);
       uint64_t* src = (uint64_t*)&wr;
       uint64_t* dst = (uint64_t*)(qp->sq.wq.buf + sq_idx * sizeof(efa_io_tx_wqe));
-      for (int i = 0; i < 8; i++) dst[i] = src[i];
+      /* One final system-scope fence publishes the complete WQE after these
+       * relaxed MMIO stores. */
+      uint64_t dstAddr = (uint64_t)__cvta_generic_to_global(dst);
+#pragma unroll
+      for (int i = 0; i < 8; i++) {
+        uint64_t value = src[i];
+        asm volatile("st.mmio.relaxed.sys.global.b64 [%0], %1;"
+                     :
+                     : "l"(dstAddr + i * sizeof(uint64_t)), "l"(value)
+                     : "memory");
+      }
       /* Publish this group's WQE writes to system scope so they are visible
        * to the NIC whenever any doorbell rings a slot in this range. */
       cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);


### PR DESCRIPTION
Use MMIO stores for EFA GDA WQE and doorbell writes, and relaxed loads for maximum inflight, SQ capacity and doorbell-order spin-loop polling to reduce post-path ordering overhead.

