### PR TITLE
Fix memory leak in allocateSpilled

### DIFF
--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -267,13 +267,22 @@ void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, 
     }
   }
 
-  { // If the next hunk we're going to allocate wouldn't be big enough but the
+  { // If the next hunk existing or to be allocated wouldn't be big enough but the
     // Unhunk proxy fits in the current hunk then go allocate as unhunked.
     size_t nextSize = (top ? top->size : 0) + (64 << 10);
     constexpr size_t maxAlign = 64;
     if (nextSize < sizeof(struct Hunk) + maxAlign + size) {
       uintptr_t uproxy = (me->topFrame.bumper + alignof(Unhunk) - 1) & -uintptr_t(alignof(Unhunk));
       if (uproxy + sizeof(struct Unhunk) <= me->topFrame.end) goto unhunked;
+    }
+
+    // The Unhunk proxy can fit in the next hunk if existing
+    if (top && top->above) {
+      struct Hunk* top1 = top->above;
+      me->topFrame.hunk = top1;
+      me->topFrame.end = reinterpret_cast<uintptr_t>(top1) + top1->size;
+      me->topFrame.bumper = reinterpret_cast<uintptr_t>(top1) + sizeof(struct Hunk);
+      goto unhunked;
     }
 
     // At this point we must need another hunk, either to fit the object


### PR DESCRIPTION
## Description

<!-- Clearly describe what the PR does and why -->

When function `allocateSpilled` creates a new Hunk, it unconditionally overwrites `top->above` with the new Hunk pointer. If `top->above` already pointed to an existing Hunk left behind by a prior Push/Pop cycle, that existing Hunk becomes detached from the chain and leaks.

More details can be found in the issue corresponding to this PR.

## Related Issues

<!-- Reference any related issues or PRs -->

Fixes #2324

## Changes & Impact

<!-- Note any breaking changes or API modifications -->

- None
- Bug fix within function allocateSpilled only

## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

- None