### PR TITLE
Fix the logic of Intel UPI bandwidth selection

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -68,10 +68,11 @@ static ncclResult_t ncclTopoGetInterCpuBw(struct ncclTopoNode* cpu, float* bw) {
     return ncclSuccess;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_INTEL) {
-    *bw = cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_ERP ? ERP_QPI_BW :
-          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SRP ? SRP_QPI_BW :
-          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SKL ? SKL_QPI_BW :
-                                                            BDW_QPI_BW;
+    *bw = cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_XEON6 ? XEON6_QPI_BW :
+          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_EMR   ? EMR_QPI_BW :
+          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SPR   ? SPR_QPI_BW :
+          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SKL   ? SKL_QPI_BW :
+                                                              BDW_QPI_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
     *bw = AMD_BW;
@@ -745,8 +746,9 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
       int familyId, modelId;
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
-      cpu->cpu.model = (familyId == 6 && modelId >= 0xCF) ? NCCL_TOPO_CPU_MODEL_INTEL_ERP :
-                       (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SRP :
+      cpu->cpu.model = (familyId == 6 && modelId == 0xCF) ? NCCL_TOPO_CPU_MODEL_INTEL_EMR :
+                       (familyId == 6 && modelId >= 0xAD) ? NCCL_TOPO_CPU_MODEL_INTEL_XEON6 :
+                       (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SPR :
                        (familyId == 6 && modelId >= 0x55) ? NCCL_TOPO_CPU_MODEL_INTEL_SKL :
                                                             NCCL_TOPO_CPU_MODEL_INTEL_BDW;
     } else if (cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -26,8 +26,9 @@
 #define AMD_BW 16.0
 #define BDW_QPI_BW 6.0
 #define SKL_QPI_BW 10.0
-#define SRP_QPI_BW 22.0
-#define ERP_QPI_BW 40.0
+#define SPR_QPI_BW 22.0
+#define EMR_QPI_BW 40.0
+#define XEON6_QPI_BW 40.0
 #define ZPI_BW 6.0
 #define YONGFENG_ZPI_BW 9.0
 #define P9_BW 32.0

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -85,8 +85,9 @@ ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncc
 #define NCCL_TOPO_CPU_VENDOR_MIXED 4
 #define NCCL_TOPO_CPU_MODEL_INTEL_BDW 1
 #define NCCL_TOPO_CPU_MODEL_INTEL_SKL 2
-#define NCCL_TOPO_CPU_MODEL_INTEL_SRP 3
-#define NCCL_TOPO_CPU_MODEL_INTEL_ERP 4
+#define NCCL_TOPO_CPU_MODEL_INTEL_SPR 3
+#define NCCL_TOPO_CPU_MODEL_INTEL_EMR 4
+#define NCCL_TOPO_CPU_MODEL_INTEL_XEON6 5
 #define NCCL_TOPO_CPU_MODEL_YONGFENG 1
 ncclResult_t ncclTopoCpuType(struct ncclTopoSystem* system, int* arch, int* vendor, int* model);
 ncclResult_t ncclTopoGetGpuCount(struct ncclTopoSystem* system, int* count);


### PR DESCRIPTION
Intel released the following server CPU platform with family/model number and improved the UPI clock from 20GT/s (EMR) to XEON6 24GT/s. This patch enables Xeon6(GNR/SRF/CWF) to select the proper UPI bandwidth.

| CPU Name                        | Abbr. | Family Number | Model Number |
| ------------------------------- | ----- | ------------- | ------------ |
| **Skylake-SP**                       | SKL   | 6             | 85 (0x55)    |
| **Ice Lake-SP**                      | ICX   | 6             | 106 (0x6A)   |
| **Sapphire Rapids**              | SPR   | 6             | 143 (0x8F)   |
| **Emerald Rapids**                | EMR   | 6             | 207 (0xCF)   |
| **Granite Rapids (Xeon 6)**     | GNR   | 6             | 173 (0xAD)   |
| **Sierra Forest (Xeon 6)**      | SRF   | 6             | 175 (0xAF)   |
| **Clearwater Forest (Xeon 6+)** | CWF   | 6             | 221 (0xDD)   |

Also fix #2107

## Description

<!-- Clearly describe what the PR does and why -->

## Related Issues

#2107 

## Changes & Impact

The UPI bandwidth selection for Intel Xeon6 CPUs.

## Performance Impact

Expect to use more NCCL ring channels with the increase of UPI bandwidth.
