### PR TITLE
gin: Make signal from C bindings respect ginStrongLegacySignals

### DIFF
--- a/src/include/nccl_device/impl/gin__funcs.h
+++ b/src/include/nccl_device/impl/gin__funcs.h
@@ -517,6 +517,7 @@ NCCL_DEVICE_INLINE void ncclGinPut_v2(ncclGin_C* net, ncclTeam team, int peer, n
   if (isSignal) {
     signal.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
     signal.indexedSignal.signalId = signalId;
+    signal.isStrong = net->comm.ginStrongLegacySignals;
   }
   if (coop.thread_rank() == 0) {
     ncclGinCall<ncclGinApi_Put>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer), /*hasWins=*/true,
@@ -692,6 +693,7 @@ NCCL_DEVICE_INLINE void ncclGinPutValue_v2(ncclGin_C* net, ncclTeam team, int pe
     if (isSignal) {
       signal.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
       signal.indexedSignal.signalId = signalId;
+      signal.isStrong = net->comm.ginStrongLegacySignals;
     }
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
     // Dispatch based on size to call with appropriate type
@@ -780,6 +782,7 @@ NCCL_DEVICE_INLINE void ncclGinSignal_v2(ncclGin_C* net, ncclTeam team, int peer
   if (isSignal) {
     signal.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
     signal.indexedSignal.signalId = signalId;
+    signal.isStrong = net->comm.ginStrongLegacySignals;
   }
   if (coop.thread_rank() == 0) {
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);


### PR DESCRIPTION
## Description

As of now, the GIN signals issued from C-style bindings are legacy signals without strength semantics. However, it does not follow the new ginStrongLegacySignals flags like C++ API. So the users of C bindings can only issue weak signal, completely breaking applications that assume the legacy API semantics and creating unnecessary hurdles for programmers.

This commit introduces ginStrongLegacySignals to C bindings so that it is aligned with the legacy semantics of CUDA C++ APIs. In theory, the C bindings should allow users to issue strong or weak signals but it is beyond scope of this commit.


## Related Issues

N/A

## Changes & Impact

The GIN signals from C bindings now follows ginStrongLegacySignals flags in the associated devcomm like their CUDA C++ counterparts.

## Performance Impact

N/A

