### PR TITLE
Tune two-rank Blackwell Ring LL128 AllReduce

### DIFF
--- a/src/tuning/ring.cc
+++ b/src/tuning/ring.cc
@@ -97,6 +97,18 @@ ncclResult_t ncclTuningRingModelSim(struct ncclTuningInput_t* const inputs, stru
   }
   float lat = inputs->comm->tuningContext.generalLatencies[inputs->func][tuning->algo][tuning->proto];
   float bw = inputs->comm->tuningContext.generalBandwidths[inputs->func][tuning->algo][tuning->proto];
+
+  // Two-rank Blackwell Ring/LL128 AllReduce does not reach the generic
+  // per-channel LL128 bandwidth cap; adjust the modeled bandwidth accordingly.
+  if (inputs->comm->nNodes == 1 &&
+      inputs->comm->nRanks == 2 &&
+      inputs->comm->minCompCap >= 100 &&
+      inputs->comm->graphs[NCCL_ALGO_RING].typeIntra == PATH_NVL &&
+      inputs->func == ncclFuncAllReduce &&
+      tuning->algo == NCCL_ALGO_RING &&
+      tuning->proto == NCCL_PROTO_LL128) {
+    bw *= 0.60f;
+  }
   if (bw == -1.0f) {
     tuning->valid = 0;
     tuning->timeUs = -1.0;


### PR DESCRIPTION
## Summary

Adjust the Ring/LL128 bandwidth model for single-node, two-rank Blackwell NVLink AllReduce.

On B200, the generic Ring/LL128 model predicts 640 GB/s for the 2-rank case, while measured throughput is consistently about 382–386 GB/s across all three GPU pairs on the node. This causes AUTO selection to prefer LL128 over Simple for large messages even though LL128 is substantially slower in practice.

The 3-rank Ring/LL128 model is already accurate (about 480 GB/s modeled vs about 479 GB/s measured), so this change is intentionally restricted to the 2-rank path rather than changing the global Blackwell LL128 per-channel cap.

## Change

Scale the modeled Ring/LL128 bandwidth by 0.60 for:

- single-node communicators
- exactly 2 ranks
- Blackwell or newer (`minCompCap >= 100`)
- NVLink Ring intra-node path
- AllReduce
- Ring + LL128

## Validation

Environment:

- NVIDIA B200
- CUDA 13.2.1
- NCCL 2.31.2

Forced 1 GiB Ring/LL128 measurements across all GPU pairs:

| GPU pair | out-of-place busbw | in-place busbw |
|---|---:|---:|
| 0-1 | 383.85 GB/s | 386.42 GB/s |
| 0-2 | 381.74 GB/s | 383.78 GB/s |
| 1-2 | 381.92 GB/s | 384.06 GB/s |

With the correction, AUTO selects Ring/Simple instead of Ring/LL128 throughout the tested 32 MiB–1 GiB range on 2 GPUs. At 1 GiB, measured AUTO latency improves from roughly 2.8 ms with Ring/LL128 to about 1.89 ms with Ring/Simple.

The 3-GPU path remains on Ring/Simple and is unaffected by the 2-rank-specific correction.