### PR TITLE
Tune Blackwell symmetric ReduceScatter CTA geometry

### DIFF
--- a/src/tuning/sym_model.cc
+++ b/src/tuning/sym_model.cc
@@ -185,6 +185,28 @@ static void queryModel_gin(struct ncclTuningInput_t* input, ncclSymkKernelId k, 
   }
 }
 
+static bool reduceScatterDeepGeometryEligible(
+    ncclSymkKernelId k, size_t nBytes, int nRanks, int nBlocks) {
+  if (nBlocks <= 0 || nRanks <= 0) return false;
+
+  size_t chunkBytes;
+  switch (k) {
+  case ncclSymkKernelId_ReduceScatter_LD:
+    chunkBytes = ncclSymkBytePerChunk;
+    break;
+  case ncclSymkKernelId_ReduceScatter_TmaLD:
+    chunkBytes = ncclSymkDeepBytePerChunk;
+    break;
+  default:
+    return false;
+  }
+
+  size_t chunks = nBytes / chunkBytes;
+  size_t chunkGroup = size_t(nRanks) * nBlocks;
+
+  return chunks >= chunkGroup && chunks % chunkGroup == 0;
+}
+
 static void queryModel_lsa(struct ncclTuningInput_t* input, ncclSymkKernelId k, size_t nBytes, float* timeUs,
                            int* nBlocks) {
   constexpr double LL_BusFactor = 9; // 2X the bytes, plus some processing, plus no unrolling
@@ -311,6 +333,22 @@ static void queryModel_lsa(struct ncclTuningInput_t* input, ncclSymkKernelId k, 
       // Decrease max block count until it is eligible for the current msg size.
       while (nMaxBlocks > nMinBlocks && !ncclSymkTmaDeepEligible(comm, k, maxWorkBytes, nMaxBlocks)) {
         nMaxBlocks -= (nMaxBlocks == 2 ? 1 : 2);
+      }
+    }
+  }
+
+  // ReduceScatter's deep path rounds work down to a multiple of
+  // nRanks * nBlocks. Prefer a CTA count that exactly divides the available
+  // deep-path chunks before falling back to the generic bandwidth model.
+  if (comm->cudaArch >= 1000 &&
+      (k == ncclSymkKernelId_ReduceScatter_LD ||
+       k == ncclSymkKernelId_ReduceScatter_TmaLD) &&
+      nMinBlocks != nMaxBlocks) {
+    for (int bn = nMaxBlocks; bn >= nMinBlocks; bn -= (bn == 2 ? 1 : 2)) {
+      if (reduceScatterDeepGeometryEligible(k, nBytes, nRanks, bn)) {
+        *nBlocks = bn;
+        *timeUs = model(busBytes, baseLat, bn, smBw, busMultiplier, peakBw);
+        return;
       }
     }
   }


### PR DESCRIPTION
## Summary

Improve symmetric ReduceScatter CTA selection on Blackwell by accounting for the deep-path chunk geometry used by the LD and TmaLD kernels.

The existing tuning model treats CTA scaling primarily as a smooth bandwidth curve. However, the ReduceScatter deep path rounds work down to a multiple of `nRanks * nBlocks`, which creates large performance discontinuities between nearby CTA counts.

This change prefers CTA counts that exactly divide the available deep-path chunks for `ReduceScatter_LD` and `ReduceScatter_TmaLD` on Blackwell, while preserving the existing model as a fallback.

This is a model-based alternative/complement to the measured crossover approach in #2307, rather than an attempt to duplicate its threshold logic.

## Motivation

On 2x NVIDIA B200, BF16 ReduceScatter with 4 MiB total input, I observed the following LD CTA discontinuity around otherwise nearby CTA counts:

- 31 CTAs: ~20.20 us
- 32 CTAs: ~14.85 us
- 33 CTAs: ~24.52 us
- 63 CTAs: ~15.09 us
- 64 CTAs: ~13.62 us

The original automatic selection for the 4 MiB case was approximately:

- `ReduceScatter_LD`, 12 CTAs
- ~29.4 us
- ~71 GB/s bus bandwidth

With this change, automatic selection becomes:

- `ReduceScatter_LD`, 64 CTAs
- 13.59 us
- 154.28 GB/s bus bandwidth

This is about 54% lower latency and ~2.17x higher bus bandwidth on this reproducer.

## Automatic selection / performance

2x B200, BF16 ReduceScatter, no `NCCL_SYM_KERNEL` or `NCCL_SYM_CTAS` override:

| Size | Automatic selection | Time |
| --- | --- | ---: |
| 1 MiB | LD / 32 CTAs | 10.71 us |
| 2 MiB | TmaLD / 32 CTAs | 12.56 us |
| 4 MiB | LD / 64 CTAs | 13.59 us |
| 8 MiB | LD / 64 CTAs | 16.71 us |
| 16 MiB | LD / 64 CTAs | 23.14 us |

All `nccl-tests` validation checks in this sweep completed with zero errors.

## Implementation

For Blackwell+ symmetric ReduceScatter LD/TmaLD, the tuner checks candidate CTA counts against the corresponding deep-path chunk size. A candidate is preferred when the available chunk count is at least `nRanks * nBlocks` and is exactly divisible by that grouping. If no candidate satisfies the geometry, selection falls back to the existing performance model.

## Validation

- `make -j8 src.build` succeeds on the clean branch.
- `git diff --check` passes.
- Tested with 2x NVIDIA B200 using `nccl-tests` ReduceScatter BF16/sum across 1, 2, 4, 8, and 16 MiB.
- Zero validation errors observed.

Related to #2305 and #2307.