### PR TITLE
[Fix] Prime socket handshake magic on the application thread

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -169,6 +169,11 @@ static void initOnceFunc() {
   NCCLCHECKGOTO(initGdrCopy(), initResult, exit);
   // Always initialize bootstrap network
   NCCLCHECKGOTO(bootstrapNetInit(), initResult, exit);
+  // Resolve the socket magic before background threads spawn: their getenv()
+  // would race with concurrent setenv() on glibc < 2.41 (glibc bug 15607).
+  // Cannot live in ncclEnvPluginInit(): it would re-enter ncclInitEnv()'s
+  // std::call_once via ncclGetEnv() and deadlock.
+  (void)ncclSocketDefaultMagic();
 
   initNvtxRegisteredEnums();
 exit:;

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -23,7 +23,9 @@ NCCL_PARAM(SocketMaxRecvBuff, "SOCKET_RCVBUF", -1);
 NCCL_PARAM(SocketMaxSendBuff, "SOCKET_SNDBUF", -1);
 
 uint64_t ncclSocketDefaultMagic(void) {
-  /* Default is the historical constant; env may override on first init. */
+  /* Default is the historical constant; env may override on first init.
+   * First call must be on an application thread (primed in initOnceFunc):
+   * getenv() from a NCCL background thread races with setenv() on glibc < 2.41. */
   static uint64_t cached = NCCL_SOCKET_MAGIC;
   static std::once_flag once;
   std::call_once(once, []() {


### PR DESCRIPTION
Fixes a startup SIGSEGV during comm init (closes #2354).

`ncclSocketDefaultMagic()` (new in 2.30.5) caches `NCCL_SOCKET_MAGIC` via `std::call_once`, so the first caller performs the `getenv()`. Today that first caller is usually the detached bootstrap root thread (bootstrap.cc: ncclSocketInit's default magic argument) or a RAS network thread. A first-time `getenv()` on a fresh background thread races with any concurrent `setenv()` in the process and segfaults on glibc < 2.41 (glibc bug 15607).

Fix: call `ncclSocketDefaultMagic()` once in `initOnceFunc()`, which every comm-creating path runs to completion on the application's thread before any NCCL background thread spawns. Background threads then only read the cached value. Placing it in `ncclEnvPluginInit()` instead would deadlock: `ncclSocketDefaultMagic()` -> `ncclGetEnv()` re-enters `ncclInitEnv()`'s `std::call_once`.