### PR TITLE
Gate KernelPhase device profiling on event mask

### DIFF
--- a/src/device/common.h
+++ b/src/device/common.h
@@ -289,12 +289,18 @@ __device__ __forceinline__ bool profilerEnabled(int workItemIdx) {
            ((struct ncclDevWorkColl*)ncclShmem.workStorage)[workItemIdx].profilerEnabled;
 }
 
+__device__ __forceinline__ bool profilerPhaseEnabled(int workItemIdx) {
+  return (ncclShmem.workType == ncclDevWorkTypeP2p) ?
+           ((struct ncclDevWorkP2p*)ncclShmem.workStorage)[workItemIdx].profilerPhaseEnabled :
+           ((struct ncclDevWorkColl*)ncclShmem.workStorage)[workItemIdx].profilerPhaseEnabled;
+}
+
 __device__ __forceinline__ void profilerPhase(int phaseId) {
   uint64_t ts = globaltimer();
   int idx = 0;
   uint64_t wc = ncclShmem.channel.workCounter + 1;
   for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-    if (!profilerEnabled(idx++)) continue;
+    if (!profilerPhaseEnabled(idx++)) continue;
     int slot = wc % MAX_PROFILER_EVENTS_PER_CHANNEL;
     ncclShmem.comm.workPhases[ncclShmem.channelId].data[slot].timestamps[phaseId] = ts;
   }
@@ -320,10 +326,8 @@ struct RunWorkBatch {
       __syncthreads();
     }
 
-    // Block-uniform gate so a profiler-off launch keeps the baseline cost (no extra
-    // sync/stamps). profilerEnabled(0) is uniform; nWorks>0 guards workStorage[0].
-    bool profOn = (ncclShmem.nWorks > 0) && profilerEnabled(0);
-    if (profOn && threadIdx.x == 0) profilerPhase(NCCL_KERNEL_PHASE_AFTER_OPEN);  // end of initial sync
+    bool phaseOn = (ncclShmem.nWorks > 0) && profilerPhaseEnabled(0);
+    if (phaseOn && threadIdx.x == 0) profilerPhase(NCCL_KERNEL_PHASE_AFTER_OPEN);
 
     NVCC_PRAGMA_UNROLL_DISABLED
     for (int w = 0; w < ncclShmem.nWorks; w++) {
@@ -339,8 +343,7 @@ struct RunWorkBatch {
       // coverity[device_thread_diverged:FALSE]
       if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work);
     }
-    // End of compute. Sync so thread 0's stamp reflects the last worker finishing.
-    if (profOn) {
+    if (phaseOn) {
       __syncthreads();
       if (threadIdx.x == 0) profilerPhase(NCCL_KERNEL_PHASE_BEFORE_CLOSE);
     }
@@ -352,34 +355,43 @@ __device__ __forceinline__ void profiler(int action) {
     int idx = 0;
     uint64_t wc = ncclShmem.channel.workCounter + 1;
     if (action == START) {
-      // workStarted timestamp+counter share one 16B slot (single cache line), so no
-      // fence is needed; the BEGIN phase stamp is ordered by STOP's fence below.
       for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-        if (!profilerEnabled(idx++)) continue;
+        bool enabled = profilerEnabled(idx);
+        bool phaseEnabled = profilerPhaseEnabled(idx);
+        idx++;
+        if (!enabled) continue;
         uint64_t ts = globaltimer();
         int slot = wc % MAX_PROFILER_EVENTS_PER_CHANNEL;
-        ncclShmem.comm.workPhases[ncclShmem.channelId].data[slot].timestamps[NCCL_KERNEL_PHASE_BEGIN] = ts;
+        if (phaseEnabled) ncclShmem.comm.workPhases[ncclShmem.channelId].data[slot].timestamps[NCCL_KERNEL_PHASE_BEGIN] = ts;
         ncclShmem.comm.workStarted[ncclShmem.channelId].data[slot].timestamp = ts;
         ncclShmem.comm.workStarted[ncclShmem.channelId].data[slot].counter = wc;
       }
     } else {
       bool fenceNeeded = false;
       for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-        if (!profilerEnabled(idx++)) continue;
+        bool enabled = profilerEnabled(idx);
+        bool phaseEnabled = profilerPhaseEnabled(idx);
+        idx++;
+        if (!enabled) continue;
         uint64_t ts = globaltimer();
         int slot = wc % MAX_PROFILER_EVENTS_PER_CHANNEL;
         ncclShmem.comm.workCompleted[ncclShmem.channelId].data[slot].timestamp = ts;
-        ncclShmem.comm.workPhases[ncclShmem.channelId].data[slot].timestamps[NCCL_KERNEL_PHASE_END] = ts;
-        fenceNeeded = true;
+        if (phaseEnabled) {
+          ncclShmem.comm.workPhases[ncclShmem.channelId].data[slot].timestamps[NCCL_KERNEL_PHASE_END] = ts;
+          fenceNeeded = true;
+        } else {
+          ncclShmem.comm.workCompleted[ncclShmem.channelId].data[slot].counter = wc;
+        }
       }
-      // workPhases stamps span the kernel and straddle cache lines, so fence once
-      // before publishing the counters to order all phase stamps ahead of them.
       if (fenceNeeded) {
         __threadfence_system();
         idx = 0;
         for (uint64_t wc2 = ncclShmem.channel.workCounter + 1; wc2 <= ncclShmem.channel.workCounter + ncclShmem.nWorks;
              wc2++) {
-          if (!profilerEnabled(idx++)) continue;
+          bool enabled = profilerEnabled(idx);
+          bool phaseEnabled = profilerPhaseEnabled(idx);
+          idx++;
+          if (!enabled || !phaseEnabled) continue;
           int slot = wc2 % MAX_PROFILER_EVENTS_PER_CHANNEL;
           ncclShmem.comm.workPhases[ncclShmem.channelId].data[slot].counter = wc2;
           ncclShmem.comm.workCompleted[ncclShmem.channelId].data[slot].counter = wc2;

--- a/src/device/sendrecv.h
+++ b/src/device/sendrecv.h
@@ -120,57 +120,64 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     uint32_t workRecvMask = shared->workRecvMask;
 
     __syncthreads(); // release scratch space used by shared->*
-    if (nWorks <= workIx) return;
+    bool phaseOn = (nWorks > 0) && profilerPhaseEnabled(0);
+    if (phaseOn && threadIdx.x == 0) profilerPhase(NCCL_KERNEL_PHASE_AFTER_OPEN);
 
-    // Thread range for whole work (send & recv combined)
-    int subtid = tid - workIx * nWarpPerWork * WARP_SIZE;
-    int subtn = nWarpPerWork * WARP_SIZE;
+    if (nWorks > workIx) {
+      // Thread range for whole work (send & recv combined)
+      int subtid = tid - workIx * nWarpPerWork * WARP_SIZE;
+      int subtn = nWarpPerWork * WARP_SIZE;
 
-    // A send primtive of sufficient size requires 2 cuda barrier ids.
-    constexpr int nSendWarpsForExtraGroup = NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE / WARP_SIZE;
-    // Count up all group ids used below this workIx:
-    int group, extra;
-    // Each recv gets one group id:
-    group = __popc(workRecvMask & ((1 << workIx) - 1));
-    // Sends accompanying recvs get one and maybe an extra:
-    extra = (nSendWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
-    group += __popc((workSendMask & workRecvMask) & ((1 << workIx) - 1)) * (1 + extra);
-    // Sends without recvs use more warps so compute extra accordingly:
-    extra = (nWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
-    group += __popc((workSendMask & ~workRecvMask) & ((1 << workIx) - 1)) * (1 + extra);
+      // A send primtive of sufficient size requires 2 cuda barrier ids.
+      constexpr int nSendWarpsForExtraGroup = NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE / WARP_SIZE;
+      // Count up all group ids used below this workIx:
+      int group, extra;
+      // Each recv gets one group id:
+      group = __popc(workRecvMask & ((1 << workIx) - 1));
+      // Sends accompanying recvs get one and maybe an extra:
+      extra = (nSendWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
+      group += __popc((workSendMask & workRecvMask) & ((1 << workIx) - 1)) * (1 + extra);
+      // Sends without recvs use more warps so compute extra accordingly:
+      extra = (nWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
+      group += __popc((workSendMask & ~workRecvMask) & ((1 << workIx) - 1)) * (1 + extra);
 
-    struct ncclDevWorkP2p* work = &works[workIx];
-    bool hasSend = 1 & (workSendMask >> workIx);
-    bool hasRecv = 1 & (workRecvMask >> workIx);
-    bool isCopy = work->sendRank == ncclShmem.comm.rank;
-    bool isSend = !hasRecv || (hasSend && subtid < nSendWarpPerWork * WARP_SIZE);
+      struct ncclDevWorkP2p* work = &works[workIx];
+      bool hasSend = 1 & (workSendMask >> workIx);
+      bool hasRecv = 1 & (workRecvMask >> workIx);
+      bool isCopy = work->sendRank == ncclShmem.comm.rank;
+      bool isSend = !hasRecv || (hasSend && subtid < nSendWarpPerWork * WARP_SIZE);
 
-    if (!isCopy && hasSend && hasRecv) {
-      // Translate thread ids to reflect just this send or recv as opposed to whole work.
-      if (isSend) {
-        subtn = nSendWarpPerWork * WARP_SIZE;
+      if (!isCopy && hasSend && hasRecv) {
+        // Translate thread ids to reflect just this send or recv as opposed to whole work.
+        if (isSend) {
+          subtn = nSendWarpPerWork * WARP_SIZE;
+        } else {
+          subtid -= nSendWarpPerWork * WARP_SIZE;
+          subtn = nRecvWarpPerWork * WARP_SIZE;
+          group += 1 + (nSendWarpPerWork >= nSendWarpsForExtraGroup ? 1 : 0);
+        }
+      }
+
+      if (isCopy) {
+        reduceCopy<COLL_UNROLL, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(
+          subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
+      } else if (isSend) {
+        if (work->sendProtoLL) {
+          runSend<ProtoLL>(subtid, subtn, group, work);
+        } else {
+          runSend<ProtoSimple<1, 1>>(subtid, subtn, group, work);
+        }
       } else {
-        subtid -= nSendWarpPerWork * WARP_SIZE;
-        subtn = nRecvWarpPerWork * WARP_SIZE;
-        group += 1 + (nSendWarpPerWork >= nSendWarpsForExtraGroup ? 1 : 0);
+        if (work->recvProtoLL) {
+          runRecv<ProtoLL>(subtid, subtn, group, work);
+        } else {
+          runRecv<ProtoSimple<1, 1>>(subtid, subtn, group, work);
+        }
       }
     }
-
-    if (isCopy) {
-      reduceCopy<COLL_UNROLL, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(
-        subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
-    } else if (isSend) {
-      if (work->sendProtoLL) {
-        runSend<ProtoLL>(subtid, subtn, group, work);
-      } else {
-        runSend<ProtoSimple<1, 1>>(subtid, subtn, group, work);
-      }
-    } else {
-      if (work->recvProtoLL) {
-        runRecv<ProtoLL>(subtid, subtn, group, work);
-      } else {
-        runRecv<ProtoSimple<1, 1>>(subtid, subtn, group, work);
-      }
+    if (phaseOn) {
+      __syncthreads();
+      if (threadIdx.x == 0) profilerPhase(NCCL_KERNEL_PHASE_BEFORE_CLOSE);
     }
   }
 };

--- a/src/device/symmetric/kernel.cuh
+++ b/src/device/symmetric/kernel.cuh
@@ -24,9 +24,8 @@ __device__ __forceinline__ void ncclSymkProfilerStart(struct ncclSymkDevWorkArgs
     uint64_t wc = args->getProfilerCounters()[ch];
     int slot = wc % MAX_PROFILER_EVENTS_PER_CHANNEL;
     uint64_t ts = ncclSymkGlobaltimer();
-    // workStarted timestamp+counter share one 16B slot, so no fence; the BEGIN phase
-    // stamp is ordered by ncclSymkProfilerStop's fence.
-    args->kcomm.workPhases[ch].data[slot].timestamps[NCCL_KERNEL_PHASE_BEGIN] = ts;
+    if (args->profilerPhaseEnabled)
+      args->kcomm.workPhases[ch].data[slot].timestamps[NCCL_KERNEL_PHASE_BEGIN] = ts;
     args->kcomm.workStarted[ch].data[slot].timestamp = ts;
     args->kcomm.workStarted[ch].data[slot].counter = wc;
   }
@@ -39,16 +38,17 @@ __device__ __forceinline__ void ncclSymkProfilerStop(struct ncclSymkDevWorkArgs 
     int slot = wc % MAX_PROFILER_EVENTS_PER_CHANNEL;
     uint64_t ts = ncclSymkGlobaltimer();
     args->kcomm.workCompleted[ch].data[slot].timestamp = ts;
-    args->kcomm.workPhases[ch].data[slot].timestamps[NCCL_KERNEL_PHASE_END] = ts;
-    // Fence so all timestamps are visible before either counter is published.
-    __threadfence_system();
-    args->kcomm.workPhases[ch].data[slot].counter = wc;
+    if (args->profilerPhaseEnabled) {
+      args->kcomm.workPhases[ch].data[slot].timestamps[NCCL_KERNEL_PHASE_END] = ts;
+      __threadfence_system();
+      args->kcomm.workPhases[ch].data[slot].counter = wc;
+    }
     args->kcomm.workCompleted[ch].data[slot].counter = wc;
   }
 }
 
 __device__ __forceinline__ void ncclSymkProfilerPhase(struct ncclSymkDevWorkArgs const* args, int phaseId) {
-  if (threadIdx.x == 0 && args->profilerEnabled) {
+  if (threadIdx.x == 0 && args->profilerEnabled && args->profilerPhaseEnabled) {
     int ch = blockIdx.x;
     uint64_t wc = args->getProfilerCounters()[ch];
     int slot = wc % MAX_PROFILER_EVENTS_PER_CHANNEL;

--- a/src/enqueue/enqueue.cc
+++ b/src/enqueue/enqueue.cc
@@ -379,6 +379,7 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     devWork.isOneRPN = comm->isOneRPN;
     devWork.netRegUsed = devWork.regUsed = 0;
     devWork.profilerEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelCh);
+    devWork.profilerPhaseEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelPhase);
     if (task->regBufType & NCCL_NET_REG_BUFFER) devWork.netRegUsed = 1;
     if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER)) devWork.regUsed = 1;
 
@@ -585,6 +586,7 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
       devWork.oneNode = (comm->nNodes == 1);
       devWork.netRegUsed = devWork.regUsed = 0;
       devWork.profilerEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelCh);
+      devWork.profilerPhaseEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelPhase);
       if (task->regBufType & NCCL_NET_REG_BUFFER) devWork.netRegUsed = 1;
       if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER)) devWork.regUsed = 1;
 
@@ -1109,6 +1111,10 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
   work->recvBytes = recvBytes == -1 ? 0 : recvBytes;
   work->profilerEnabled =
     ncclProfilerPluginLoaded() && ((p2pTasks[0] ? p2pTasks[0] : p2pTasks[1])->eActivationMask & ncclProfileKernelCh);
+  work->profilerPhaseEnabled =
+    ncclProfilerPluginLoaded() &&
+    (((p2pTasks[0] ? p2pTasks[0]->eActivationMask : 0) | (p2pTasks[1] ? p2pTasks[1]->eActivationMask : 0)) &
+     ncclProfileKernelPhase);
 
   for (int dir = 0; dir < nProxyOps; dir++) {
     struct ncclProxyOp* op = &proxyOps[dir];

--- a/src/enqueue/task_prep/task_posttuning.cc
+++ b/src/enqueue/task_prep/task_posttuning.cc
@@ -654,6 +654,7 @@ static ncclResult_t postTuneLegacyEnqueueCollWork(
   devWork.oneNode = (comm->nNodes == 1);
   devWork.netRegUsed = devWork.regUsed = 0;
   devWork.profilerEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelCh);
+  devWork.profilerPhaseEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelPhase);
   if (task->algorithm != NCCL_ALGO_NVLS && task->algorithm != NCCL_ALGO_NVLS_TREE) {
     devWork.isOneRPN = comm->isOneRPN;
   }

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -255,6 +255,7 @@ struct alignas(16) ncclDevWorkP2p {
   uint8_t sendNetReg:1, recvNetReg:1;
   uint8_t sendIpcReg:1, recvIpcReg:1;
   uint8_t profilerEnabled:1;
+  uint8_t profilerPhaseEnabled:1;
 };
 
 // Compute the subset of the data transfer corresponding to the given part index.
@@ -290,7 +291,8 @@ struct alignas(16) ncclDevWorkColl {
   uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1;
   uint32_t profilerEnabled:1;
   uint32_t root;
-  uint8_t pad1[12];  // pad to 16-byte boundary (20 bytes above -> 32)
+  uint8_t profilerPhaseEnabled;
+  uint8_t pad1[11];  // pad to 16-byte boundary (20 bytes above -> 32)
   void* recvbuff;
   void* sendbuff;
   uint64_t pad0;     // pad to 16-byte boundary (16 bytes above -> 32)

--- a/src/include/sym_kernels.h
+++ b/src/include/sym_kernels.h
@@ -119,6 +119,7 @@ struct alignas(16) ncclSymkDevWorkArgs {
   int nMaxChannels;
   int maxDynamicSmem;
   int profilerEnabled; // when set, profilerWorkCounters[nMaxChannels] follows before channelWorkRange
+  int profilerPhaseEnabled;
   // Variable-length trailing data layout:
   //   if profilerEnabled: uint64_t profilerWorkCounters[nMaxChannels] (aligned to 16)
   //   ncclSymkChannelWorkRange[nChannels] (aligned to 16)

--- a/src/scheduler/symmetric_sched.cc
+++ b/src/scheduler/symmetric_sched.cc
@@ -294,6 +294,8 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm,
   // cuLaunchKernel, so the mirrored counter can't advance across graph replays. Under
   // capture we launch the clean kernel and keep only host-side group/coll events.
   bool profilerEnabled = profilingRequested && !plan->persistent;
+  bool profilerPhaseEnabled =
+    profilerEnabled && (headTask->eActivationMask & ncclProfileKernelPhase);
   plan->kernelFn = (profilerEnabled && ncclSymkKernelListProfile[kernelIndex] != nullptr) ?
                      ncclSymkKernelListProfile[kernelIndex] :
                      ncclSymkKernelList[kernelIndex];
@@ -316,6 +318,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm,
   argsBuf->nMaxChannels = nMaxChannels;
   argsBuf->maxDynamicSmem = maxDynamicSmem;
   argsBuf->profilerEnabled = profilerEnabled ? 1 : 0;
+  argsBuf->profilerPhaseEnabled = profilerPhaseEnabled ? 1 : 0;
 
   remainCell = cellPerChannel = DIVUP(DIVUP(totalCount, nMaxChannels), cellCount);
   workRangePtr = argsBuf->getWorkRange();


### PR DESCRIPTION
## Description

Enabling `ncclProfileKernelCh` in NCCL 2.31.2 also enabled KernelPhase-style device instrumentation in several kernel paths. This caused KernelCh-only profiling to pay for `workPhases` timestamp writes and the related system fence even when `ncclProfileKernelPhase` was not requested.

In our 1MB AllReduce test with KernelCh-only profiling, NCCL 2.29.7 showed only 0.44% overhead, from 52.648 GB/s to 52.418 GB/s. After upgrading to NCCL 2.31.2, the overhead increased to 10.49%, from 52.265 GB/s to 46.783 GB/s. The same issue also affected the symmetric AllReduce path.

This PR separates KernelCh start/stop recording from KernelPhase device-side instrumentation so that KernelCh-only profiling does not incur unnecessary phase timestamp writes or system fence overhead.

Fixes: NVIDIA/nccl#2355

## Related Issues

- Fixes NVIDIA/nccl#2355

## Changes & Impact

- Add a separate `profilerPhaseEnabled` control derived from `ncclProfileKernelPhase`.
- Keep KernelCh start/stop timestamp recording under `profilerEnabled`.
- Gate phase timestamp writes and the related system fence on `profilerPhaseEnabled`.
- Apply the separation across regular collective, P2P, and symmetric kernel paths.
- Preserve the existing dependency that KernelPhase instrumentation requires `ncclProfileKernelCh`.
- No profiler plugin API changes.
- No breaking API or ABI changes are introduced.

## Performance Impact

This change removes unintended KernelPhase-style overhead when only `ncclProfileKernelCh` is enabled.

1MB AllReduce KernelCh-only profiling results:

| Version | Baseline | KernelCh-only | Overhead |
| --- | ---: | ---: | ---: |
| NCCL 2.29.7 | 52.648 GB/s | 52.418 GB/s | 0.44% |
| NCCL 2.31.2 before fix | 52.265 GB/s | 46.783 GB/s | 10.49% |

The fix restores the intended behavior by ensuring KernelCh-only profiling records kernel channel start/stop timestamps without also executing KernelPhase timestamp writes and the associated system fence.

Testing performed:

- AllReduce path with KernelCh-only profiling.
- Symmetric AllReduce path affected by the same issue.
- P2P kernel path coverage for the new gating logic.