### PR TITLE
Fix OOB read of caller's ncclConfig_t in shim

### DIFF
--- a/contrib/nccl_checkpoint/shim.cc
+++ b/contrib/nccl_checkpoint/shim.cc
@@ -2,6 +2,7 @@
 #include "shim_core.h"
 #include <dlfcn.h>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 using namespace nccl_checkpoint;
@@ -26,12 +27,21 @@ static CommInitParams* allocInitParams(int nranks, int rank, const ncclConfig_t*
   params->net_name[0] = '\0';
   params->comm_name[0] = '\0';
   if (configPtr) {
-    params->config = *configPtr;
-    if (configPtr->netName) {
-      strncpy(params->net_name, configPtr->netName, sizeof(params->net_name) - 1);
+    // The caller may have been compiled against an older nccl.h and passed a
+    // shorter struct, so overlay only the bytes it owns onto the defaults;
+    // fields it never had keep their NCCL_CONFIG_UNDEF_INT sentinel.
+    params->config = NCCL_CONFIG_INITIALIZER;
+    size_t callerSize = configPtr->size;
+    // A caller newer than us: take what we understand, ignore the rest.
+    if (callerSize > sizeof(ncclConfig_t)) callerSize = sizeof(ncclConfig_t);
+    memcpy(&params->config, configPtr, callerSize);
+    // Read the names out of our own copy, not configPtr: if callerSize stopped
+    // short of them they are NCCL_CONFIG_UNDEF_PTR here.
+    if (params->config.netName) {
+      strncpy(params->net_name, params->config.netName, sizeof(params->net_name) - 1);
     }
-    if (configPtr->commName) {
-      strncpy(params->comm_name, configPtr->commName, sizeof(params->comm_name) - 1);
+    if (params->config.commName) {
+      strncpy(params->comm_name, params->config.commName, sizeof(params->comm_name) - 1);
     }
   } else {
     params->config = NCCL_CONFIG_INITIALIZER;


### PR DESCRIPTION
## Description

Problem: allocInitParams() in contrib/nccl_checkpoint/shim.cc copies the caller's config with a whole-struct assignment:

    params->config = *configPtr;

ncclConfig_t is versioned by its leading size field precisely so a caller built against an older nccl.h can pass a shorter struct. The assignment reads sizeof(ncclConfig_t) bytes regardless, so for any such caller it reads past the end of the caller's object. 

## Related Issues

Fixes #2347

## Changes & Impact

Solution: start from NCCL_CONFIG_INITIALIZER and memcpy only min(configPtr->size, sizeof(ncclConfig_t)) bytes over it, so fields the caller never had keep their NCCL_CONFIG_UNDEF_INT sentinel and validation skips them. Read netName and commName out of the local copy rather than the caller's struct, which removes the same overread on that path.

## Performance Impact

Not tested, should be negligible.

