### PR TITLE
net/ib: release device list on all ncclIbInitDevices error paths

### DIFF
--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -286,6 +286,7 @@ ncclResult_t ncclIbFinalizeDevices(void) {
 extern int64_t ncclIbArThreshold;
 ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
+  struct ibv_device** devices = NULL;
   if (netRefCount++) return ret;
   ncclProfilerFunction = profFunction;
   if (ncclParamIbDisable()) return ncclInternalError;
@@ -311,7 +312,6 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // Detect IB cards
       int nIbDevs;
-      struct ibv_device** devices;
 
       // Check if user defined which IB device:port to use
       const char* userIbEnv = ncclGetEnv("NCCL_IB_HCA");
@@ -390,7 +390,8 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
                 TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
               } else {
                 WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
-                return res;
+                ret = res;
+                goto fail;
               }
             }
           }
@@ -423,7 +424,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
                           ret, fail);
             if (dev == 1) {
               snprintf(ncclIbDevs[ncclNIbDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
-              NCCLCHECK(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX));
+              NCCLCHECKGOTO(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX), ret, fail);
               strncpy(ncclIbDevs[ncclNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
               ncclIbDevs[ncclNIbDevs].capsProvider.mlx5.dataDirect = 1;
             }
@@ -433,7 +434,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
             ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
             ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
             ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
-            NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
+            NCCLCHECKGOTO(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats), ret, fail);
 
             ncclIbDevs[ncclNIbDevs].railId = (userIfId >= 0) ? userIfs[userIfId].rail : -1;
             ncclIbDevs[ncclNIbDevs].planeId = (userIfId >= 0) ? userIfs[userIfId].plane : -1;
@@ -466,9 +467,13 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
         }
       }
 
-      if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) {
-        ret = ncclInternalError;
-        goto fail;
+      if (devices) {
+        ncclResult_t freeRet = wrap_ibv_free_device_list(devices);
+        devices = NULL;
+        if (freeRet != ncclSuccess) {
+          ret = ncclInternalError;
+          goto fail;
+        }
       }
     }
     if (ncclNIbDevs == 0) {
@@ -521,6 +526,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 exit:
   return ret;
 fail:
+  if (devices) wrap_ibv_free_device_list(devices);
   goto exit;
 }
 


### PR DESCRIPTION
## Fix

Closes #2189. `ncclIbInitDevices()` calls `wrap_ibv_get_device_list()` (which allocates the device list) but only released it on the success path. Any error after the allocation leaked the list:

- the `wrap_mlx5dv_get_data_direct_sysfs_path()` failure branch did `return res;` directly, bypassing `wrap_ibv_free_device_list()`;
- every `NCCLCHECKGOTO(..., ret, fail)` after allocation (`ncclIbQueryOooRqSize`, `ncclIbGetPciPath`, `ncclIbGidInfoQuery`, and the `wrap_ibv_close_device()` failure) jumped to `fail:`, which had no cleanup;
- two plain `NCCLCHECK` calls after allocation (`ncclCalloc` for the data-direct `pciPath`, `ncclIbStatsInit`) returned directly on error, leaking the list too.

## Change

- Hoist `struct ibv_device** devices` to function scope (initialized to `NULL`) so the `fail:` label can reach it.
- Route the data-direct failure branch through `fail:`.
- Convert the two post-allocation plain `NCCLCHECK` calls to `NCCLCHECKGOTO(..., ret, fail)`.
- Release the device list in `fail:` (guarded by the `NULL` check), and set `devices = NULL` after the success-path free so later failure paths do not double-free.

Behavior on the success path is unchanged. All error paths now release the list exactly once.