### PR TITLE
Skip NET shared buffers for single-rank communicators

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1681,11 +1681,13 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       }
     }
 
-    // Connect to local net proxy
-    NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_NET, 1, comm->rank, &proxyConn), ret, fail);
-    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int),
-                                        NULL, 0),
-                  ret, fail);
+    // A single-rank communicator cannot have a remote peer, so it does not need NET shared buffers.
+    if (comm->nRanks > 1) {
+      NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_NET, 1, comm->rank, &proxyConn), ret, fail);
+      NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int),
+                                          NULL, 0),
+                    ret, fail);
+    }
 
     // Then to remote ones when using PXN
     if (ncclPxnDisable(comm) == 0) {


### PR DESCRIPTION
## Description

Skip eager local NET proxy shared-buffer initialization for single-rank communicators when runtime connect is disabled.

A single-rank communicator has no remote peer that can consume this pool. Communicators with more than one rank keep the existing initialization path unchanged.

## Related Issues

Fixes #2363.

## Changes & Impact

- Guard the local NET shared-buffer initialization with comm->nRanks > 1.
- Preserve the proxy subsystem and all multi-rank initialization behavior.
- No public API or ABI changes.

## Performance Impact

Validated on a single PCIe host with RTX 3090 GPUs, CUDA 13.0, and an SM86-only NCCL build.

- One GPU, NCCL_RUNTIME_CONNECT=0: initialization memory decreased from 996 MiB to 484 MiB (-512 MiB).
- One GPU, default runtime connect: initialization memory remained 484 MiB.
- Two-GPU all-reduce sweep (1 MiB to 256 MiB, 20 warmups, 100 iterations, 5 cycles): average bus bandwidth was 3.816 GB/s before and 3.826 GB/s after (+0.27%).
- Three-GPU all-reduce sweep with the same methodology: average bus bandwidth was 4.940 GB/s before and 4.954 GB/s after (+0.30%).
- All nccl-tests runs reported zero out-of-bounds values.
- 100 separate single-rank initialization/all-reduce/destruction cycles completed under a 20-second per-process timeout.
- A 20-cycle ncclCommSplit test with split resource sharing enabled completed before and after the change. Each cycle split a two-rank parent into two singleton children, ran all-reduce and self send/recv, then destroyed child and parent communicators.
- NCCL and nccl-tests both built successfully; the modified NCCL library also passed a fresh clean build.
