### PR TITLE
Fix profiler KernelCh timestamp drift for communicators with broadcast/AllGatherV

### DIFF
--- a/src/enqueue/enqueue.cc
+++ b/src/enqueue/enqueue.cc
@@ -440,6 +440,17 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
       t->datatype = bcastTask->datatype;
       // Carry the profiler tag onto the converted coll task so its coll event reports it.
       t->profilerTag = bcastTask->profilerTag;
+      // Carry the profiler activation mask and API event handles onto the converted coll task.
+      // The single-peer broadcast is rewritten into a fresh ncclTaskColl here, so without this
+      // copy its eActivationMask stays memset-zeroed and the ncclProfileKernelCh bit is dropped.
+      // hasProfilerOps would then be false and ncclProfilerPostPlanWork() would never bump the
+      // host workCounter for this task, while the device still advances channel.workCounter for
+      // its work. That drift makes every subsequent KernelCh event read the wrong device slot
+      // (observed as out-of-order timestamps and multi-second bogus durations under
+      // NCCL_ALLGATHERV_ENABLE=1).
+      t->eActivationMask = bcastTask->eActivationMask;
+      t->groupApiEventHandle = bcastTask->groupApiEventHandle;
+      t->collApiEventHandle = bcastTask->collApiEventHandle;
       t->trafficBytes = t->count * ncclFuncTrafficPerByte(t->func, comm->nRanks);
       t->chunkSteps = BROADCAST_CHUNKSTEPS;
       t->sliceSteps = BROADCAST_SLICESTEPS;
@@ -2776,6 +2787,15 @@ static ncclResult_t collTaskAppend(struct ncclComm* comm, struct ncclInfo* info,
     t->root = info->root;
     // 0 for a plain broadcast; the user value for a profiler-tag-only ncclBroadcastConfig.
     t->profilerTag = info->collConfig.userProfilerTag;
+    // Carry the profiler activation mask and API event handles. ncclTaskBcast is allocated from a
+    // memset-zeroed pool, so without this its eActivationMask stays 0 and the ncclProfileKernelCh
+    // bit is lost. That desyncs the host and device workCounters (the host only bumps
+    // comm->profiler.workCounter[] for tasks whose eActivationMask has ncclProfileKernelCh, while
+    // the device advances channel.workCounter unconditionally), which corrupts every subsequent
+    // KernelCh timestamp mapping. Mirrors the regular coll task path below.
+    t->eActivationMask = ncclProfilerApiState.eActivationMask;
+    t->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
+    t->collApiEventHandle = ncclProfilerApiState.collApiEventHandle;
 
     // update bcast min/max peer
     planner->bcast_info.minBcastPeer = std::min(planner->bcast_info.minBcastPeer, info->root);


### PR DESCRIPTION
Fix profiler KernelCh timestamp drift for broadcast (AllGatherV path)

## Problem
With the profiler enabled (`ncclProfileKernelCh`) and the default
`NCCL_ALLGATHERV_ENABLE=1`, any workload containing `ncclBroadcast`
produced badly corrupted KernelCh profiling data: GPU kernel timestamps
were mapped onto the wrong task, so exported events showed out-of-order
timestamps (end before begin) and bogus durations in the multi-second
range (observed drift of ~3s / ~6s and larger). Setting `NCCL_ALLGATHERV_ENABLE=0` 
made the problem disappear, pointing at the AllGatherV/broadcast path.

## Root cause
A host/device `workCounter` desync:

- When AllGatherV is enabled, a plain `ncclBroadcast` is appended as an
  `ncclTaskBcast` (`collTaskAppend`). A single-peer broadcast
  (`BcastPeers==1`) is then rewritten into a fresh `ncclTaskColl`
  (`ncclPrepareTasks`).
- Both tasks are allocated from a memset-zeroed memory pool, and neither
  set/copied `eActivationMask`, so the `ncclProfileKernelCh` bit was lost.
- Host side (`ncclProfilerPostPlanWork`) only bumps
  `comm->profiler.workCounter[]` for tasks whose `eActivationMask` carries
  `ncclProfileKernelCh`; the device kernel advances `channel.workCounter`
  unconditionally (`src/device/common.h`). Each affected op left the host
  one bump behind the device. The drift accumulated permanently and
  shifted the ring-buffer slot that even correctly-sampled ops (e.g.
  AllGather) read, so they picked up GPU timestamps from the wrong slot.

## Solution
Propagate the profiler activation state along the whole broadcast
scheduling chain, in `src/enqueue/enqueue.cc`:

1. In `collTaskAppend` (AllGatherV/bcast branch): set `eActivationMask`,
   `groupApiEventHandle` and `collApiEventHandle` from
   `ncclProfilerApiState` when the `ncclTaskBcast` is created.
2. In `ncclPrepareTasks` (`BcastPeers==1` bcast->coll conversion): copy the
   same three fields from the bcast task onto the converted coll task.

## Limitations
Only restores propagation of profiler metadata. No changes to the data
path, device kernels, or the profiler plugin ABI. With profiling off
`ncclProfilerApiState.eActivationMask` is already 0, so behavior is
unchanged.

Signed-off-by: zhenghao.cs <zhenghao.cs@bytedance.com>