### PR TITLE
init: fix use-after-free and resource leaks on comm split/grow/childcomm failure paths

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -2749,6 +2749,7 @@ fail:
     free(comm->abortFlag);
     if (comm->abortFlagDev) (void)ncclCudaHostFree((void*)comm->abortFlagDev);
     free(comm->abortFlagRefCount);
+    free((void*)comm->config.netName);
     free(comm);
   }
   if (newcomm) *newcomm = NULL;
@@ -3445,11 +3446,23 @@ exit:
   return res;
 fail:
   if (childComm) {
-    if (!comm->shareResources) {
+    if (comm->shareResources) {
+      // Abort flags are shared with (owned by) the parent; do not free them here.
+      // Undo the reference taken during setup so the parent can free them at destroy time.
+      if (childComm->abortFlagRefCount) ncclAtomicRefCountDecrement(comm->abortFlagRefCount);
+    } else {
+      // Child owns these abort flags. The parent's childAbortFlag/childAbortFlagDev back-pointers
+      // may alias this child's flags (set during init); clear them before freeing to avoid a later
+      // use-after-free when the parent is later destroyed/aborted/revoked/shrunk (setCommAbortFlags).
+      if (comm->childAbortFlag == childComm->abortFlag) {
+        comm->childAbortFlag = NULL;
+        comm->childAbortFlagDev = NULL;
+      }
       if (childComm->abortFlag) free(childComm->abortFlag);
       if (childComm->abortFlagDev) ncclCudaHostFree(childComm->abortFlagDev);
       if (childComm->abortFlagRefCount) free(childComm->abortFlagRefCount);
     }
+    free((void*)childComm->config.netName);
     free(childComm);
   }
   if (newcomm) *newcomm = NULL;
@@ -3624,7 +3637,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   } else {
     // New rank: new comm, no parent
     int device;
-    CUDACHECK(cudaGetDevice(&device));
+    CUDACHECKGOTO(cudaGetDevice(&device), res, fail);
     job->parent = NULL;
     job->cudaDev = device;
     job->myrank = rank;
@@ -3668,12 +3681,11 @@ fail:
   }
   // Clean up newly allocated comm on failure
   if (newComm) {
-    // Only free abort resources if we allocated them (not shared)
-    if (!isExistingRank || !comm->shareResources) {
-      free(newComm->abortFlag);
-      if (newComm->abortFlagDev) (void)ncclCudaHostFree((void*)newComm->abortFlagDev);
-      free(newComm->abortFlagRefCount);
-    }
+    // Grow always allocates fresh abort resources (never shared), so always free them.
+    free(newComm->abortFlag);
+    if (newComm->abortFlagDev) (void)ncclCudaHostFree((void*)newComm->abortFlagDev);
+    free(newComm->abortFlagRefCount);
+    free((void*)newComm->config.netName);
     free(newComm);
     if (newcomm) *newcomm = NULL;
   }


### PR DESCRIPTION
## Summary

Fixes a heap use-after-free plus several resource leaks on the failure/cleanup
paths of communicator split / shrink / grow / child-comm init. All changes are
in `src/init.cc`.

## Bugs and fixes

### 1. Use-after-free of the parent's child abort flag (the headline)

During `ncclCommInitChildComm`, when abort resources are **not** shared, the
parent stores back-pointers to the child's abort flags so it can abort the
in-flight child during init:

```c
comm->childAbortFlag = childComm->abortFlag;
comm->childAbortFlagDev = childComm->abortFlagDev;
```

On the failure path the child was freed (`free(childComm->abortFlag)` etc.)
without clearing those parent back-pointers. A subsequent
`ncclCommDestroy` / `ncclCommAbort` / `ncclCommRevoke` / `ncclCommShrink` of the
**parent** calls `setCommAbortFlags()`, which does
`COMPILER_ATOMIC_STORE(comm->childAbortFlag, ...)` / `...ChildAbortFlagDev...` —
a write **through the freed child abort flag**: a heap use-after-free write.

**Trigger:** any failure inside `ncclCommInitChildComm` after the child abort
flags are allocated (e.g. `parseCommConfig` / `copyCommConfig` failure, or the
async-job allocation failing), followed by destroying/aborting the parent.

**Fix:** before freeing the child, null the parent's back-pointers when they
alias this child:

```c
if (comm->childAbortFlag == childComm->abortFlag) {
  comm->childAbortFlag = NULL;
  comm->childAbortFlagDev = NULL;
}
```

### 2. `abortFlagRefCount` leak in the shareResources failure path

The `shareResources` branch increments the parent's `abortFlagRefCount`
(`ncclAtomicRefCountIncrement`) but the failure path never decremented it, so
the parent's abort flags are never freed at the parent's own destroy (the
refcount never returns to zero). The fix decrements it on failure and does not
free the shared flags (they belong to the parent):

```c
if (childComm->abortFlagRefCount) ncclAtomicRefCountDecrement(comm->abortFlagRefCount);
```

### 3. `comm->config.netName` leak on three failure paths

`comm->config.netName` is heap-allocated in `envConfigOverride` /
`parseCommConfig` and is freed unconditionally by `commFree`
(`free((void*)comm->config.netName)`). It was leaked on the failure paths of
`ncclCommInitRankDev`, `ncclCommInitChildComm` and `ncclCommGrow`, which free
the comm struct directly without going through `commFree`. Each failure path now
frees it, mirroring `commFree`. (Safe: `copyCommConfig` memcpy's the parent's
pointer, but `envConfigOverride` immediately re-`malloc`s a fresh buffer or sets
it to `NULL`, so the child/new comm never aliases the parent's buffer.)

### 4. `ncclCommGrow`: bare `CUDACHECK(cudaGetDevice(&device))`

For the new-rank path, `cudaGetDevice` was checked with `CUDACHECK`, which
`return`s directly on error — bypassing `ncclGroupEndInternal()`. That leaves the
group depth incremented and leaks the already-allocated `job` and `newComm`,
while handing back a `*newcomm` that never completes. Changed to
`CUDACHECKGOTO(cudaGetDevice(&device), res, fail)` so it runs the existing
cleanup and group-end.

### 5. `ncclCommGrow`: abort resources leaked on config failure

`ncclCommGrow` always allocates **fresh** abort resources (it never shares
them), but its failure path only freed `abortFlag`/`abortFlagDev`/
`abortFlagRefCount` under an `(!isExistingRank || !comm->shareResources)` guard.
When an existing rank grew while the (stale) parent `shareResources` flag was
set, a `parseCommConfig` failure leaked all three. The failure path now always
frees them.

## Verification

Verified by static analysis against master (`7b83616d`, v2.31.2-1). I don't have
multi-GPU/NVSwitch hardware or a full NCCL build on my dev box, so these paths
were not runtime-tested; the changes are self-contained cleanup-path edits that
mirror the existing `commFree` / success-path ownership model.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
