### PR TITLE
transport: close fds on the error paths of proxy connect and UDS import

### DIFF
--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1014,10 +1014,11 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
         CUCHECK(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)resources->buffers[p], dmaBufSize,
                                               CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
                                               getHandleForAddressRangeFlags(resources->useGdr)));
-        NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p],
+        ncclResult_t dmaBufRegRes = proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p],
                                                    resources->buffSizes[p], type, 0ULL, dmabuf_fd,
-                                                   &resources->mhandles[p]));
-        (void)close(dmabuf_fd);
+                                                   &resources->mhandles[p]);
+        (void)close(dmabuf_fd);  // close the DMA-BUF fd whether or not registration succeeded
+        NCCLCHECK(dmaBufRegRes);
       } else // FALL-THROUGH to nv_peermem GDR path
 #endif
       {
@@ -1187,10 +1188,11 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
         CUCHECK(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)resources->buffers[p], dmaBufSize,
                                               CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
                                               getHandleForAddressRangeFlags(resources->useGdr)));
-        NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p],
+        ncclResult_t dmaBufRegRes = proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p],
                                                    resources->buffSizes[p], type, 0ULL, dmabuf_fd,
-                                                   &resources->mhandles[p]));
-        (void)close(dmabuf_fd);
+                                                   &resources->mhandles[p]);
+        (void)close(dmabuf_fd);  // close the DMA-BUF fd whether or not registration succeeded
+        NCCLCHECK(dmaBufRegRes);
       } else // FALL-THROUGH to nv_peermem GDR path
 #endif
       {

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -291,8 +291,9 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm* comm, int peer, size_
       NCCLCHECK(ncclProxyClientGetFdBlocking(comm, peer, &cuDesc->data, &fd));
       INFO(NCCL_P2P, "UDS converted handle 0x%lx to fd %lld on remote peer %d", *(uint64_t*)&cuDesc->data,
            (long long)fd, peer);
-      CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type));
-      SYSCHECK(ncclIpcFdClose(fd), "close");
+      CUresult p2pImportRes = cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type);
+      SYSCHECK(ncclIpcFdClose(fd), "close");  // close the UDS fd whether or not the import succeeded
+      CUCHECK(p2pImportRes);
     } else {
       CUCHECK(cuMemImportFromShareableHandle(&handle, cuDesc, type));
     }

--- a/src/transport/shm.cc
+++ b/src/transport/shm.cc
@@ -381,8 +381,9 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, 
       ncclIpcFd fd = NCCL_INVALID_IPC_FD;
       // Send cuMem handle to remote for conversion to an fd
       NCCLCHECK(ncclProxyClientGetFdBlocking(comm, proxyRank, &desc->shmci.data, &fd));
-      CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type));
-      (void)ncclIpcFdClose(fd);
+      CUresult shmImportRes = cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type);
+      (void)ncclIpcFdClose(fd);  // close the UDS fd whether or not the import succeeded
+      CUCHECK(shmImportRes);
     } else {
       CUCHECK(cuMemImportFromShareableHandle(&handle, &desc->shmci.handle, type));
     }


### PR DESCRIPTION
## Problem

Three proxy-side paths open an fd and close it on the success path only, so a failure of the intervening call leaks the fd:

- **`net.cc`** `sendProxyConnect` / `recvProxyConnect`: the DMA-BUF fd from `cuMemGetHandleForAddressRange` is closed *after* `regMrDmaBuf`, but `NCCLCHECK(regMrDmaBuf(...))` returns first when registration fails (a NIC MR/registration limit, a transient plugin error), skipping `close(dmabuf_fd)`. The register-path siblings were already fixed this way in #2267; the connect paths were not.
- **`shm.cc`** `ncclShmImportShareableBuffer` and **`p2p.cc`** `p2pMap`: the UDS fd from `ncclProxyClientGetFdBlocking` is closed *after* `cuMemImportFromShareableHandle`, but `CUCHECK(cuMemImportFromShareableHandle(...))` returns first on failure, skipping the close.

Each leaked fd is per proxy-connect / per import, so a flapping NIC or a driver error under load accumulates descriptors.

## Fix

Capture the call result, close the fd unconditionally, then propagate the error — so the fd is released on both success and failure. Same shape as #2267.

## Testing

Static change (NCCL isn't buildable on my dev box). The edits only move the existing `close` ahead of the error check; the success path is unchanged, and the failure path now closes the fd before returning the same error. Brace balance verified on all three files.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
