### PR TITLE
device: fix single-node NVLS AllGather/ReduceScatter rank ordering (#1906)

### DIFF
--- a/src/device/all_gather.h
+++ b/src/device/all_gather.h
@@ -367,7 +367,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
-            prims.gather(offset, nvls->nHeads * count, nelem, count, -1, 0);
+            prims.gatherRemap(offset, nvls->nHeads * count, nelem, count, -1, 0, ncclShmem.comm.denseToUserRank);
           }
           // coverity[overrun-call] => Coverity think prims.index can be greater than 1
         } else if (tid < tidEndBcast) {

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -403,9 +403,10 @@ private:
   // Scatter/Gather generic op
   // skip: my own rank order in the buffer chunks
   // shift: peer offset to avoid all ranks sending to or receiving from same peer
-  template <int DirectRecv1, int DirectSend1, int Recv, int Send>
+  template <int DirectRecv1, int DirectSend1, int Recv, int Send, bool Remap = false>
   __device__ __forceinline__ void ScatterGatherOp(intptr_t inpIx, intptr_t outIx, ssize_t totalElem, int peerElem,
-                                                  ssize_t peerOffset, int skip, int shift, bool postOp) {
+                                                  ssize_t peerOffset, int skip, int shift, bool postOp,
+                                                  const int* remap = nullptr) {
     constexpr int DirectRecv = 1 && Direct && DirectRecv1;
     constexpr int DirectSend = 1 && Direct && DirectSend1;
     int offset = 0; // slice offset
@@ -428,7 +429,10 @@ private:
           // Loop over peers
           for (int j = 0; j < fan.nsend(); j++) {
             int i = (j + shift) % fan.nsend();
-            ssize_t pOffset = i * peerOffset;
+            // Optionally remap the per-peer offset (e.g. the NVLS dense-head index ->
+            // user rank). remap wrappers pass skip<0, so the skip test below stays on i.
+            int slot = (Remap && remap != nullptr) ? remap[i] : i;
+            ssize_t pOffset = slot * peerOffset;
             // Skip the data I am responsible of reducing myself
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
             void* src0 = (T*)ncclShmem.groups[group].srcs[0] + pOffset;
@@ -452,7 +456,8 @@ private:
           NVCC_PRAGMA_UNROLL_AUTO
           for (int j = 0; j < fan.nrecv(); j++) {
             int i = (j + shift) % fan.nrecv();
-            pOffset = i * peerOffset;
+            int slot = (Remap && remap != nullptr) ? remap[i] : i;
+            pOffset = slot * peerOffset;
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
             void* dst0 = (T*)ncclShmem.groups[group].dsts[0] + pOffset;
             ssize_t realPeerSize = min(realSize, totalElem - pOffset);
@@ -1017,6 +1022,13 @@ public:
                                           int shift) {
     ScatterGatherOp<0, 0, 0, 1>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
   }
+  // Like scatter(), but remaps each peer's source offset through `remap` (e.g. the NVLS
+  // dense-head-index -> user-rank table). Assumes skip < 0.
+  __device__ __forceinline__ void scatterRemap(intptr_t inpIx, ssize_t totalElem, int peerElem, ssize_t peerOffset,
+                                               int skip, int shift, const int* remap) {
+    ScatterGatherOp<0, 0, 0, 1, /*Remap=*/true>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift,
+                                                /*postOp=*/false, remap);
+  }
   __device__ __forceinline__ void directScatter(intptr_t inpIx, ssize_t totalElem, int peerElem, ssize_t peerOffset,
                                                 int skip, int shift) {
     ScatterGatherOp<0, 1, 0, 1>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
@@ -1087,6 +1099,13 @@ public:
   __device__ __forceinline__ void gather(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip,
                                          int shift, bool postOp = false) {
     ScatterGatherOp<0, 0, 1, 0>(-1, outIx, totalElem, peerElem, peerOffset, skip, shift, postOp);
+  }
+  // Like gather(), but remaps each peer's destination offset through `remap` (e.g. the NVLS
+  // dense-head-index -> user-rank table). Assumes skip < 0.
+  __device__ __forceinline__ void gatherRemap(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset,
+                                              int skip, int shift, const int* remap, bool postOp = false) {
+    ScatterGatherOp<0, 0, 1, 0, /*Remap=*/true>(-1, outIx, totalElem, peerElem, peerOffset, skip, shift, postOp,
+                                                remap);
   }
   __device__ __forceinline__ void directGather(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset,
                                                int skip, int shift) {

--- a/src/device/reduce_scatter.h
+++ b/src/device/reduce_scatter.h
@@ -326,7 +326,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
-            prims.scatter(offset, nvls->nHeads * count, nelem, count, -1, 0);
+            prims.scatterRemap(offset, nvls->nHeads * count, nelem, count, -1, 0, ncclShmem.comm.denseToUserRank);
           }
           // coverity[overrun-call] => Coverity think prims.index can be greater than 1
         } else if (tid < tidEndReduce) {


### PR DESCRIPTION
Fixes #1906.

## The bug

Single-node NVLS AllGather returns each rank's chunk in the **wrong output position** when `CUDA_VISIBLE_DEVICES` permutes GPUs out of dense-head order — a silent data corruption (the output is a permutation of the correct result). @sjeaugey confirmed the root cause on the issue: the single-node NVLS AllGather is *"missing the user rank table which ensures proper data ordering."*

In the non-registered `oneNode` path:

```
src/device/all_gather.h:     prims.gather(offset, nvls->nHeads * count, nelem, count, -1, 0);
  ⟶ src/device/prims_simple.h (ScatterGatherOp, Recv branch):  pOffset = i * peerOffset;
```

the peer loop index `i` is the **dense head index**, so head `i`'s gathered slice is written to output slot `i`. But head `i` physically holds the data of user rank `denseToUserRank[i]`, so slot `i` is wrong whenever `denseToUserRank[i] != i`.

Every correct sibling path already remaps through `denseToUserRank`:

- multi-node NVLS — `all_gather.h:317`: `int rank = denseToUserRank[node*nRails+rail]; userOneBeg = rank*countPerRank;`
- CollNetDirect — `all_gather.h:546` (same form)
- the PAT helper `nvlsDenseToUserOffset` in `prims_simple.h`

`ReduceScatter` has the exact symmetric mirror (`reduce_scatter.h`, `oneNode`/`!regUsed` scatter → `pOffset = i*peerOffset` on the *source* side). The `oneNode` **`regUsed`** paths use `rank*count` directly and are already correct; multi-node paths are already correct; and `AllReduce`'s NVLS scatter+gather round-trip is order-invariant (its output is the fully-reduced array), so it must **not** change.

## Why this is device-only

The `denseToUserRank` table is already **built and copied to the device for pure single-node NVLS** on current master — `ncclTransportInitRankMap` (`init.cc:1573`) is gated only on `comm->nvlsSupport` (no `nNodes>1` guard), and `devCommSetup` copies it (`init.cc:698`, null-guarded). So no host / `comm.h` / `init.cc` / `connect.cc` changes are needed — only the device-side consumption was missing.

## The fix

- `ScatterGatherOp` gains an opt-in `template <..., bool Remap = false>` plus a `const int* remap = nullptr`; the per-peer offset becomes `(Remap && remap != nullptr) ? remap[i] : i`. Because `Remap` is a template constant, **every existing caller compiles to byte-identical code** (AllReduce, multi-node, CollNet, the two reg-sync `gather/scatter(0,0,0,0,-1,0)`, `directScatter`/`directGather`) — they don't pass the new arg.
- New `scatterRemap()` / `gatherRemap()` wrappers set `Remap=true`.
- The two `oneNode` NVLS sites pass `ncclShmem.comm.denseToUserRank`, so peer `i`'s slice is placed at slot `denseToUserRank[i]` — matching the multi-node/CollNet/PAT direction exactly.

## Direction (the load-bearing detail)

Specialized to a single node (`node=0`, `nRails=nHeads`), the correct multi-node formula `rank = denseToUserRank[node*nRails+rail]; slot = rank*count` reduces to `slot(i) = denseToUserRank[i]`. `denseToUserRank[i]` is the user rank that owns head `i` (`generic.cc` builds `userToDenseRank` then inverts it; for a head rank `r`, `userToDenseRank[r]=h` where `nvlsHeads[h]==r`). So peer `i` (head `i`) → output slot `denseToUserRank[i]`. Using the inverse table would double-permute; this uses the same table and direction as every correct path.

## Testing

I **cannot validate this on hardware** — I don't have an NVSwitch box and can't do a full NCCL build. I verified: (1) the fix matches the multi-node / CollNet / PAT remap direction line-for-line; (2) the C++ template/overload/wrapper mechanics compile clean and a standalone harness confirms `scatterRemap`/`gatherRemap` permute the per-peer offset by `remap[]` and that an identity remap is byte-identical to plain `scatter`/`gather`.

Please validate on NVSwitch before merging — I'd suggest `all_gather_perf` / `reduce_scatter_perf` forcing `NCCL_ALGO=NVLS`, with `#wrong == 0` across the identity and several non-identity `CUDA_VISIBLE_DEVICES` permutations (e.g. `1,2,3,4,5,6,7,0` and `3,4,5,6,7,0,1,2`), plus a non-NVLS regression pass.

Two notes for reviewers: the `ReduceScatter` change is the symmetric mirror (the issue reproduces AllGather only — happy to drop it if you'd rather land AllGather first), and both sites keep the existing `nvls->nHeads*count` span, which assumes `nHeads == nRanks` on this single-node path (as the current code already does).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
