### PR TITLE
feat(efa-gda): Implement Get

### DIFF
--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -9,9 +9,9 @@
  *
  * Implemented: Put (data + signal/counter endpoints, signal-only via
  *              scratch buffer), PutValue (value staged through the
- *              per-endpoint slot pool), Flush, GetSignalPtr,
+ *              per-endpoint slot pool), Get, Flush, GetSignalPtr,
  *              GetCounterPtr, ResetSignal, ResetCounter.
- * Stub: Get, FlushAsync, Wait.
+ * Stub: FlushAsync, Wait.
  *************************************************************************/
 
 #ifndef _NCCL_DEVICE_GIN_EFA_GDA_H_
@@ -54,12 +54,20 @@ static constexpr cuda::thread_scope ncclGinScope =
  * has wrapped. Never compare absolute counter values. */
 static constexpr uint32_t EFA_CNTR_MASK = 0x7fffffffu;
 
-/* Hardware cap on a single RDMA write: efadv_device_attr.max_rdma_size,
+/* Hardware cap on a single RDMA op (write or read): efadv_device_attr.max_rdma_size,
  * 1 GiB on current EFA devices. A WQE exceeding it fails on the NIC as a CQ
- * error, which this CQ-less path never observes, so the put hangs; the u32
- * SGE length field additionally truncates sizes >= 4 GiB. Larger puts are
- * split into chunks of at most this size in putImplMode. */
-static constexpr uint32_t EFA_GDA_MAX_WRITE_SIZE = 1u << 30;
+ * error, which this CQ-less path never observes, so the op hangs; the u32
+ * SGE length field additionally truncates sizes >= 4 GiB. Larger transfers are
+ * split into chunks of at most this size in putImplMode / getImplMode. */
+static constexpr uint32_t EFA_GDA_MAX_RDMA_OP_SIZE = 1u << 30;
+
+/* Which RDMA operation the post path issues. A write and a read populate identical
+ * WR fields, so the opcode is the only difference between them and it is what
+ * decides which way the bytes move. */
+enum efaGdaRdmaOp {
+  EFA_GDA_RDMA_WRITE,
+  EFA_GDA_RDMA_READ
+};
 
 /* ── Atomic primitives parameterized on scope and memory order ────── */
 
@@ -121,7 +129,7 @@ NCCL_DEVICE_INLINE static void ringDoorbell(efa_cuda_qp* qp, uint64_t* submitted
   dbrung_ref.store(target, cuda::memory_order_release);
 }
 
-/* ── postRdmaWrite: shared post path for Put and PutValue ─────────── */
+/* ── postRdmaOp: shared post path for Put, PutValue and Get ──────── */
 
 /* Posts an RDMA write on `ep`'s local QP (its FI_WRITE counter tracks
  * local completion) to the remote QP given by the explicit
@@ -135,13 +143,13 @@ NCCL_DEVICE_INLINE static void ringDoorbell(efa_cuda_qp* qp, uint64_t* submitted
  * its own pool slot at pvSliceBase + (reserved SQ slot % sq_size) *
  * pvSlotSize and points the WR's SGE there. Put (pvSrcVal == nullptr) uses
  * the caller's fixed srcAddr/srcLkey. */
-template <ncclGinResourceSharingMode mode>
-NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_handle* ep, uint16_t ah, uint16_t qpn,
-                                             uint32_t qkey, uint64_t srcAddr, uint32_t srcLkey, uint32_t writeBytes,
-                                             uint64_t dstAddr, uint32_t dstRkey,
-                                             uint32_t optFlags = ncclGinOptFlagsDefault, const void* pvSrcVal = nullptr,
-                                             uint32_t pvValBytes = 0, uint32_t pvLkey = 0, uint64_t pvSliceBase = 0,
-                                             uint32_t pvSlotSize = 0) {
+template <ncclGinResourceSharingMode mode, efaGdaRdmaOp op = EFA_GDA_RDMA_WRITE>
+NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle* ep, uint16_t ah, uint16_t qpn,
+                                          uint32_t qkey, uint64_t srcAddr, uint32_t srcLkey, uint32_t writeBytes,
+                                          uint64_t dstAddr, uint32_t dstRkey,
+                                          uint32_t optFlags = ncclGinOptFlagsDefault, const void* pvSrcVal = nullptr,
+                                          uint32_t pvValBytes = 0, uint32_t pvLkey = 0, uint64_t pvSliceBase = 0,
+                                          uint32_t pvSlotSize = 0) {
   efa_cuda_qp* qp = (efa_cuda_qp*)ep->qp;
   uint64_t* submitted_count_ptr = &ep->submitted_count;
   uint64_t* local_cntr_ptr = ep->local_cntr_value;
@@ -149,7 +157,15 @@ NCCL_DEVICE_INLINE static void postRdmaWrite(nccl_ofi_gin_gdaki_dev_endpoint_han
 
   /* Only the SGE differs for PutValue, so set_sge is deferred. */
   efa_io_tx_wqe wr;
-  efa_cuda_init_rdma_write_wr(&wr, (uint16_t)threadIdx.x, dstRkey, dstAddr);
+  /* The opcode is the only thing that differs between a Put and a Get here: both
+   * carry the RDMA address pair (dstAddr, dstRkey) and the local buffer in the SGE,
+   * and the opcode decides which way the bytes move. A read therefore arrives with
+   * the REMOTE source in the RDMA pair and the LOCAL destination in the SGE. */
+  if NCCL_IF_CONSTEXPR (op == EFA_GDA_RDMA_READ) {
+    efa_cuda_init_rdma_read_wr(&wr, (uint16_t)threadIdx.x, dstRkey, dstAddr);
+  } else {
+    efa_cuda_init_rdma_write_wr(&wr, (uint16_t)threadIdx.x, dstRkey, dstAddr);
+  }
   efa_cuda_wr_set_remote(&wr, ah, (uint32_t)qpn, qkey);
   /* Tag the WQE as PPS-sensitive. GIN puts are small, high-rate writes, so
    * ask the NIC to optimize for packets-per-second (burst PPS) rather than
@@ -374,7 +390,7 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
      *
      * Empty puts cannot be dropped as no-ops, because under
      * ncclGinOptFlagsAggregateRequests a put carries a LOCAL side effect: its
-     * non-aggregated doorbell rendezvous in postRdmaWrite is what publishes
+     * non-aggregated doorbell rendezvous in postRdmaOp is what publishes
      * earlier deferred WQEs on the QP. Dropping an "empty" put would make it
      * impossible to terminate a deferred stream whose last real put was
      * aggregated -- the tail WQEs (and their signals) would never be handed to
@@ -466,13 +482,13 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        *
        * Correctness-first: this issues the writes as separate posts (one
        * doorbell each). A future optimization can batch the doorbell over
-       * a larger reservation via postRdmaWrite's chunk loop; that must NOT
+       * a larger reservation via postRdmaOp's chunk loop; that must NOT
        * be done by suppressing doorbells across calls, which would break
        * the wqes_completed sliding-window / rendezvous invariant.
        *
        * TODO: batch the doorbells for a signal Add-by-N (and across the
        * payload + scratch writes) instead of ringing one doorbell per
-       * write. Must reuse postRdmaWrite's chunk loop (one doorbell per
+       * write. Must reuse postRdmaOp's chunk loop (one doorbell per
        * max_batch reservation), NOT a doorbell-suppress flag across
        * separate calls. */
       uint32_t signalCount = 1u;
@@ -498,9 +514,9 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
       const uint16_t dataSigQpn = dev->data.target_remote_qpns[targetIdx];
       const uint32_t dataSigQkey = dev->data.target_qkey[targetIdx];
 
-      /* Chunk payloads that exceed the EFA per-write limit.
+      /* Chunk payloads that exceed the EFA per-op limit.
        *
-       * A single RDMA write is capped at EFA_GDA_MAX_WRITE_SIZE (1 GiB).
+       * A single RDMA write is capped at EFA_GDA_MAX_RDMA_OP_SIZE (1 GiB).
        * Split larger payloads into full-size leading chunks plus a tail
        * (<= cap); the tail is posted by the normal signal/counter-carrying
        * path below.
@@ -509,8 +525,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * fires and the caller's counter does not tick. They are posted
        * non-aggregated so their doorbells ring (the drain below only counts
        * rung WQEs). */
-      if (hasPayload && bytes > (size_t)EFA_GDA_MAX_WRITE_SIZE) {
-        const size_t cap = (size_t)EFA_GDA_MAX_WRITE_SIZE;
+      if (hasPayload && bytes > (size_t)EFA_GDA_MAX_RDMA_OP_SIZE) {
+        const size_t cap = (size_t)EFA_GDA_MAX_RDMA_OP_SIZE;
         const size_t nLeading = (bytes - 1) / cap; /* tail is (0, cap] */
         /* Peer's DATA EP tuple: target slot 0 -> idx = 0*nranks + peer. */
         const uint32_t dataIdx = (uint32_t)peer;
@@ -518,8 +534,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
         const uint16_t dQpn = dev->data.target_remote_qpns[dataIdx];
         const uint32_t dQkey = dev->data.target_qkey[dataIdx];
         for (size_t i = 0; i < nLeading; i++) {
-          postRdmaWrite<mode>(&dev->data, dAh, dQpn, dQkey, absSrcAddr + i * cap, srcLkey, (uint32_t)cap,
-                              absDstAddr + i * cap, dstRkey, ncclGinOptFlagsDefault);
+          postRdmaOp<mode>(&dev->data, dAh, dQpn, dQkey, absSrcAddr + i * cap, srcLkey, (uint32_t)cap,
+                           absDstAddr + i * cap, dstRkey, ncclGinOptFlagsDefault);
         }
         /* EFA SRD is unordered: the tail landing does not imply the leading
          * chunks landed. So when the tail announces completion (signal or
@@ -556,8 +572,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * addressed to the resolved target so the receiver's FI_REMOTE_WRITE
        * fires once. absSrcAddr/absDstAddr/writeBytes already point at the
        * payload or the scratch region per the hasPayload branch above. */
-      postRdmaWrite<mode>(main_ep, main_ah, main_qpn, main_qkey, absSrcAddr, srcLkey, writeBytes, absDstAddr, dstRkey,
-                          optFlags);
+      postRdmaOp<mode>(main_ep, main_ah, main_qpn, main_qkey, absSrcAddr, srcLkey, writeBytes, absDstAddr, dstRkey,
+                       optFlags);
 
       /* Remaining (signalCount - 1) signal increments: 0-byte writes to
        * the peer scratch region on the DATA endpoint, so the caller's
@@ -565,8 +581,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * signalCount > 1, which implies an INDEXED Add (and thus a
        * signal endpoint target). */
       for (uint32_t k = 1u; k < signalCount; k++) {
-        postRdmaWrite<mode>(&dev->data, dataSigAh, dataSigQpn, dataSigQkey, dev->scratch_local_addr, dev->scratch_lkey,
-                            0u, dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer], optFlags);
+        postRdmaOp<mode>(&dev->data, dataSigAh, dataSigQpn, dataSigQkey, dev->scratch_local_addr, dev->scratch_lkey, 0u,
+                         dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer], optFlags);
       }
     }
   }
@@ -597,6 +613,78 @@ NCCL_DEVICE_INLINE static void putImpl(ncclGinCtx ctx, Coop coop, int peer, bool
     putImplMode<NCCL_GIN_RESOURCE_SHARING_GPU>(ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff, bytes, signal,
                                                signalOp, signalOpArg, hasCounter, counterId, hasDescriptor, descriptor,
                                                required, given, optFlags);
+    break;
+  }
+}
+
+/* ── getImplMode: mode-templated Get implementation ──────────────── */
+
+/* Fetches `bytes` from the peer's `remoteWin` into this rank's `localWin` with RDMA
+ * reads on the data endpoint.
+ *
+ * Get is the reverse of Put and reuses the same post path: the RDMA address pair
+ * carries the peer's window (the source the NIC reads) and the SGE carries the local
+ * window (the destination it fills), with postRdmaOp's op selecting the
+ * direction. The fetched bytes become observable to the caller once the read
+ * completes, which the caller establishes with flush or flushAsync/wait. */
+template <ncclGinResourceSharingMode mode, typename Coop>
+NCCL_DEVICE_INLINE static void getImplMode(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t remoteWin,
+                                           size_t remoteOff, ncclGinWindow_t localWin, size_t localOff, size_t bytes,
+                                           uint32_t optFlags) {
+  coop.sync();
+  if (coop.thread_rank() == 0) {
+    nccl_ofi_gin_gdaki_dev_handle* dev = getDevHandle(ctx);
+
+    /* Both windows resolve to this context's rail, as in Put. The peer's window
+     * supplies the remote address and rkey; this rank's window supplies the local
+     * address and lkey. */
+    nccl_ofi_gin_gdaki_mr_handle* remoteMh = ((nccl_ofi_gin_gdaki_mr_handle**)remoteWin)[dev->rail_id];
+    nccl_ofi_gin_gdaki_mr_handle* localMh = ((nccl_ofi_gin_gdaki_mr_handle**)localWin)[dev->rail_id];
+    uint64_t absRemoteAddr = remoteMh->peers[peer].remote_addr + remoteOff;
+    uint32_t remoteRkey = remoteMh->peers[peer].rkey;
+    uint64_t absLocalAddr = localMh->local_addr + localOff;
+    uint32_t localLkey = localMh->lkey;
+
+    /* Target slot 0 addresses the peer's data endpoint, which is the endpoint that
+     * serves window memory. */
+    const uint32_t targetIdx = 0u * (uint32_t)dev->nranks + (uint32_t)peer;
+    const uint16_t ah = dev->data.target_address_handles[targetIdx];
+    const uint16_t qpn = dev->data.target_remote_qpns[targetIdx];
+    const uint32_t qkey = dev->data.target_qkey[targetIdx];
+
+    /* One RDMA read carries at most EFA_GDA_MAX_RDMA_OP_SIZE, so a larger fetch splits
+     * into full-size chunks plus a tail, advancing both sides together. A zero-byte
+     * fetch posts one zero-length read rather than nothing, so that it still produces
+     * a completion for flush and flushAsync/wait to terminate on. */
+    const size_t cap = (size_t)EFA_GDA_MAX_RDMA_OP_SIZE;
+    size_t remaining = bytes;
+    uint64_t remoteAddr = absRemoteAddr;
+    uint64_t localAddr = absLocalAddr;
+    do {
+      const size_t chunk = (remaining > cap) ? cap : remaining;
+      postRdmaOp<mode, EFA_GDA_RDMA_READ>(&dev->data, ah, qpn, qkey, localAddr, localLkey, (uint32_t)chunk, remoteAddr,
+                                          remoteRkey, optFlags);
+      remoteAddr += chunk;
+      localAddr += chunk;
+      remaining -= chunk;
+    } while (remaining > 0);
+  }
+  coop.sync();
+}
+
+/* ── getImpl: dispatch on the context's resource-sharing mode ────── */
+
+template <typename Coop>
+NCCL_DEVICE_INLINE static void getImpl(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t remoteWin, size_t remoteOff,
+                                       ncclGinWindow_t localWin, size_t localOff, size_t bytes, uint32_t optFlags) {
+  switch ((ncclGinResourceSharingMode)ctx.resourceSharingMode) {
+  case NCCL_GIN_RESOURCE_SHARING_CTA:
+    getImplMode<NCCL_GIN_RESOURCE_SHARING_CTA>(ctx, coop, peer, remoteWin, remoteOff, localWin, localOff, bytes,
+                                               optFlags);
+    break;
+  default:
+    getImplMode<NCCL_GIN_RESOURCE_SHARING_GPU>(ctx, coop, peer, remoteWin, remoteOff, localWin, localOff, bytes,
+                                               optFlags);
     break;
   }
 }
@@ -653,21 +741,21 @@ NCCL_DEVICE_INLINE static void putValueImplMode(ncclGinCtx ctx, Coop coop, int p
     /* Value write: stage srcVal into pvdata's pool and RDMA-write it to the
      * destination. The arrival ticks the target sc EP's FI_REMOTE_WRITE once
      * (signalled) or no signal (no-signal). */
-    postRdmaWrite<mode>(ep, ah, qpn, qkey, /*srcAddr=*/0, /*srcLkey=*/0,
-                        /*writeBytes=*/(uint32_t)sizeof(T), absDstAddr, dstRkey,
-                        /*optFlags=*/ncclGinOptFlagsDefault,
-                        /*pvSrcVal=*/&srcVal, /*pvValBytes=*/(uint32_t)sizeof(T),
-                        /*pvLkey=*/dev->putvalue_lkey,
-                        /*pvSliceBase=*/ep->putvalue_slice_base,
-                        /*pvSlotSize=*/dev->putvalue_slot_size);
+    postRdmaOp<mode>(ep, ah, qpn, qkey, /*srcAddr=*/0, /*srcLkey=*/0,
+                     /*writeBytes=*/(uint32_t)sizeof(T), absDstAddr, dstRkey,
+                     /*optFlags=*/ncclGinOptFlagsDefault,
+                     /*pvSrcVal=*/&srcVal, /*pvValBytes=*/(uint32_t)sizeof(T),
+                     /*pvLkey=*/dev->putvalue_lkey,
+                     /*pvSliceBase=*/ep->putvalue_slice_base,
+                     /*pvSlotSize=*/dev->putvalue_slot_size);
 
     /* Remaining (signalCount - 1) signal increments: 0-byte writes to
      * the peer scratch region on the DATA endpoint. The loop body is empty
      * unless signalCount > 1, which implies an INDEXED Add (and thus a
      * signal endpoint target). */
     for (uint32_t k = 1u; k < signalCount; k++) {
-      postRdmaWrite<mode>(ep, ah, qpn, qkey, dev->scratch_local_addr, dev->scratch_lkey, 0u,
-                          dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer]);
+      postRdmaOp<mode>(ep, ah, qpn, qkey, dev->scratch_local_addr, dev->scratch_lkey, 0u,
+                       dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer]);
     }
   }
   (void)hasDescriptor;
@@ -714,7 +802,7 @@ NCCL_DEVICE_INLINE static ncclResult_t flushImplMode(ncclGinCtx ctx, Coop coop, 
     else (void)startCycle; // referenced only when HasTimeout is true
 
     /* For each endpoint with outstanding work, spin on the NIC-written
-     * FI_WRITE counter until it catches up with submitted_count.
+     * FI_WRITE + FI_READ counter until it catches up with submitted_count.
      * submitted_count is re-read (scoped relaxed atomic load matching the
      * relaxed bumps from the post path) on every iteration rather than
      * snapshotted once: another thread may keep posting on this context
@@ -727,7 +815,7 @@ NCCL_DEVICE_INLINE static ncclResult_t flushImplMode(ncclGinCtx ctx, Coop coop, 
       cuda::atomic_ref<uint64_t, ncclGinScope<mode>> target_ref(ep.submitted_count);
 
       /* Drain-to-zero: outstanding = (submitted - completed) reduced to
-       * 31 bits, since the NIC FI_WRITE counter wraps at 2^31. Wait until
+       * 31 bits, since the NIC FI_WRITE + FI_READ counter wraps at 2^31. Wait until
        * no work is outstanding. Outstanding is bounded by sq_size « 2^31,
        * so the masked difference is exact and cannot be fooled by a
        * counter wrap. */
@@ -822,19 +910,9 @@ struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_EFA_GDA> {
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t remoteWin, size_t remoteOff,
                                       ncclGinWindow_t localWin, size_t localOff, size_t bytes, bool hasDescriptor,
                                       ncclGinDescriptorSmem* descriptor, uint32_t optFlags = ncclGinOptFlagsDefault) {
-    coop.sync();
-    /* TODO: implement with efa_cuda_init_rdma_read_wr */
-    (void)ctx;
-    (void)peer;
-    (void)remoteWin;
-    (void)remoteOff;
-    (void)localWin;
-    (void)localOff;
-    (void)bytes;
     (void)hasDescriptor;
     (void)descriptor;
-    (void)optFlags;
-    coop.sync();
+    nccl::gin::efa_gda::getImpl(ctx, coop, peer, remoteWin, remoteOff, localWin, localOff, bytes, optFlags);
   }
 };
 


### PR DESCRIPTION
## Description

<!-- Clearly describe what the PR does and why -->

Get was a stub.


## Changes & Impact

<!-- Note any breaking changes or API modifications -->

Get rides the data endpoint. The plugin binds that endpoint's local completion counter FI_WRITE | FI_READ, so a read's completion is visible to the SQ ring-reuse backpressure and to the blocking Flush.

A read and a write populate identical WR fields — the RDMA address pair holds the remote address and rkey, the SGE holds the local buffer — and only the opcode differs, deciding which way the bytes move. So the whole post path is reusable: parameterize it on the operation instead of duplicating it.

- getImpl dispatches on the resource-sharing mode, like putImpl.

- getImplMode resolves the peer's window as the source and this rank's window as the destination, addresses the peer's data endpoint (target slot 0, the endpoint that serves window memory), and chunks the fetch at the EFA per-operation limit. A zero-byte fetch posts one zero-length read, so flush and flushAsync/wait have a completion to terminate on.

- postRdmaWrite becomes postRdmaOp, templated on efaGdaRdmaOp op, and selects the read or write WR builder. Every other line of it, including warp coalescing, the doorbell rendezvous, req_id stamping and both backpressure gates, is unchanged and now serves Get too.


## Performance Impact

<!-- If possible include benchmark results for performance changes & list what testing you've performed -->

