### PR TITLE
graph: size the fused topology XML for all local ranks

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -1958,15 +1958,11 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
   NCCLCHECKGOTO(bootstrapIntraNodeAllGather(comm->bootstrap, localRanks, localRank, nLocalRanks, mem,
                                             xmlMemSize(NCCL_TOPO_XML_MAX_NODES)),
                 ret, fail);
-  if (comm->MNNVL) {
-    // Ensure that we have enough room when fusing topos from multiple nodes.
-    free(xml);
-    xml = NULL;
-    NCCLCHECKGOTO(xmlAlloc(&xml, nLocalRanks * NCCL_TOPO_XML_MAX_NODES), ret, fail);
-  } else {
-    // In the intra-node case there's no need to enlarge the topo xml.
-    xml->maxIndex = 0;
-  }
+  // Ensure that we have enough room when fusing the topos: subtrees with per-rank attributes (e.g. the gpu
+  // nodes) do not dedup, so the fused topo can exceed NCCL_TOPO_XML_MAX_NODES even in the intra-node case.
+  free(xml);
+  xml = NULL;
+  NCCLCHECKGOTO(xmlAlloc(&xml, nLocalRanks * NCCL_TOPO_XML_MAX_NODES), ret, fail);
   for (int i = 0; i < nLocalRanks; i++) {
     struct ncclXml* peerXml = (struct ncclXml*)(mem + xmlMemSize(NCCL_TOPO_XML_MAX_NODES) * i);
     NCCLCHECKGOTO(ncclTopoConvertXml(peerXml, (uintptr_t)peerXml->nodes, 0), ret, fail);


### PR DESCRIPTION
## Description

Fixes the "too many XML nodes (max 256)" failure in intra-node topology fusion.

In ncclTopoGetSystem each rank builds its own topology XML in a 256 node buffer, the local ranks exchange them and the result is fused into one tree. The MNNVL path allocates a bigger buffer for the fused tree (nLocalRanks x 256 nodes) but the intra-node path just reused the 256 node per-rank buffer. The fused tree is the union of all local trees though. Nodes only dedup when every attribute matches and the gpu node carries a per-rank "rank" attribute, so each rank's gpu subtree gets appended, plus anything else that differs per rank. On big hosts this goes past 256 and xmlAddTree fails, so ncclCommInitRank returns ncclInternalError.

This just makes the enlargement unconditional, same thing the MNNVL path already did.

## Related Issues

Fixes #2160

## Changes & Impact

One place in src/graph/topo.cc. The fused xml is now always allocated with nLocalRanks x NCCL_TOPO_XML_MAX_NODES nodes. The MNNVL path is unchanged in behavior, the intra-node path gets the same buffer size.

Tested on one GPU (RTX 2070) with several ranks on the same device (NCCL_MULTI_RANK_GPU_ENABLE=1) and a topology file that gives the gpu 18 nvlink children, so each rank contributes 19 nodes that cannot dedup: 12 ranks fuse to 233 nodes and pass, 14 ranks (271 nodes) fail before this change and pass after it. The fused NCCL_TOPO_DUMP_FILE output for 2 and 8 ranks is byte identical before and after. all_reduce_perf with -c 1 passes. Built with WERROR=1 and checked with an ASAN build. I could not test on a real multi GPU host, MNNVL, or with the EFA/IB plugins.

Out of scope: the 256 node limit when loading a topology file (NCCL_TOPO_FILE) is unchanged, and the warning text is the same.

## Performance Impact

Init only. The fused xml is freed at the end of ncclTopoGetSystem, so it is a transient host allocation of about 3.6 MB per local rank (8 GPUs: ~29 MB per process for the duration of topology detection). No change to the data path.