### PR TITLE
os: skip truncated shared objects before dlopen

### DIFF
--- a/src/os/linux.cc
+++ b/src/os/linux.cc
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <dlfcn.h>
+#include <elf.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -48,7 +49,75 @@ static void saveDlError() {
   }
 }
 
+// dlopen() of a shared object truncated inside one of its PT_LOAD segments kills the process with SIGBUS (glibc
+// maps the missing part and faults while zero-filling it), so refuse such files before loading them.
+// Returns 1 if the file is truncated, 0 if it looks loadable, -1 if dlopen() would skip it and search on.
+static int dlFileCheck(const char* path) {
+  int fd = open(path, O_RDONLY | O_CLOEXEC);
+  if (fd < 0) return -1;
+  int res = 0;
+  struct stat st;
+  Elf64_Ehdr ehdr;
+  if (fstat(fd, &st) == 0 && S_ISREG(st.st_mode) && pread(fd, &ehdr, sizeof(ehdr), 0) == (ssize_t)sizeof(ehdr) &&
+      memcmp(ehdr.e_ident, ELFMAG, SELFMAG) == 0) {
+    if (ehdr.e_ident[EI_CLASS] != ELFCLASS64) {
+      res = -1;
+    } else if (ehdr.e_phentsize == sizeof(Elf64_Phdr)) {
+      for (int i = 0; i < ehdr.e_phnum && res == 0; i++) {
+        Elf64_Phdr phdr;
+        off_t off = (off_t)ehdr.e_phoff + (off_t)i * (off_t)sizeof(phdr);
+        // Headers past the end of the file are rejected by dlopen() itself.
+        if (pread(fd, &phdr, sizeof(phdr), off) != (ssize_t)sizeof(phdr)) break;
+        if (phdr.p_type == PT_LOAD &&
+            (phdr.p_offset > (uint64_t)st.st_size || phdr.p_filesz > (uint64_t)st.st_size - phdr.p_offset)) {
+          res = 1;
+        }
+      }
+    }
+  }
+  close(fd);
+  return res;
+}
+
+// Best effort: only names we can resolve ourselves are checked, i.e. paths and bare names found in LD_LIBRARY_PATH.
+// dlopen() also consults RPATH/RUNPATH, hwcaps subdirectories and ld.so.cache, which are not emulated here.
+static bool dlCheckFile(const char* filename) {
+  if (filename == NULL) return true;
+  // Already loaded: dlopen() will not touch the file.
+  void* loaded = dlopen(filename, RTLD_NOLOAD | RTLD_LAZY);
+  if (loaded) {
+    dlclose(loaded);
+    return true;
+  }
+  char path[PATH_MAX];
+  const char* found = NULL;
+  int res = 0;
+  if (strchr(filename, '/')) {
+    found = filename;
+    res = dlFileCheck(found);
+  } else {
+    const char* dirs = getenv("LD_LIBRARY_PATH");
+    while (dirs && found == NULL) {
+      const char* end = strpbrk(dirs, ":;");
+      int len = end ? (int)(end - dirs) : (int)strlen(dirs);
+      // An empty entry stands for the current directory.
+      if (snprintf(path, sizeof(path), "%.*s/%s", len ? len : 1, len ? dirs : ".", filename) < (int)sizeof(path)) {
+        res = dlFileCheck(path);
+        if (res >= 0) found = path;
+      }
+      dirs = end ? end + 1 : NULL;
+    }
+  }
+  if (res == 1) {
+    snprintf(ncclDlErrorBuf, sizeof(ncclDlErrorBuf),
+             "%.180s: file is truncated (a segment ends beyond the end of the file)", found);
+    return false;
+  }
+  return true;
+}
+
 ncclOsLibraryHandle ncclOsDlopen(const char* filename) {
+  if (!dlCheckFile(filename)) return NULL;
   ncclOsLibraryHandle handle = dlopen(filename, RTLD_NOW | RTLD_LOCAL);
   if (handle == NULL) {
     saveDlError();
@@ -69,6 +138,7 @@ const char* ncclOsDlerror() {
 }
 
 ncclOsLibraryHandle ncclOsDlopen(const char* path, int mode) {
+  if (!dlCheckFile(path)) return NULL;
   ncclOsLibraryHandle handle = dlopen(path, (mode == NCCL_OS_DL_NOW) ? RTLD_NOW : RTLD_LAZY);
   if (handle == NULL) saveDlError();
   return handle;


### PR DESCRIPTION
## Description

A plugin .so that got truncated (copy interrupted, disk full, partial download) makes NCCL die with SIGBUS inside dlopen(). glibc checks that the ELF headers fit in the file but not that the PT_LOAD segments do, so it maps the missing part and faults while zero-filling the last page. There is no error to catch, the process is just gone, with no NCCL log line. Every other kind of broken plugin (missing, empty, not ELF, no symbols) is logged and skipped, this one was the exception.

This adds a best effort check in ncclOsDlopen (Linux only): when NCCL can tell which file dlopen is going to open, meaning the name is a path or a bare name that sits in one of the LD_LIBRARY_PATH directories, it reads the ELF program headers first and refuses the file if any PT_LOAD segment ends past the end of the file. The refusal goes through the normal dlerror path, so the plugin loader logs "Plugin: <name>: <path>: file is truncated (a segment ends beyond the end of the file)" and falls back like for any other unloadable plugin. Objects that are already loaded are not checked (dlopen does not touch the file for those), files the loader would skip (unreadable, wrong ELF class) are skipped the same way, and names that come from RPATH, hwcaps subdirs, ld.so.cache or the system directories are passed to dlopen unchanged.

## Related Issues

Fixes #2367

## Changes & Impact

src/os/linux.cc only: two static helpers plus one line at the top of each ncclOsDlopen overload, about 70 lines. Windows untouched. The check only runs on files it can find, and only rejects files that would either crash dlopen or load with silently truncated data, so a plugin that loads today still loads.

Tested on one GPU with a tiny .so truncated to 2000 bytes: before, NCCL_PROFILER_PLUGIN, NCCL_NET_PLUGIN, NCCL_TUNER_PLUGIN, NCCL_ENV_PLUGIN and a truncated libnccl-net.so found through LD_LIBRARY_PATH all killed the process with signal 7; after, all five are logged and skipped and the communicator comes up. A size sweep shows the check rejects every size between the end of the program headers and the end of the last segment, glibc's own "file too short" still handles smaller files, and intact files load. Also checked: empty LD_LIBRARY_PATH entry, ';' as separator, an unreadable copy earlier in the path, an already loaded copy (LD_PRELOAD with SONAME), directory or text or empty file in place of the plugin, missing file, zeroed program headers (all give the same dlopen messages as before), NVML still loads, the net and tuner example plugins load, WERROR=1 build, ASAN build, all_reduce_perf -c 1. Not tested: Windows, plugins resolved via RPATH or ld.so.cache (those are simply not pre-checked).

## Performance Impact

None on the data path. One open/fstat and two small reads per dlopen at init.