### PR TITLE
transport: agree on cuMem host buffers with the peer

### DIFF
--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -56,6 +56,7 @@ struct ncclPeerInfo {
   nvmlGpuFabricInfoV_t fabricInfo;
   int fabricHandleSupport;
   int cuMemSupport;
+  int cuMemHostSupport;
   int version;
   uint64_t supportedGinTypeBitMask;
   bool crossNicSupport;

--- a/src/init.cc
+++ b/src/init.cc
@@ -757,6 +757,7 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
   info->hostHash = getHostHash() + commHash;
   info->pidHash = getPidHash() + commHash;
   info->cuMemSupport = ncclCuMemEnable();
+  info->cuMemHostSupport = ncclCuMemEnable() && ncclCuMemHostEnable();
   info->fabricHandleSupport = 0;
   CUdevice currentDev;
   CUCHECK(cuDeviceGet(&currentDev, comm->cudaDev));

--- a/src/misc/cudawrap.cc
+++ b/src/misc/cudawrap.cc
@@ -50,57 +50,79 @@ int ncclCuMemEnable() {
   return param >= 0 ? param : (param == -2 && ncclCuMemSupported);
 }
 
-static int ncclCumemHostEnable = -1;
-int ncclCuMemHostEnable() {
-  if (ncclCumemHostEnable != -1) return ncclCumemHostEnable;
-#if CUDART_VERSION < 12020
-  ncclCumemHostEnable = 0;
-  return ncclCumemHostEnable;
-#else
-  ncclResult_t ret = ncclSuccess;
+#if CUDART_VERSION >= 12020
+// cuMem host allocation support per CUDA device (-1 = not probed yet). The probe allocates on the NUMA node
+// of the device, so its result can differ between the devices used by one process.
+static int* ncclCumemHostEnable = NULL;
+static int ncclCumemHostEnableCount = 0;
+static std::mutex ncclCumemHostEnableLock;
+
+static ncclResult_t ncclCuMemHostProbe(int cudaDev, int* enable) {
   int cudaDriverVersion;
-  int paramValue = -1;
-  CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
+  int paramValue;
+  CUDACHECK(cudaDriverGetVersion(&cudaDriverVersion));
   if (cudaDriverVersion < 12020) {
-    ncclCumemHostEnable = 0;
-  } else {
-    paramValue = ncclParamCuMemHostEnable();
-    if (paramValue != -1) ncclCumemHostEnable = paramValue;
-    else ncclCumemHostEnable = (cudaDriverVersion >= 12060) ? 1 : 0;
-    if (ncclCumemHostEnable) {
-      // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
-      // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").
-      int cudaDev;
-      CUdevice currentDev;
-      int cpuNumaNodeId = -1;
-      CUmemAllocationProp prop = {};
-      size_t granularity = 0;
-      size_t size;
-      CUmemGenericAllocationHandle handle;
-      CUDACHECK(cudaGetDevice(&cudaDev));
-      CUCHECK(cuDeviceGet(&currentDev, cudaDev));
-      CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID, currentDev));
-      if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
-      prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
-      prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-      prop.requestedHandleTypes = ncclCuMemHandleType;
-      prop.location.id = cpuNumaNodeId;
-      CUCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-      size = 1;
-      ALIGN_SIZE(size, granularity);
-      if (CUPFN(cuMemCreate(&handle, size, &prop, 0)) != CUDA_SUCCESS) {
-        INFO(NCCL_INIT, "cuMem host allocations do not appear to be working; falling back to a /dev/shm/ based "
-                        "implementation. This could be due to the container runtime disabling NUMA support. "
-                        "To disable this warning, set NCCL_CUMEM_HOST_ENABLE=0");
-        ncclCumemHostEnable = 0;
-      } else {
-        CUCHECK(cuMemRelease(handle));
-      }
+    *enable = 0;
+    return ncclSuccess;
+  }
+  paramValue = ncclParamCuMemHostEnable();
+  if (paramValue != -1) *enable = paramValue;
+  else *enable = (cudaDriverVersion >= 12060) ? 1 : 0;
+  if (*enable) {
+    // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
+    // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").
+    CUdevice currentDev;
+    int cpuNumaNodeId = -1;
+    CUmemAllocationProp prop = {};
+    size_t granularity = 0;
+    size_t size;
+    CUmemGenericAllocationHandle handle;
+    CUCHECK(cuDeviceGet(&currentDev, cudaDev));
+    CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID, currentDev));
+    if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
+    prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.requestedHandleTypes = ncclCuMemHandleType;
+    prop.location.id = cpuNumaNodeId;
+    CUCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+    size = 1;
+    ALIGN_SIZE(size, granularity);
+    if (CUPFN(cuMemCreate(&handle, size, &prop, 0)) != CUDA_SUCCESS) {
+      INFO(NCCL_INIT,
+           "cuMem host allocations do not appear to be working for device %d (NUMA node %d); falling back "
+           "to a /dev/shm/ based implementation. This could be due to the container runtime disabling "
+           "NUMA support. To disable this warning, set NCCL_CUMEM_HOST_ENABLE=0",
+           cudaDev, cpuNumaNodeId);
+      *enable = 0;
+    } else {
+      CUCHECK(cuMemRelease(handle));
     }
   }
-  return ncclCumemHostEnable;
-error:
-  return (ret == ncclSuccess);
+  return ncclSuccess;
+}
+#endif
+
+// Returns whether cuMem host allocations can be used for the current CUDA device.
+int ncclCuMemHostEnable() {
+#if CUDART_VERSION < 12020
+  return 0;
+#else
+  int cudaDev;
+  if (!CUDASUCCESS(cudaGetDevice(&cudaDev))) return 0;
+  std::lock_guard<std::mutex> lock(ncclCumemHostEnableLock);
+  if (ncclCumemHostEnable == NULL) {
+    int count;
+    if (!CUDASUCCESS(cudaGetDeviceCount(&count)) || ncclCalloc(&ncclCumemHostEnable, count) != ncclSuccess) return 0;
+    for (int i = 0; i < count; i++) ncclCumemHostEnable[i] = -1;
+    ncclCumemHostEnableCount = count;
+  }
+  if (cudaDev < 0 || cudaDev >= ncclCumemHostEnableCount) return 0;
+  if (ncclCumemHostEnable[cudaDev] == -1) {
+    int enable = 0;
+    if (ncclCuMemHostProbe(cudaDev, &enable) != ncclSuccess) enable = 0;
+    ncclCumemHostEnable[cudaDev] = enable;
+  }
+  return ncclCumemHostEnable[cudaDev];
 #endif
 }
 

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -87,6 +87,7 @@ struct connectMap {
 
 struct sendNetResources {
   struct connectMap map;
+  int shmLegacy;
   void* netSendComm;
   struct ncclSendMem* sendMem;
   struct ncclRecvMem* recvMem;
@@ -181,6 +182,7 @@ struct setupReq {
   int channelId;
   int connIndex;
   int sameDevice;  // proxy and kernel are on the same CUDA device
+  int shmLegacy;   // use a /dev/shm segment for the host buffer
 };
 
 NCCL_PARAM(NetOptionalRecvCompletion, "NET_OPTIONAL_RECV_COMPLETION", 1);
@@ -317,6 +319,8 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.tpRank = comm->topParentRanks[myInfo->rank];
   req.tpRemoteRank = comm->topParentRanks[peerInfo->rank];
   req.sameDevice = (comm->peerInfo[proxyRank].cudaDev == comm->cudaDev);
+  // The host buffer is created by the proxy rank and imported here, so both must support cuMem host memory.
+  req.shmLegacy = !myInfo->cuMemHostSupport || !comm->peerInfo[proxyRank].cuMemHostSupport;
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), NULL, 0));
 
   if (proxyRank == myInfo->rank) {
@@ -405,8 +409,8 @@ static ncclResult_t netMapShm(struct ncclComm* comm, struct ncclProxyConnector* 
   return ncclSuccess;
 }
 
-static ncclResult_t netCreateShm(struct ncclProxyState* proxyState, struct connectMapMem* mem) {
-  NCCLCHECK(ncclShmAllocateShareableBuffer(mem->size, false, &mem->createDesc, (void**)&mem->cpuPtr,
+static ncclResult_t netCreateShm(struct ncclProxyState* proxyState, struct connectMapMem* mem, bool legacy) {
+  NCCLCHECK(ncclShmAllocateShareableBuffer(mem->size, legacy, &mem->createDesc, (void**)&mem->cpuPtr,
                                            (void**)&mem->gpuPtr));
   return ncclSuccess;
 }
@@ -763,6 +767,7 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   resources->tpRemoteRank = req->tpRemoteRank;
   resources->netDev = req->netDev;
   resources->shared = connection->shared = req->shared;
+  resources->shmLegacy = req->shmLegacy;
   resources->useGdr = req->useGdr;
   resources->channelId = req->channelId;
   resources->connIndex = req->connIndex;
@@ -976,7 +981,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     NCCLCHECK(ncclCudaHostCalloc(&map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr, map->mems[NCCL_NET_MAP_HOSTMEM].size));
     map->mems[NCCL_NET_MAP_HOSTMEM].gpuPtr = map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr;
   } else {
-    NCCLCHECK(netCreateShm(proxyState, map->mems + NCCL_NET_MAP_HOSTMEM));
+    NCCLCHECK(netCreateShm(proxyState, map->mems + NCCL_NET_MAP_HOSTMEM, resources->shmLegacy));
     void* sendMem = (void*)NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
     void* recvMem = (void*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
     memset(sendMem, 0, sizeof(struct ncclSendMem));

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -33,6 +33,7 @@ struct ncclP2pRequest {
   size_t size;
   int refcount;
   int peerRank;
+  int shmLegacy;  // CE path: use a /dev/shm segment for the host buffer
 };
 
 struct p2pConnectInfo {
@@ -446,6 +447,8 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   req.size = sendSize;
   req.refcount = 0;
   req.peerRank = peerInfo->rank;  // Track which peer will import this buffer
+  // CE path: the host buffer is created by the proxy of info->rank and imported by the peer.
+  req.shmLegacy = !comm->peerInfo[info->rank].cuMemHostSupport || !peerInfo->cuMemHostSupport;
   if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) &&
       (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev)) {
     req.refcount++;
@@ -455,8 +458,8 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   }
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_P2P, 1, info->rank, &send->proxyConn));
   if (useMemcpy) {
-    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, NULL, 0, &resources->proxyInfo,
-                                    sizeof(struct p2pShmProxyInfo)));
+    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(struct ncclP2pRequest),
+                                    &resources->proxyInfo, sizeof(struct p2pShmProxyInfo)));
     memcpy(&info->desc, &resources->proxyInfo.desc, sizeof(ncclShmIpcDesc_t));
   } else {
     NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(struct ncclP2pRequest),
@@ -685,9 +688,11 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
                                       void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   if (useMemcpy) {
     // CE memcpy support
+    struct ncclP2pRequest* req = (struct ncclP2pRequest*)reqBuff;
     struct p2pShmProxyInfo* proxyInfo;
     size_t shmSize;
 
+    if (reqSize != sizeof(struct ncclP2pRequest)) return ncclInternalError;
     if (respSize != sizeof(struct p2pShmProxyInfo)) return ncclInternalError;
     NCCLCHECK(ncclCalloc(&proxyInfo, 1));
     connection->transportResources = proxyInfo;
@@ -696,7 +701,7 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
 
     // Create a SHM segment for the peer to attach to
     shmSize = sizeof(struct ncclSendMem) + sizeof(struct ncclRecvMem);
-    NCCLCHECK(ncclShmAllocateShareableBuffer(shmSize, false, &proxyInfo->desc, (void**)&proxyInfo->shm,
+    NCCLCHECK(ncclShmAllocateShareableBuffer(shmSize, req->shmLegacy, &proxyInfo->desc, (void**)&proxyInfo->shm,
                                              (void**)&proxyInfo->devShm));
 
     NCCLCHECK(ncclCudaHostCalloc(&proxyInfo->ceRecvMem, 1));

--- a/src/transport/shm.cc
+++ b/src/transport/shm.cc
@@ -102,8 +102,9 @@ static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
     for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) shmSize += comm->buffSizes[p];
   }
   req.size = shmSize;
-  if (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash) req.legacy = true;
-  else req.legacy = false;
+  // The peer can only import a cuMem host buffer if cuMem host allocations work on its side too.
+  req.legacy = (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash) ||
+               !myInfo->cuMemHostSupport || !peerInfo->cuMemHostSupport;
 
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_SHM, 1, myInfo->rank, &send->proxyConn));
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, (void*)&req, sizeof(struct shmRequest),
@@ -135,8 +136,9 @@ static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
     for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) shmSize += comm->buffSizes[p];
   }
   req.size = shmSize;
-  if (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash) req.legacy = true;
-  else req.legacy = false;
+  // The peer can only import a cuMem host buffer if cuMem host allocations work on its side too.
+  req.legacy = (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash) ||
+               !myInfo->cuMemHostSupport || !peerInfo->cuMemHostSupport;
 
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_SHM, 0, myInfo->rank, &recv->proxyConn));
   NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, (void*)&req, sizeof(struct shmRequest),
@@ -309,7 +311,7 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020
-  if (ncclCuMemEnable() && ncclCuMemHostEnable() && !legacy) {
+  if (!legacy) {
     // cuMem API support
     CUmemAllocationHandleType type = SHM_HANDLE_TYPE;
     CUmemGenericAllocationHandle handle;
@@ -362,7 +364,7 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, 
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020
-  if (ncclCuMemEnable() && ncclCuMemHostEnable() && !desc->legacy) {
+  if (!desc->legacy) {
     // cuMem API support
     CUdeviceptr hostptr = 0;
     CUmemAllocationHandleType type = SHM_HANDLE_TYPE;
@@ -451,7 +453,7 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, 
 ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t* desc) {
   if (desc) {
 #if CUDART_VERSION >= 12020
-    if (ncclCuMemEnable() && ncclCuMemHostEnable() && !desc->legacy) {
+    if (!desc->legacy) {
       NCCLCHECK(ncclCuMemHostFree(desc->shmci.ptr));
     } else {
       NCCLCHECK(ncclShmClose(desc->shmli.handle));


### PR DESCRIPTION
## Description

Since 2.26.3 every process probes whether cuMem host allocations work (`ncclCuMemHostEnable`) and falls back to `/dev/shm` when they do not. In the SHM transport the rank that allocates a buffer picks the kind from its own probe result, and the rank that imports it branches on *its* own probe result rather than on the descriptor's `legacy` flag. If the probe passes on one rank and fails on another, the fallback rank reads the cuMem handle bytes through the `/dev/shm` half of the `shmIpcDesc` union: the handle value becomes the file name and the zeroed tail becomes the size, which is exactly the reported `Error while attaching to shared memory segment /dev/shm/nccl-<garbage> (size 0)`. The analysis in the issue shows how the driver can reject `cuMemCreate(HOST_NUMA)` on some NUMA nodes but not others; any other reason for the probe to diverge produces the same failure.

This adds the cuMem host capability to `ncclPeerInfo`, next to the existing `cuMemSupport`, and requests a legacy `/dev/shm` segment whenever either side of a connection lacks it. The same rule is applied at the three places that allocate a host buffer for another process to import: the SHM transport (`shmSendSetup`/`shmRecvSetup`), the PXN shared buffer created by the proxy rank in the net transport (`netCreateShm`), and the P2P copy-engine path (`p2pSendProxySetup` with `NCCL_P2P_USE_CUDA_MEMCPY=1`). A rank that can use cuMem can always open a `/dev/shm` segment (that direction already works today), so mixed nodes now initialize. Pairs where both ranks can use cuMem host memory keep using it. The importer additionally refuses a cuMem descriptor it cannot decode with a clear message instead of trying a garbage path.

## Related Issues

Fixes #2190

## Changes & Impact

Five files, about 30 lines: `src/include/transport.h` (new `int cuMemHostSupport` in the internal `ncclPeerInfo`, exchanged at init like the other fields), `src/init.cc` (`fillInfo` sets it from `ncclCuMemEnable() && ncclCuMemHostEnable()`, the same predicate the allocator uses), `src/transport/shm.cc` (the `req.legacy` decision in both setup functions, plus the importer check), `src/transport/net.cc` (`setupReq.shmLegacy` computed in `sendSetup` from the importing rank and the proxy rank, carried to `netCreateShm`), `src/transport/p2p.cc` (`ncclP2pRequest.shmLegacy`; the CE branch of `p2pSendSetup` now sends the request it already builds). No public API or ABI change; no data-path change.

Tested on one GPU with two processes that rendezvous through `NCCL_COMM_ID` and use the SHM transport, with `NCCL_CUMEM_HOST_ENABLE` set to 1 in one process and 0 in the other: before, the rank set to 0 fails with the exact message from the issue in both directions of the mismatch; after, both directions initialize, complete an all-reduce, and log `MMAP imported` on both sides. Both matching configurations behave as before (`CUMEM`/`MMAP` unchanged). Also run: `all_reduce_perf -g 1 -c 1`, an in-process two-rank all-reduce over P2P and over SHM (same-process pairs still use the legacy segment), `WERROR=1` build, `DEBUG=1 ASAN=1` build through the reproducer. Not tested: multi-GPU PCIe nodes where SHM is chosen naturally (two ranks on one GPU are at PATH_LOC distance and always take P2P, so a local test hook was needed to force SHM), the PXN path (no NIC here) and the CE path (its per-communicator proxy pool does not fit twice in this container's 64 MB `/dev/shm`), fabric handle types, Windows.

Note, out of scope: the probe runs once per process for the device current on first call, so a single process driving GPUs on several NUMA nodes still applies one node's answer to all of them.

## Performance Impact

None on the data path. One call to a cached function per rank at init. Connections involving a rank that cannot use cuMem host memory use `/dev/shm`, which is what that rank already did for its own buffers.