### PR TITLE
profiler/example: fix zero timestamps in the trace

### DIFF
--- a/plugins/profiler/example/event.h
+++ b/plugins/profiler/example/event.h
@@ -72,7 +72,7 @@ struct kernelPhase {
 };
 
 struct kernelCh {
-  uint8_t type;
+  uint64_t type;                    // must be first and 64-bit: handle dispatch reads *(uint64_t*)
   uint8_t channelId;
   struct taskEventBase* parent;
   double startTs;

--- a/plugins/profiler/example/plugin.cc
+++ b/plugins/profiler/example/plugin.cc
@@ -553,6 +553,7 @@ __hidden ncclResult_t exampleProfilerStartEvent(void* context, void** eHandle, n
       return ncclSuccess;
     }
     event->type = ncclProfileCollApi;
+    event->startTs = gettime() - startTime;
     event->collApiId = collApiId;
     event->ctx = ctx;
     event->func = eDescr->collApi.func;
@@ -582,6 +583,7 @@ __hidden ncclResult_t exampleProfilerStartEvent(void* context, void** eHandle, n
       return ncclSuccess;
     }
     event->type = ncclProfileP2pApi;
+    event->startTs = gettime() - startTime;
     event->p2pApiId = p2pApiId;
     event->ctx = ctx;
     event->func = eDescr->p2pApi.func;
@@ -607,6 +609,7 @@ __hidden ncclResult_t exampleProfilerStartEvent(void* context, void** eHandle, n
       return ncclSuccess;
     }
     event->type = ncclProfileKernelLaunch;
+    event->startTs = gettime() - startTime;
     event->ctx = ctx;
     event->stream = (cudaStream_t) eDescr->kernelLaunch.stream;
     struct groupApi* parent = (struct groupApi *) eDescr->parentObj;


### PR DESCRIPTION
## Description

Two small fixes to the example profiler plugin, both visible as "ts": 0.000000 in the JSON trace it writes.

The CollApi, P2pApi and KernelLaunch events never had their startTs set in exampleProfilerStartEvent, so every one of their begin records prints ts 0.0 (the README sample trace shows it too). Every other event kind stamps startTs there, these three just missed it when they were added in 2.28.

struct kernelCh still declares type as uint8_t, but since 2.28 the plugin reads the event type of every handle as *(uint64_t*) (the new API event bits do not fit in a byte). For a KernelCh handle that read returns type + 256 * channelId, which only matches ncclProfileKernelCh for channel 0. For every other channel updateEvent and recordEventState fall through, so the end record has ts 0.0 and StopGpuClk 0, and the parent event's refCount is never dropped. This is the same one-line change as #1973, I folded it in because the issue thread covers both and a trace still looks broken with only one of them fixed. Happy to drop that hunk if you would rather take #1973.

## Related Issues

Fixes #1961
Overlaps with #1973 (kernelCh.type width)

## Changes & Impact

plugins/profiler/example/plugin.cc: three lines, event->startTs = gettime() - startTime for CollApi, P2pApi and KernelLaunch.
plugins/profiler/example/event.h: struct kernelCh type is uint64_t. This grows the struct by 8 bytes per channel slot in the collective and p2p pools, nothing serializes it.

One visible side effect of the event.h change: since the KernelCh stop now runs for every channel, the refCount cascade KernelCh -> Coll/P2p -> CollApi/P2pApi completes again, so the end records of those parent events move from enqueue time to the completion of the last channel, which is how the plugin already behaved for single channel traces and what the comment in exampleProfilerStopEvent describes. Traces diffed before and after differ only in numeric fields.

Tested on one GPU (RTX 2070) with 2 and 4 ranks on the same device (NCCL_MULTI_RANK_GPU_ENABLE=1), NCCL_PROFILER_PLUGIN=example, NCCL_PROFILE_EVENT_MASK=4095 and 4 channels. Before: all 20 API begin records per rank have ts 0.0 and 28 of 32 KernelCh end records (every one on channels 1..3) have ts 0.0 and StopGpuClk 0. After: none. Single channel traces are unchanged. The plugin builds clean with -Wall -Wextra (same pre-existing warnings as before). Not tested on multi GPU hosts, with PXN, or with CE collectives, none of which touch these lines.

Out of scope: the README sample trace still shows the old zeros and lists pool sizes of 256 while the defaults in plugin.cc are 8. The inspector plugin has its own event structs and is not affected.

## Performance Impact

None on NCCL itself. In the plugin one extra clock_gettime per profiled API call, same as every other event already does.