### PR TITLE
Use CUDACC to detect CUDA compilation in two headers

### DIFF
--- a/src/include/bitops.h
+++ b/src/include/bitops.h
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "compiler.h"
 
-#if !__NVCC__
+#ifndef __CUDACC__
 #ifndef __host__
 #define __host__
 #endif

--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -33,7 +33,7 @@ std::mutex& getGdrMutex();
 } while(false)
 
 // This is required as the GDR memory is mapped WC
-#if !defined(__NVCC__)
+#if !defined(__CUDACC__)
 #if defined(__PPC__)
 static inline void wc_store_fence(void) { asm volatile("sync" : : : "memory"); }
 #elif defined(__x86_64__) || (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))


### PR DESCRIPTION
## Description

bitops.h and gdrwrap.h check `__NVCC__` to decide whether they are being compiled as CUDA code. That macro only says "the compiler is nvcc". Clang can compile CUDA too and does not define it, so under clang both headers take the plain C++ path: bitops.h enters its `__host__`/`__device__` fallback block (harmless today only because clang predefines both macros) and gdrwrap.h compiles its host-only write combining fence into a CUDA translation unit. The macro every CUDA compiler defines for this is `__CUDACC__`, which is what the public nccl_device headers already use.

Note that `__CUDACC__` has to be tested with `defined()`, clang defines it empty so `#if !__CUDACC__` is a hard error there. `__CUDA_ARCH__` (suggested in the issue) is not a fit either, it is only defined in the device pass and is undefined in nvcc's own host pass.

## Related Issues

Fixes #1738

## Changes & Impact

Two lines: `#if !__NVCC__` becomes `#ifndef __CUDACC__` in src/include/bitops.h and `#if !defined(__NVCC__)` becomes `#if !defined(__CUDACC__)` in src/include/gdrwrap.h. nvcc defines both macros when compiling .cu files, which is the only way NCCL invokes it, so the nvcc build is unchanged (the preprocessed output is identical). Plain C++ compilation of .cc files defines neither, also unchanged. Only a clang CUDA compile of these headers behaves differently. One side effect: in nvcc's host only mode (nvcc -x c++, which NCCL does not use) only __NVCC__ is defined, and there the old bitops.h guard did not even compile while the new one does.

Tested on one GPU with nvcc 12.9 and clang 22: a small .cu that includes bitops.h and calls minval/maxval from a kernel compiles with both compilers before and after; a .cu that includes gdrwrap.h compiles with both, and with the fix clang no longer pulls in wc_store_fence; bitops.h still compiles as plain C++ with g++ and clang++; make src.build WERROR=1 and nccl-tests all_reduce_perf -c 1 with one and two ranks. NCCL itself cannot be built with clang as the device compiler (nvcc only flags in the Makefile and CMake), so this is a hygiene fix, not a build fix.

## Performance Impact

None.