### PR TITLE
Order the CTS fifo nreqs load after the idx check in ncclIbIsend

### DIFF
--- a/src/transport/net_ib/p2p.cc
+++ b/src/transport/net_ib/p2p.cc
@@ -296,6 +296,8 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
     *request = NULL;
     return ncclSuccess;
   }
+  // Order the nreqs load after the idx load above; on weakly ordered CPUs it could otherwise return a stale value.
+  std::atomic_thread_fence(std::memory_order_acquire);
   nreqs = slots[0].nreqs;
   // Wait until all data has arrived
   for (int r = 1; r < nreqs; r++) {


### PR DESCRIPTION
## Description

In `ncclIbIsend` the sender polls the CTS fifo slot that the receiver's NIC writes by RDMA. It checks `slots[0].idx` and then reads `slots[0].nreqs`, but nothing orders the second load after the first. The only fence in that block comes after both loads, so it protects the tag/addr/rkey reads that follow but not `nreqs` itself. On CPUs that can reorder independent loads (Arm, POWER) the `nreqs` load can be satisfied before the `idx` load and return the value from the slot's previous use. Slots are never cleared and get reused every 256 rounds, so that stale value can be non zero: if it is bigger than the real count, the `while (slots[r].idx != idx)` loop spins forever on an element the receiver never writes and the proxy thread hangs; if it is smaller, too few RDMA writes get posted. x86 keeps loads in order, which is why this never showed up there.

This adds an acquire fence between the `idx` check and the `nreqs` load, same style as the fence a few lines below. On x86 it is a compiler-only barrier (no instruction emitted), on AArch64 it is one `dmb ishld` on the path where the CTS has actually arrived.

## Related Issues

Fixes #1983

## Changes & Impact

One fence and a comment in `src/transport/net_ib/p2p.cc`, in `ncclIbIsend`. Only the IB/RoCE transport send path is touched.

Tested here on x86 only: `make src.build` and `make src.build WERROR=1` are clean, `git clang-format --diff master` is clean, nccl-tests single rank and two MPI processes pass with `-c 1`. The x86 object gets no new barrier instruction. I compiled a standalone extract of the poll loop for aarch64 to check that the fence lands between the two loads (`dmb ishld`) and is absent without the patch. I do not have an Arm host with an RDMA NIC, so I could not reproduce the hang itself; the fix follows from the memory model and the maintainer comment on the issue.

## Performance Impact

None on x86. On AArch64 one `dmb ishld` per successful CTS poll on the proxy thread, next to the existing full `dmb ish`.