### PR TITLE
Fix IB MR cache ordering on deregistration

### DIFF
--- a/src/transport/net_ib/reg.cc
+++ b/src/transport/net_ib/reg.cc
@@ -105,7 +105,11 @@ ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) 
   for (int i = 0; i < cache->population; i++) {
     if (mhandle == cache->slots[i].mr) {
       if (0 == --cache->slots[i].refs) {
-        memmove(&cache->slots[i], &cache->slots[--cache->population], sizeof(struct ncclIbMr));
+        cache->population--;
+        if (i < cache->population) {
+          memmove(cache->slots + i, cache->slots + i + 1,
+                  (cache->population - i) * sizeof(struct ncclIbMr));
+        }
         if (cache->population == 0) {
           free(cache->slots);
           cache->slots = NULL;


### PR DESCRIPTION
# Fix IB MR cache ordering after deregistration

## Description

The IB MR cache is maintained in ascending address order during insertion. Its lookup stops at the first entry whose address is greater than the requested address.

When an MR reference count reaches zero, the current deregistration path replaces the removed entry with the last cache entry. Removing any non-tail entry can therefore break the ordering invariant. A later registration may stop before reaching an existing MR and register the same memory range again.

For example:

```text
Initial cache:       [A, B, C, D]
Remove A (current):  [D, B, C]
Register B again:    stops at D and creates a duplicate MR
```

## Changes & Impact

Shift all entries after the removed MR one position to the left. This preserves the ordering required by the lookup logic.

The change is limited to the IB MR cache removal path and does not modify public APIs or communication algorithms.

## Performance Impact

No measurable regression was observed.

Four-GPU A30 AllReduce:

```text
Baseline average bus bandwidth: 5.43316 GB/s
Fixed average bus bandwidth:    5.41851 GB/s
Out-of-bounds values:           0
```

Two-GPU A30 AllReduce with P2P and SHM disabled to force NET/IB:

```text
Baseline average bus bandwidth: 5.86740 GB/s
Fixed average bus bandwidth:    5.86784 GB/s
Out-of-bounds values:           0
```

## Testing

Built the baseline and fixed versions for sm_80 in Release mode with `WERROR=1`.

A focused test uses NCCL's production IB registration functions and a real mlx5 protection domain. It registers four ascending memory regions, removes the first, middle, and last entries independently, and verifies:

- the exact remaining cache entries and order;
- MR handles are reused when surviving regions are registered again;
- reference counts increase correctly;
- all MR and cache resources are released successfully.

Results:

```text
Baseline:
delete_first:  delete=fail reuse=fail refs=fail cleanup=pass
delete_middle: delete=fail reuse=fail refs=fail cleanup=pass
delete_last:   delete=pass reuse=pass refs=pass cleanup=pass
exit code: 1

Fixed:
delete_first:  delete=pass reuse=pass refs=pass cleanup=pass
delete_middle: delete=pass reuse=pass refs=pass cleanup=pass
delete_last:   delete=pass reuse=pass refs=pass cleanup=pass
exit code: 0
```

## Related Issues

None found in the public issue tracker.