### PR TITLE
Propagate UDS proxy service errors

### DIFF
--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -2043,7 +2043,12 @@ void* ncclProxyServiceUDS(void* _args) {
 
     if (pollfds[0].revents) {
       // A request was seen on the UDS fd
-      proxyUDSRecvReq(proxyState, pollfds[0].fd);
+      ncclResult_t ret = proxyUDSRecvReq(proxyState, pollfds[0].fd);
+      if (ret != ncclSuccess) {
+        COMPILER_ATOMIC_STORE(&proxyState->asyncResult, ret, std::memory_order_release);
+        COMPILER_ATOMIC_STORE(proxyState->abortFlag, uint32_t(1), std::memory_order_release);
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Propagate errors from the UDS proxy service to the communicator instead of
leaving clients blocked waiting for an fd response that will never arrive.

`ncclProxyServiceUDS` currently ignores the return value from
`proxyUDSRecvReq`. If exporting a cuMem handle or sending the fd response
fails, the service continues polling while the requesting thread remains in
`ncclIpcSocketRecvMsg` indefinitely.

This change stores the service error in `proxyState->asyncResult` and sets the
communicator abort flag. The waiting client then returns an NCCL error through
the existing abort check.

## Related Issues

Related to #2379. The reporter's spontaneous failure has not been reproduced
on the available four-GPU PCIe system, but the permanent-wait behavior after a
UDS response failure is deterministic.

## Changes & Impact

- Check the result of `proxyUDSRecvReq`.
- Publish the failure through the proxy async result.
- Abort the affected communicator to wake clients blocked in UDS receive.

The successful UDS request path is unchanged.

## Performance Impact

No expected steady-state performance impact. The new branch runs only after a
UDS request has already failed.

Four-GPU AllReduce from 8 B through 64 MiB:

- Baseline average bus bandwidth: 5.42546 GB/s
- Fixed average bus bandwidth: 5.46973 GB/s
- Baseline and fixed: `#wrong 0`

## Testing

Environment:

- Four GPUs, PCIe topology
- CUDA 13.3
- NCCL master `fd168324a3dc0c9080fd4881b6c7f4bb252a95a2`
- Strict build with `WERROR=1`, `sm_80`

Focused fault-injection test:

1. An `LD_PRELOAD` shim makes the first UDS fd response `sendmsg` fail with
   `EIO`.
2. Baseline initializes the communicators but completes no collective and
   times out after 30.056 seconds.
3. Fixed NCCL returns an error on all four ranks in 645 milliseconds instead
   of hanging.

Normal-path stress:

- 50 communicators initialized as one NCCL group.
- First AllReduce submitted on every communicator.
- 20 create/use/destroy cycles.
- 4000 communicator lifecycles and 4000 validated collectives completed.
- No errors; fd count returned to baseline after every cycle.