### PR TITLE
Dispatch IB async events by context and port

### DIFF
--- a/src/transport/net_ib/common.cc
+++ b/src/transport/net_ib/common.cc
@@ -165,9 +165,10 @@ static void ncclIbUpdateDeviceSpeed(struct ncclIbDev* dev) {
 std::thread ncclIbAsyncThread;
 void* ncclIbAsyncThreadMain(void* args) {
   struct ncclIbDev* dev = (struct ncclIbDev*)args;
+  struct ibv_context* context = dev->context;
   while (1) {
     struct ibv_async_event event;
-    if (ncclSuccess != wrap_ibv_get_async_event(dev->context, &event)) break;
+    if (ncclSuccess != wrap_ibv_get_async_event(context, &event)) break;
     char* str;
     struct ibv_cq* cq = event.element.cq;    // only valid if CQ error
     struct ibv_qp* qp = event.element.qp;    // only valid if QP error
@@ -177,7 +178,9 @@ void* ncclIbAsyncThreadMain(void* args) {
     case IBV_EVENT_DEVICE_FATAL:
       // the above is device fatal error
       WARN("NET/IB : %s:%d async fatal event: %s", dev->devName, dev->portNum, str);
-      ncclIbDevFatalError(dev);
+      for (int d = 0; d < ncclNIbDevs; d++) {
+        if (ncclIbDevs[d].context == context) ncclIbDevFatalError(ncclIbDevs + d);
+      }
       break;
     case IBV_EVENT_CQ_ERR:
       WARN("NET/IB : %s:%d async fatal event on CQ (%p) handle=%u cqe=%d: %s", dev->devName, dev->portNum, cq,
@@ -206,14 +209,19 @@ void* ncclIbAsyncThreadMain(void* args) {
       WARN("NET/IB : %s:%d async fatal event on SRQ, unused for now (%p): %s", dev->devName, dev->portNum, srq, str);
       break;
     case IBV_EVENT_GID_CHANGE:
-      if (ncclIbEventGidChange(dev) != ncclSuccess) {
-        WARN("NET/IB : %s:%d marking device with fatal error after GID-change event handler failed", dev->devName,
-             dev->portNum);
-        ncclIbDevFatalError(dev);
-      }
-      break;
     case IBV_EVENT_DEVICE_SPEED_CHANGE:
-      ncclIbUpdateDeviceSpeed(dev);
+      // A context can contain multiple ports and Data Direct entries for the same port.
+      for (int d = 0; d < ncclNIbDevs; d++) {
+        struct ncclIbDev* portDev = ncclIbDevs + d;
+        if (portDev->context != context || portDev->portNum != event.element.port_num) continue;
+        if (event.event_type == IBV_EVENT_DEVICE_SPEED_CHANGE) {
+          ncclIbUpdateDeviceSpeed(portDev);
+        } else if (ncclIbEventGidChange(portDev) != ncclSuccess) {
+          WARN("NET/IB : %s:%d marking device with fatal error after GID-change event handler failed",
+               portDev->devName, portDev->portNum);
+          ncclIbDevFatalError(portDev);
+        }
+      }
       break;
     case IBV_EVENT_PATH_MIG_ERR:
     case IBV_EVENT_PORT_ERR:

--- a/src/transport/net_ib/init.cc
+++ b/src/transport/net_ib/init.cc
@@ -452,10 +452,6 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
                  ncclIbDevs[ncclNIbDevs].speed, context, ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].ar,
                  ncclIbDevs[ncclNIbDevs].oooRqSize);
 
-            ncclIbAsyncThread = std::thread(ncclIbAsyncThreadMain, ncclIbDevs + ncclNIbDevs);
-            ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", ncclNIbDevs);
-            ncclIbAsyncThread.detach();
-
             ncclNIbDevs++;
             nPorts++;
           }
@@ -513,6 +509,15 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       vProps.ndevs = 1;
       vProps.devs[0] = d;
       NCCLCHECK(ncclIbMakeVDeviceInternal(&vDev, &vProps));
+    }
+    // Start one reader per context only after the device table is complete and sorted.
+    for (int d = 0; d < ncclNIbDevs; d++) {
+      int first = 0;
+      while (first < d && ncclIbDevs[first].context != ncclIbDevs[d].context) first++;
+      if (first != d) continue;
+      ncclIbAsyncThread = std::thread(ncclIbAsyncThreadMain, ncclIbDevs + d);
+      ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", d);
+      ncclIbAsyncThread.detach();
     }
     char addrline[SOCKET_NAME_MAXLEN + 1];
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",


### PR DESCRIPTION
## Description

Fix port-scoped IB async event dispatch when multiple NCCL devices share an
`ibv_context`.

Each port currently starts an event reader, but `ibv_get_async_event()` reads
from the shared context. A port 2 event may be consumed by port 1's reader.
The handler then queries `dev->portNum` and refreshes port 1, leaving port 2's
GID or speed cache stale. New connections can copy that stale GID cache.

## Related Issues

Fixes #1819.

#2183 refreshes the GID during recovery. This patch fixes the earlier async
event dispatch to the per-device cache.

## Reproduction

The focused test compiles the production `common.cc` and mocks the verbs/GID
query boundaries:

1. Create port 1 and port 2 entries sharing one context.
2. Inject a port 2 `IBV_EVENT_GID_CHANGE`.
3. Deliver it to the reader represented by port 1.
4. Return a new GID for port 2 and inspect both caches and a new communicator
   snapshot.

Baseline:

```text
event port=2, reader port=1
query_port port=1
query_gid  port=1
port 2 cache/snapshot: index 2 (stale)
```

Fixed:

```text
event port=2, reader port=1
query_port port=2
query_gid  port=2
port 2 cache/snapshot: index 102
```

The same test covers speed changes, query failures, Data Direct aliases,
context isolation, and fatal-event ownership.

Results:

| Test | Baseline | Fixed |
|---|---:|---:|
| 27 focused cases | 10 failures | 0 failures |
| 100 runs in two reader modes | Same failures every run | 5,400 cases passed |
| UBSan | N/A | 27 cases passed |

## Changes & Impact

- Start one event reader per context after device enumeration and sorting.
- Dispatch GID and speed events by source context and
  `event.element.port_num`.
- Update all matching entries, including Data Direct aliases.
- Mark all entries on a context when it reports `IBV_EVENT_DEVICE_FATAL`.

This only affects the NET/IB async control path. There are no API,
configuration, collective, or transfer-path changes.

## Performance Impact

No data-path impact is expected. Default and forced-NET/IB AllReduce smoke
tests passed with zero validation errors.

## Testing

- Base: `fd168324a3dc0c9080fd4881b6c7f4bb252a95a2`
- Fix: `d3797ba68e7e3164bb995b2ba9ff5441421ec97d`
- Release builds: CUDA 13.3, `sm_80`, `WERROR=1`
- Fixed UBSan focused test: 27/27 passed
- Default and forced-NET/IB AllReduce: six runs per version, all correct

The reproducer injects events at wrapper boundaries; it does not reproduce an
IP reassignment on multi-port hardware. It also bypasses `ncclIbInitDevices()`,
so the post-sort reader startup is not covered by the focused test.
