### PR TITLE
Fix typo in ibverbs dlopen failure message

### DIFF
--- a/src/misc/ibvsymbols.cc
+++ b/src/misc/ibvsymbols.cc
@@ -84,7 +84,7 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
     if (ibVerbsLib[i] == nullptr) continue;
     ibvhandle = dlopen(ibVerbsLib[i], RTLD_NOW);
     if (ibvhandle) break;
-    INFO(NCCL_INIT, "Count not open %s", ibVerbsLib[i]);
+    INFO(NCCL_INIT, "Could not open %s", ibVerbsLib[i]);
   }
   if (ibvhandle == nullptr) goto teardown;
 


### PR DESCRIPTION
Problem: The dlopen failure log reads "Count not open".
Solution: Correct the wording to "Could not open".

## Description

`buildIbvSymbols()` logs `"Count not open %s"` when `dlopen()` fails to open an
ibverbs library. Corrected to `"Could not open %s"`.

## Related Issues

None.

## Changes & Impact

One-word log string fix in `src/misc/ibvsymbols.cc`. No API or behavior change.

## Performance Impact

None — log message text only.

