### PR TITLE
graph/os: close the topology file and sysfs directory on error paths

### DIFF
--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -298,8 +298,9 @@ ncclResult_t ncclTopoDumpXmlToFile(const char* xmlTopoFile, struct ncclXml* xml)
     INFO(NCCL_GRAPH | NCCL_ENV, "Unable to open %s, not dumping topology.", xmlTopoFile);
     return ncclSuccess;
   }
-  NCCLCHECK(ncclTopoDumpXmlRec(0, file, xml->nodes));
-  fclose(file);
+  ncclResult_t res = ncclTopoDumpXmlRec(0, file, xml->nodes);
+  fclose(file);  // close the file whether or not the dump succeeded
+  NCCLCHECK(res);
   return ncclSuccess;
 }
 
@@ -420,8 +421,9 @@ ncclResult_t ncclTopoGetXmlFromFile(const char* xmlTopoFile, struct ncclXml* xml
   INFO(NCCL_GRAPH, "Loading topology file %s", xmlTopoFile);
   struct xmlHandler handlers[] = {{"system", ncclTopoXmlLoadSystem}};
   xml->maxIndex = 0;
-  NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
-  fclose(file);
+  ncclResult_t res = xmlLoadSub(file, xml, NULL, handlers, 1);
+  fclose(file);  // close the file whether or not the parse succeeded
+  NCCLCHECK(res);
 #elif NCCL_OS_WINDOWS
   (void)xmlTopoFile;
   (void)xml;
@@ -1292,8 +1294,9 @@ ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXm
   }
   struct xmlHandler handlers[] = {{"graphs", ncclTopoXmlGraphLoadGraphs}};
   xml->maxIndex = 0;
-  NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
-  fclose(file);
+  ncclResult_t res = xmlLoadSub(file, xml, NULL, handlers, 1);
+  fclose(file);  // close the file whether or not the parse succeeded
+  NCCLCHECK(res);
   return ncclSuccess;
 }
 

--- a/src/os/linux.cc
+++ b/src/os/linux.cc
@@ -692,6 +692,7 @@ ncclResult_t ncclOsGetPciDeviceClassByBusId(const char* busId, char* deviceClass
 }
 
 ncclResult_t ncclOsGetBcmLinks(const char* busId, int* nlinks, char** peers) {
+  ncclResult_t ret = ncclSuccess;
   *nlinks = 0;
   *peers = NULL;
 
@@ -712,13 +713,14 @@ ncclResult_t ncclOsGetBcmLinks(const char* busId, int* nlinks, char** peers) {
       free(path);
 
       // Add to peers list
-      NCCLCHECK(ncclRealloc(peers, (*nlinks) * BUSID_SIZE, ((*nlinks) + 1) * BUSID_SIZE));
+      NCCLCHECKGOTO(ncclRealloc(peers, (*nlinks) * BUSID_SIZE, ((*nlinks) + 1) * BUSID_SIZE), ret, exit);
       memcpy((*peers) + BUSID_SIZE * (*nlinks)++, file->d_name, BUSID_SIZE);
     }
-    closedir(dir);
+exit:
+    closedir(dir);  // also on the realloc failure path
   }
 
-  return ncclSuccess;
+  return ret;
 }
 
 ncclResult_t ncclOsGetNumaNodeAffinity(unsigned int numaId, char* affinityStr, size_t maxLen, int* cpuOffset) {


### PR DESCRIPTION
## Problem

Four error paths return with an open handle:

- `ncclTopoDumpXmlToFile`, `ncclTopoGetXmlFromFile`, `ncclTopoGetXmlGraphFromFile` (`src/graph/xml.cc`): each `fopen`s the topology/graph file and then `NCCLCHECK`s the XML dump/parse **before** `fclose`, so a failure — e.g. a malformed `NCCL_TOPO_FILE` / `NCCL_GRAPH_FILE` — returns with the `FILE*` leaked (and, for the dump, unflushed).
- `ncclOsGetBcmLinks` (`src/os/linux.cc`): `opendir`s the Broadcom switch link directory and `NCCLCHECK`s the peers `ncclRealloc` inside the `readdir` loop, returning without `closedir` if it fails.

## Fix

- xml.cc: capture the result, `fclose`, then `NCCLCHECK(res)` — the same shape as the fd fixes in #2267 / #2376.
- linux.cc: `ncclResult_t ret`, `NCCLCHECKGOTO(..., ret, exit)` and an `exit:` label just before `closedir(dir)` inside the same `if (dir)` block, returning `ret`.

No behaviour change on the success paths.

I don't have a CUDA build environment here, so this was checked by inspection plus an independent review pass (goto legality, double close, semantic change).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
