### PR TITLE
strongstream: destroy the temporary stream on the error paths of ncclStreamAdvanceToEvent

### DIFF
--- a/src/misc/strongstream.cc
+++ b/src/misc/strongstream.cc
@@ -393,43 +393,51 @@ ncclResult_t ncclStreamAdvanceToEvent(struct ncclCudaGraph g, cudaStream_t s, cu
   if (g.graphId == ULLONG_MAX) {
     CUDACHECK(cudaStreamWaitEvent(s, e, 0));
   } else {
+    ncclResult_t ret = ncclSuccess;
     cudaStream_t tmp;
-    CUDACHECK(cudaStreamCreateWithFlags(&tmp, cudaStreamNonBlocking));
-    CUDACHECK(cudaStreamWaitEvent(tmp, e, 0));
-
+    // Declared before the first goto below so that `fail` does not cross an initialization.
     cudaStreamCaptureStatus status;
     cudaGraphNode_t const* nodes;
     size_t count = 0;
+    cudaError_t res;
+    CUDACHECK(cudaStreamCreateWithFlags(&tmp, cudaStreamNonBlocking));
+    // From here on, every failure must destroy the temporary stream.
+    CUDACHECKGOTO(cudaStreamWaitEvent(tmp, e, 0), ret, fail);
+
 #if CUDART_VERSION >= 13000
-    cudaError_t res = cudaStreamGetCaptureInfo_v3(tmp, &status, nullptr, nullptr, &nodes, nullptr, &count);
+    res = cudaStreamGetCaptureInfo_v3(tmp, &status, nullptr, nullptr, &nodes, nullptr, &count);
 #else
-    cudaError_t res = cudaStreamGetCaptureInfo_v2(tmp, &status, nullptr, nullptr, &nodes, &count);
+    res = cudaStreamGetCaptureInfo_v2(tmp, &status, nullptr, nullptr, &nodes, &count);
 #endif
 
 #if CUDART_VERSION >= 12030
     if (res == cudaErrorLossyQuery) {
       // CUDA is telling us the dependencies have edge annotations.
       cudaGraphEdgeData const* edges;
-      CUDACHECK(cudaStreamGetCaptureInfo_v3(tmp, &status, nullptr, nullptr, &nodes, &edges, &count));
-      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, edges, count,
-                                                       cudaStreamSetCaptureDependencies));
+      CUDACHECKGOTO(cudaStreamGetCaptureInfo_v3(tmp, &status, nullptr, nullptr, &nodes, &edges, &count), ret, fail);
+      CUDACHECKGOTO(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, edges, count,
+                                                           cudaStreamSetCaptureDependencies), ret, fail);
     }
 #else
     if (false) {
     }
 #endif
     else {
-      CUDACHECK(res /* = cudaStreamGetCaptureInfo_v2(...)*/);
+      CUDACHECKGOTO(res /* = cudaStreamGetCaptureInfo_v2(...)*/, ret, fail);
 #if CUDART_VERSION >= 13000
-      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, nullptr, count,
-                                                       cudaStreamSetCaptureDependencies));
+      CUDACHECKGOTO(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, nullptr, count,
+                                                           cudaStreamSetCaptureDependencies), ret, fail);
 #else
-      CUDACHECK(cudaStreamUpdateCaptureDependencies(s, (cudaGraphNode_t*)nodes, count,
-                                                    cudaStreamSetCaptureDependencies));
+      CUDACHECKGOTO(cudaStreamUpdateCaptureDependencies(s, (cudaGraphNode_t*)nodes, count,
+                                                        cudaStreamSetCaptureDependencies), ret, fail);
 #endif
     }
 
     CUDACHECK(cudaStreamDestroy(tmp));
+    return ncclSuccess;
+fail:
+    (void)cudaStreamDestroy(tmp);
+    return ret;
   }
   return ncclSuccess;
 }


### PR DESCRIPTION
## Problem

`ncclStreamAdvanceToEvent` (graph-capture path) creates a temporary non-blocking stream, uses it to pull the event's capture dependencies into `s`, and destroys it at the end. Every `CUDACHECK` between the create and the destroy — `cudaStreamWaitEvent`, `cudaStreamGetCaptureInfo_v2/v3`, `cudaStreamUpdateCaptureDependencies(_v2)` — returns directly on failure, so the temporary stream is leaked on any of those error paths.

## Fix

Convert those checks to `CUDACHECKGOTO(..., ret, fail)` with a `fail:` label that destroys the temporary stream and returns the error, matching the label style already used in this file (`do_unlock`). The locals the earlier jumps would cross (`status`, `nodes`, `count`, `res`) are declared before the first `goto`, and `res` is assigned rather than initialized inside the `CUDART_VERSION` branches. The success path is unchanged.

Same class as #2267 / #2376 / #2403 (release on the error path).

I don't have a CUDA build environment here, so this was checked by inspection plus an independent review pass (goto legality across the `#if` branches, double destroy, semantic change).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
