### PR TITLE
Efa gda putvalue payload inline and flushAsync

### DIFF
--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -8,9 +8,9 @@
  * specializations that target EFA via efa-dp-direct.
  *
  * Implemented: Put (data + signal/counter endpoints, signal-only via
- *              scratch buffer), PutValue (value staged through the
- *              per-endpoint slot pool), Get, Flush, GetSignalPtr,
- *              GetCounterPtr, ResetSignal, ResetCounter.
+ *              scratch buffer), PutValue (inline in 128-byte RDMA-write
+ *              WQEs), Get, Flush, GetSignalPtr, GetCounterPtr,
+ *              ResetSignal, ResetCounter.
  * Stub: FlushAsync, Wait.
  *************************************************************************/
 
@@ -129,27 +129,49 @@ NCCL_DEVICE_INLINE static void ringDoorbell(efa_cuda_qp* qp, uint64_t* submitted
   dbrung_ref.store(target, cuda::memory_order_release);
 }
 
+/* ── RDMA payload encoders ───────────────────────────────────────── */
+
+/* Put, signal, and Get operations transfer their payload through an SGE. */
+struct RdmaSgeEncoder {
+  uint64_t addr;
+  uint32_t lkey;
+  uint32_t bytes;
+
+  NCCL_DEVICE_INLINE void encode(EfaCudaWrBuilder& wr) {
+    int ret = wr.set_sge(lkey, addr, bytes);
+    assert(ret == 0 && "EFA GDA: failed to encode RDMA SGE");
+    (void)ret;
+  }
+};
+
+/* PutValue carries its payload directly in the 128-byte RDMA-write WQE. */
+template <typename T>
+struct PutValuePayloadEncoder {
+  T srcVal;
+
+  NCCL_DEVICE_INLINE PutValuePayloadEncoder(T value) : srcVal(value) {}
+
+  NCCL_DEVICE_INLINE void encode(EfaCudaWrBuilder& wr) {
+    int ret = wr.set_inline_data(&srcVal, sizeof(T));
+    assert(ret == 0 && "EFA GDA: failed to encode inline PutValue");
+    (void)ret;
+  }
+};
+
 /* ── postRdmaOp: shared post path for Put, PutValue and Get ──────── */
 
-/* Posts an RDMA write on `ep`'s local QP (its FI_WRITE counter tracks
- * local completion) to the remote QP given by the explicit
- * (ah, qpn, qkey) tuple. The local poster QP and the remote target QP
- * are chosen independently by the caller: counterId selects the local
- * poster (this `ep`), the target slot selects the remote tuple (via the
- * poster's [total_slots*nranks] target table).
+/* Posts an RDMA operation on `ep`'s local QP to the remote QP given by
+ * the explicit (ah, qpn, qkey) tuple. The local poster QP and the remote
+ * target QP are chosen independently by the caller: counterId selects
+ * the local poster (this `ep`), the target slot selects the remote tuple
+ * (via the poster's [total_slots*nranks] target table).
  *
- * PutValue staging (pvSrcVal != nullptr): the caller posts from the
- * dedicated PutValue endpoint (pvdata), so each lane stages its value into
- * its own pool slot at pvSliceBase + (reserved SQ slot % sq_size) *
- * pvSlotSize and points the WR's SGE there. Put (pvSrcVal == nullptr) uses
- * the caller's fixed srcAddr/srcLkey. */
-template <ncclGinResourceSharingMode mode, efaGdaRdmaOp op = EFA_GDA_RDMA_WRITE>
+ * PayloadEncoder runs after this lane's SQ slot is known and either attaches
+ * a local SGE or writes inline data into the WQE. */
+template <ncclGinResourceSharingMode mode, efaGdaRdmaOp op = EFA_GDA_RDMA_WRITE, typename PayloadEncoder>
 NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle* ep, uint16_t ah, uint16_t qpn,
-                                          uint32_t qkey, uint64_t srcAddr, uint32_t srcLkey, uint32_t writeBytes,
-                                          uint64_t dstAddr, uint32_t dstRkey,
-                                          uint32_t optFlags = ncclGinOptFlagsDefault, const void* pvSrcVal = nullptr,
-                                          uint32_t pvValBytes = 0, uint32_t pvLkey = 0, uint64_t pvSliceBase = 0,
-                                          uint32_t pvSlotSize = 0) {
+                                          uint32_t qkey, uint64_t dstAddr, uint32_t dstRkey,
+                                          PayloadEncoder payloadEncoder, uint32_t optFlags = ncclGinOptFlagsDefault) {
   efa_cuda_qp* qp = (efa_cuda_qp*)ep->qp;
   uint64_t* submitted_count_ptr = &ep->submitted_count;
   uint64_t* local_cntr_ptr = ep->local_cntr_value;
@@ -161,7 +183,6 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
   efa_io_tx_wqe_128 wr_storage;
   uint16_t wqe_size = qp->sq.wr_ctx.wqe_size;
 
-  /* Only the SGE differs for PutValue, so set_sge is deferred. */
   EfaCudaWrBuilder wr(&qp->sq.wr_ctx, (uint8_t*)&wr_storage);
   /* The opcode is the only thing that differs between a Put and a Get here: both
    * carry the RDMA address pair (dstAddr, dstRkey) and the local buffer in the SGE,
@@ -295,20 +316,7 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
     if (my_idx >= chunk_start && my_idx < chunk_start + chunk_size) {
       uint32_t my_slot = chunk_base + (uint32_t)(my_idx - chunk_start);
 
-      uint64_t wrSrcAddr = srcAddr;
-      uint32_t wrSrcLkey = srcLkey;
-      if (pvSrcVal != nullptr) {
-        /* PutValue: stage the value into this lane's pool slot, then point
-         * the SGE at it. */
-        uint64_t slot_idx = (uint64_t)my_slot % (uint64_t)sq_size_val;
-        uint64_t local_addr = pvSliceBase + slot_idx * (uint64_t)pvSlotSize;
-        for (uint32_t b = 0; b < pvValBytes; b++) ((uint8_t*)local_addr)[b] = ((const uint8_t*)pvSrcVal)[b];
-        wrSrcAddr = local_addr;
-        wrSrcLkey = pvLkey;
-      }
-
-      /* Only the source SGE is per-lane, the rest of wr was already built above. */
-      wr.set_sge(wrSrcLkey, wrSrcAddr, writeBytes);
+      payloadEncoder.encode(wr);
 
       uint32_t sq_idx = my_slot & qp->sq.wq.queue_mask;
       int wqe_phase = (int)((my_slot >> qp->sq.wq.queue_size_shift) & 1u);
@@ -540,8 +548,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
         const uint16_t dQpn = dev->data.target_remote_qpns[dataIdx];
         const uint32_t dQkey = dev->data.target_qkey[dataIdx];
         for (size_t i = 0; i < nLeading; i++) {
-          postRdmaOp<mode>(&dev->data, dAh, dQpn, dQkey, absSrcAddr + i * cap, srcLkey, (uint32_t)cap,
-                           absDstAddr + i * cap, dstRkey, ncclGinOptFlagsDefault);
+          postRdmaOp<mode>(&dev->data, dAh, dQpn, dQkey, absDstAddr + i * cap, dstRkey,
+                           RdmaSgeEncoder{absSrcAddr + i * cap, srcLkey, (uint32_t)cap}, ncclGinOptFlagsDefault);
         }
         /* EFA SRD is unordered: the tail landing does not imply the leading
          * chunks landed. So when the tail announces completion (signal or
@@ -578,8 +586,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * addressed to the resolved target so the receiver's FI_REMOTE_WRITE
        * fires once. absSrcAddr/absDstAddr/writeBytes already point at the
        * payload or the scratch region per the hasPayload branch above. */
-      postRdmaOp<mode>(main_ep, main_ah, main_qpn, main_qkey, absSrcAddr, srcLkey, writeBytes, absDstAddr, dstRkey,
-                       optFlags);
+      postRdmaOp<mode>(main_ep, main_ah, main_qpn, main_qkey, absDstAddr, dstRkey,
+                       RdmaSgeEncoder{absSrcAddr, srcLkey, writeBytes}, optFlags);
 
       /* Remaining (signalCount - 1) signal increments: 0-byte writes to
        * the peer scratch region on the DATA endpoint, so the caller's
@@ -587,8 +595,9 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * signalCount > 1, which implies an INDEXED Add (and thus a
        * signal endpoint target). */
       for (uint32_t k = 1u; k < signalCount; k++) {
-        postRdmaOp<mode>(&dev->data, dataSigAh, dataSigQpn, dataSigQkey, dev->scratch_local_addr, dev->scratch_lkey, 0u,
-                         dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer], optFlags);
+        postRdmaOp<mode>(&dev->data, dataSigAh, dataSigQpn, dataSigQkey, dev->scratch_remote_addrs[peer],
+                         dev->scratch_remote_rkeys[peer],
+                         RdmaSgeEncoder{dev->scratch_local_addr, dev->scratch_lkey, 0u}, optFlags);
       }
     }
   }
@@ -668,8 +677,8 @@ NCCL_DEVICE_INLINE static void getImplMode(ncclGinCtx ctx, Coop coop, int peer, 
     uint64_t localAddr = absLocalAddr;
     do {
       const size_t chunk = (remaining > cap) ? cap : remaining;
-      postRdmaOp<mode, EFA_GDA_RDMA_READ>(&dev->data, ah, qpn, qkey, localAddr, localLkey, (uint32_t)chunk, remoteAddr,
-                                          remoteRkey, optFlags);
+      postRdmaOp<mode, EFA_GDA_RDMA_READ>(&dev->data, ah, qpn, qkey, remoteAddr, remoteRkey,
+                                          RdmaSgeEncoder{localAddr, localLkey, (uint32_t)chunk}, optFlags);
       remoteAddr += chunk;
       localAddr += chunk;
       remaining -= chunk;
@@ -744,24 +753,16 @@ NCCL_DEVICE_INLINE static void putValueImplMode(ncclGinCtx ctx, Coop coop, int p
     uint64_t absDstAddr = dstMh->peers[peer].remote_addr + dstOff;
     uint32_t dstRkey = dstMh->peers[peer].rkey;
 
-    /* Value write: stage srcVal into pvdata's pool and RDMA-write it to the
-     * destination. The arrival ticks the target sc EP's FI_REMOTE_WRITE once
-     * (signalled) or no signal (no-signal). */
-    postRdmaOp<mode>(ep, ah, qpn, qkey, /*srcAddr=*/0, /*srcLkey=*/0,
-                     /*writeBytes=*/(uint32_t)sizeof(T), absDstAddr, dstRkey,
-                     /*optFlags=*/ncclGinOptFlagsDefault,
-                     /*pvSrcVal=*/&srcVal, /*pvValBytes=*/(uint32_t)sizeof(T),
-                     /*pvLkey=*/dev->putvalue_lkey,
-                     /*pvSliceBase=*/ep->putvalue_slice_base,
-                     /*pvSlotSize=*/dev->putvalue_slot_size);
+    PutValuePayloadEncoder<T> payloadEncoder(srcVal);
+    postRdmaOp<mode>(ep, ah, qpn, qkey, absDstAddr, dstRkey, payloadEncoder, ncclGinOptFlagsDefault);
 
     /* Remaining (signalCount - 1) signal increments: 0-byte writes to
      * the peer scratch region on the DATA endpoint. The loop body is empty
      * unless signalCount > 1, which implies an INDEXED Add (and thus a
      * signal endpoint target). */
     for (uint32_t k = 1u; k < signalCount; k++) {
-      postRdmaOp<mode>(ep, ah, qpn, qkey, dev->scratch_local_addr, dev->scratch_lkey, 0u,
-                       dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer]);
+      postRdmaOp<mode>(ep, ah, qpn, qkey, dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer],
+                       RdmaSgeEncoder{dev->scratch_local_addr, dev->scratch_lkey, 0u});
     }
   }
   (void)hasDescriptor;

--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda.h
@@ -9,9 +9,42 @@
  *
  * Implemented: Put (data + signal/counter endpoints, signal-only via
  *              scratch buffer), PutValue (inline in 128-byte RDMA-write
- *              WQEs), Get, Flush, GetSignalPtr, GetCounterPtr,
- *              ResetSignal, ResetCounter.
- * Stub: FlushAsync, Wait.
+ *              WQEs), Get, Flush, FlushAsync, Wait,
+ *              GetSignalPtr, GetCounterPtr, ResetSignal, ResetCounter.
+ *
+ * COMPLETION
+ * ----------
+ * Every write is posted with COMP_REQ = 1, so the NIC writes one CQE per write
+ * and increments the posting endpoint's FI_WRITE hardware counter. Completion is
+ * read three ways:
+ *
+ *   *ep->local_cntr_value   per-QP completion: the endpoint's FI_WRITE NIC
+ *                     counter, read directly from GPU memory by the blocking
+ *                     Flush. Wraps at 2^31, so compared under EFA_CNTR_MASK.
+ *   *dev->completed_count_per_ctx  count of CQEs the host has drained from the
+ *                     shared CQ, host-published via gdrcopy. Read by the
+ *                     per-context CQ-overflow gate in postRdmaOp, which claims its
+ *                     span of submitted_count_per_ctx before waiting on it.
+ *   dev->ordered_completed_count_per_peer[peer]:
+ *                     a contiguous prefix in that peer's own posting sequence,
+ *                     derived from the shared CQ and host-published via gdrcopy.
+ *                     Read by FlushAsync/Wait and put's signal-ordering wait.
+ *
+ * The per-context and per-peer counts come from a host thread (the plugin's CQ
+ * progress pass, driven by NCCL's GIN progress thread) that drains the context's
+ * shared CQ. Each WQE stamps req_id with a (peer, pseq) split (peer in the high
+ * bits, pseq in the low NCCL_OFI_GDAKI_PSEQ_BITS bits), echoed by
+ * efa_io_cdesc_common::req_id, so the host reads peer and pseq from the CQE.
+ *
+ * The per-peer count is a contiguous prefix rather than a bare count, because EFA
+ * SRD completes out of order even to one peer: only "everything below N completed"
+ * proves a particular earlier write finished. Only a contiguous prefix expresses
+ * that, which is why the host derives per-peer from the CQ while per-QP stays the
+ * NIC counter.
+ *
+ * The FI_REMOTE_WRITE hardware counter is used for signal delivery; the FI_WRITE
+ * counter also backs the user-facing GIN counter value.
+ *
  *************************************************************************/
 
 #ifndef _NCCL_DEVICE_GIN_EFA_GDA_H_
@@ -26,6 +59,24 @@
 
 /* efa-dp-direct device functions (inline implementations) */
 #include "../../transport/net_efa_gda/efa-dp-direct/include/device/efa_cuda_dp_impl.cuh"
+
+/* This request carries what FlushAsync hands to Wait: a peer and a snapshot of
+ * that peer's submitted count.
+ *
+ * submitted_count_at_flush is ctx->submitted_count_per_peer[peer] read at the
+ * moment of the call: how many writes this CONTEXT had admitted to that peer,
+ * across every QP. FlushAsync copies the value rather than re-reading the counter
+ * later, because the counter keeps growing as more puts happen; copying it both
+ * excludes puts issued after the flushAsync (the contract) and guarantees the
+ * wait terminates. Wait compares the copy against the host-published per-peer
+ * ordered prefix, so one number suffices. */
+struct ncclGinEfaGdaRequest {
+  uint32_t peer;
+  uint32_t submitted_count_at_flush;
+  uint64_t reserved;
+};
+static_assert(sizeof(ncclGinEfaGdaRequest) <= sizeof(ncclGinRequest_t),
+              "ncclGinEfaGdaRequest must fit in ncclGinRequest_t");
 
 namespace nccl {
 namespace gin {
@@ -69,18 +120,40 @@ enum efaGdaRdmaOp {
   EFA_GDA_RDMA_READ
 };
 
+/* req_id is the field the EFA completion echoes back (efa_io_cdesc_common), and it
+ * carries a write's attribution: the peer in the high EFA_GDA_PEER_BITS, and the
+ * write's position in that peer's posting sequence (pseq) in the low
+ * EFA_GDA_PSEQ_BITS. The split must match NCCL_OFI_GDAKI_PSEQ_BITS in the plugin,
+ * which sizes the host's per-peer completion bitmap from the same number, and it
+ * caps the ranks this backend can address at 2^EFA_GDA_PEER_BITS. The assert below
+ * pins the two widths to the field they divide, so widening one without narrowing
+ * the other fails the build instead of silently aliasing peers or pseqs. */
+static constexpr uint32_t EFA_GDA_PSEQ_BITS = 32;
+static constexpr uint32_t EFA_GDA_PEER_BITS = 32;
+static constexpr uint64_t EFA_GDA_PSEQ_MASK = (1ull << EFA_GDA_PSEQ_BITS) - 1ull;
+static constexpr uint64_t EFA_GDA_PEER_MASK = (1ull << EFA_GDA_PEER_BITS) - 1ull;
+static_assert(EFA_GDA_PEER_BITS + EFA_GDA_PSEQ_BITS ==
+                (sizeof(decltype(efa_io_tx_meta_desc::req_id)) + sizeof(decltype(efa_io_tx_meta_desc::req_id_ex))) * 8,
+              "req_id must be split entirely between its peer and pseq fields");
+
 /* ── Atomic primitives parameterized on scope and memory order ────── */
 
-template <cuda::thread_scope Scope, cuda::memory_order Order>
-NCCL_DEVICE_INLINE static uint64_t scopedAtomicLoad(uint64_t* ptr) {
-  cuda::atomic_ref<uint64_t, Scope> r(*ptr);
+template <cuda::thread_scope Scope, cuda::memory_order Order, typename T>
+NCCL_DEVICE_INLINE static T scopedAtomicLoad(T* ptr) {
+  cuda::atomic_ref<T, Scope> r(*ptr);
   return r.load(Order);
 }
 
-template <cuda::thread_scope Scope, cuda::memory_order Order>
-NCCL_DEVICE_INLINE static void scopedAtomicAdd(uint64_t* ptr, uint64_t val) {
-  cuda::atomic_ref<uint64_t, Scope> r(*ptr);
+template <cuda::thread_scope Scope, cuda::memory_order Order, typename T>
+NCCL_DEVICE_INLINE static void scopedAtomicAdd(T* ptr, T val) {
+  cuda::atomic_ref<T, Scope> r(*ptr);
   r.fetch_add(val, Order);
+}
+
+template <cuda::thread_scope Scope, cuda::memory_order Order, typename T>
+NCCL_DEVICE_INLINE static T scopedAtomicFetchAdd(T* ptr, T val) {
+  cuda::atomic_ref<T, Scope> r(*ptr);
+  return r.fetch_add(val, Order);
 }
 
 /* ── NIC-written hardware counter (FI_WRITE / FI_REMOTE_WRITE) ────── */
@@ -95,6 +168,29 @@ NCCL_DEVICE_INLINE static void scopedAtomicAdd(uint64_t* ptr, uint64_t val) {
 template <cuda::memory_order Order = cuda::memory_order_acquire>
 NCCL_DEVICE_INLINE static uint64_t hwCounterLoad(uint64_t* ptr) {
   return scopedAtomicLoad<cuda::thread_scope_system, Order>(ptr);
+}
+
+/* ── Completion state (per-QP: NIC counter; per-ctx/per-peer: CQ-derived) ─── */
+
+/* This spins until `peer`'s first `target` writes on this context have all
+ * completed. It is sound on an out-of-order transport because the ordered prefix
+ * advances only over a contiguous run: a missing earlier completion holds the
+ * ordered prefix below the target however late that completion arrives. */
+template <bool HasTimeout>
+NCCL_DEVICE_INLINE static ncclResult_t waitPeerCompleted(nccl_ofi_gin_gdaki_dev_handle* dev, uint32_t peer,
+                                                         uint32_t target, uint32_t* abortFlag, uint64_t startCycle,
+                                                         uint64_t timeoutCycles) {
+  /* The signed difference orders the per-peer uint32 counter correctly across its
+   * wrap at 2^32, since the true gap is bounded by what can be in flight. */
+  while ((int32_t)(scopedAtomicLoad<cuda::thread_scope_system, cuda::memory_order_acquire>(
+                     &dev->ordered_completed_count_per_peer[peer]) -
+                   target) < 0) {
+    if NCCL_IF_CONSTEXPR (HasTimeout) {
+      if (clock64() - startCycle >= timeoutCycles) return ncclTimeout;
+    }
+    if (abortFlag && *abortFlag) return ncclInProgress;
+  }
+  return ncclSuccess;
 }
 
 /* ── ringDoorbell: shared doorbell-ring used by the post-path ring sites ─
@@ -158,7 +254,7 @@ struct PutValuePayloadEncoder {
   }
 };
 
-/* ── postRdmaOp: shared post path for Put, PutValue and Get ──────── */
+/* ── postRdmaOp: admission gate + shared post path for Put, PutValue and Get ── */
 
 /* Posts an RDMA operation on `ep`'s local QP to the remote QP given by
  * the explicit (ah, qpn, qkey) tuple. The local poster QP and the remote
@@ -167,15 +263,79 @@ struct PutValuePayloadEncoder {
  * (via the poster's [total_slots*nranks] target table).
  *
  * PayloadEncoder runs after this lane's SQ slot is known and either attaches
- * a local SGE or writes inline data into the WQE. */
+ * a local SGE or writes inline data into the WQE.
+ *
+ *
+ * `dev` and `peerIdx` identify the target peer: they drive req_id stamping and
+ * the per-peer and per-context backpressure and counts. */
 template <ncclGinResourceSharingMode mode, efaGdaRdmaOp op = EFA_GDA_RDMA_WRITE, typename PayloadEncoder>
-NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle* ep, uint16_t ah, uint16_t qpn,
-                                          uint32_t qkey, uint64_t dstAddr, uint32_t dstRkey,
+NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_handle* dev,
+                                          nccl_ofi_gin_gdaki_dev_endpoint_handle* ep, uint32_t peerIdx, uint16_t ah,
+                                          uint16_t qpn, uint32_t qkey, uint64_t dstAddr, uint32_t dstRkey,
                                           PayloadEncoder payloadEncoder, uint32_t optFlags = ncclGinOptFlagsDefault) {
+  /* ── Admission: leader-only over contiguous per-peer blocks ──────────
+   *
+   * A write takes its position in the peer's posting sequence once, then joins the
+   * posting pass below only when that position is inside the peer's window and the
+   * shared CQ has room. The lanes converged here partition by peer, one leader per
+   * peer reserves the subgroup's block with a single atomic, and that leader alone
+   * waits until the block's top position has room. The members idle at
+   * warp-internal syncs, so the PCIe-resident counters see one reader per peer
+   * instead of one per lane.
+   *
+   * Waiting while holding a block is safe because admission happens before the
+   * posting group is formed: a waiting lane holds no doorbell turn and no SQ slot.
+   * Every position below the block's base belongs to an earlier block, groups take
+   * the doorbell in strict slot order, and the max_batch gate in the posting pass
+   * bounds the un-rung depth, so the completions a leader waits for always reach
+   * the NIC without help from any lane waiting here. This needs
+   * max_batch + 32 < peer_window, which the plugin checks at context setup. */
+  cooperative_groups::coalesced_group active = cooperative_groups::coalesced_threads();
+  auto peerGroup = cooperative_groups::labeled_partition(active, peerIdx);
+
+  uint32_t blockSize = (uint32_t)peerGroup.num_threads();
+  uint32_t blockBase = 0;
+  if (peerGroup.thread_rank() == 0) {
+    blockBase = scopedAtomicFetchAdd<ncclGinScope<mode>, cuda::memory_order_relaxed>(
+      &dev->submitted_count_per_peer[peerIdx], blockSize);
+  }
+  blockBase = peerGroup.shfl(blockBase, 0);
+  uint32_t pseq = blockBase + (uint32_t)peerGroup.thread_rank();
+
+  if (peerGroup.thread_rank() == 0) {
+    uint32_t peerTop = blockBase + blockSize;
+    /* The block has room once the peer's ordered prefix has come within
+     * peer_window of the block's claimed count, which keeps the host's per-peer
+     * completion bitmap a fixed size and every live position in it distinct.
+     * The prefix only advances, so once the block fits it keeps fitting. */
+    while ((uint32_t)(peerTop - scopedAtomicLoad<cuda::thread_scope_system, cuda::memory_order_acquire>(
+                                  &dev->ordered_completed_count_per_peer[peerIdx])) > dev->peer_window) {
+      /* spin */
+    }
+      /* The block claims its span of the context's shared CQ with one atomic, then
+     * waits until the host has read enough entries for that span to fit within
+     * cq_depth, since an overflow drops completions. Claiming before waiting is
+     * what bounds occupancy: concurrent leaders reserve disjoint spans instead of
+     * all passing the same reading of an unclaimed counter. The host only advances
+     * completed_count_per_ctx, so once the span fits it keeps fitting. */
+    uint64_t cqTop = scopedAtomicFetchAdd<ncclGinScope<mode>, cuda::memory_order_relaxed>(dev->submitted_count_per_ctx,
+                                                                                          (uint64_t)blockSize) +
+                     (uint64_t)blockSize;
+    while (cqTop -
+             scopedAtomicLoad<cuda::thread_scope_system, cuda::memory_order_relaxed>(dev->completed_count_per_ctx) >
+           (uint64_t)dev->cq_depth) {
+        /* spin */
+    }
+  }
+  /* The members wait for their leader's admission here, and the peer subgroups
+   * then reconverge into the full active group, so the posting pass below still
+   * runs the warp as one group under one doorbell. */
+  peerGroup.sync();
+  active.sync();
+
+  /* ── Posting: one group per QP, one doorbell per batch ─────────────── */
   efa_cuda_qp* qp = (efa_cuda_qp*)ep->qp;
   uint64_t* submitted_count_ptr = &ep->submitted_count;
-  uint64_t* local_cntr_ptr = ep->local_cntr_value;
-  uint32_t sq_size_val = ep->sq_size;
 
   /* WQE staging buffer. Always the 128B form: the builder zeroes and the MMIO
    * loop copies only the QP's negotiated wqe_size, but sizing the storage to
@@ -183,15 +343,25 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
   efa_io_tx_wqe_128 wr_storage;
   uint16_t wqe_size = qp->sq.wr_ctx.wqe_size;
 
+  /* req_id carries this write's (peer, pseq): peer in the high bits, pseq in the low
+   * EFA_GDA_PSEQ_BITS, matching NCCL_OFI_GDAKI_PSEQ_BITS in the plugin. pseq is the
+   * position this write reserved in that peer's own posting sequence, the same
+   * counter FlushAsync snapshots. The EFA completion echoes req_id back
+   * (efa_io_cdesc_common), so the host reads peer and pseq from the CQE and advances
+   * that peer's ordered_completed_count_per_peer. The admission gate above admits a
+   * write only while its position is within peer_window of that prefix, so pseq
+   * uniquely identifies each live write. */
+  const uint64_t wrReqId =
+    (((uint64_t)peerIdx & EFA_GDA_PEER_MASK) << EFA_GDA_PSEQ_BITS) | ((uint64_t)pseq & EFA_GDA_PSEQ_MASK);
   EfaCudaWrBuilder wr(&qp->sq.wr_ctx, (uint8_t*)&wr_storage);
   /* The opcode is the only thing that differs between a Put and a Get here: both
    * carry the RDMA address pair (dstAddr, dstRkey) and the local buffer in the SGE,
    * and the opcode decides which way the bytes move. A read therefore arrives with
    * the REMOTE source in the RDMA pair and the LOCAL destination in the SGE. */
   if NCCL_IF_CONSTEXPR (op == EFA_GDA_RDMA_READ) {
-    wr.init_rdma_read((uint64_t)threadIdx.x, dstRkey, dstAddr);
+    wr.init_rdma_read(wrReqId, dstRkey, dstAddr);
   } else {
-    wr.init_rdma_write((uint64_t)threadIdx.x, dstRkey, dstAddr);
+    wr.init_rdma_write(wrReqId, dstRkey, dstAddr);
   }
   wr.set_remote(ah, (uint32_t)qpn, qkey);
   /* Tag the WQE as PPS-sensitive. GIN puts are small, high-rate writes, so
@@ -224,9 +394,9 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
    *                    window check below (gated on db_rung), so the EFA
    *                    staging limit is always respected.
    *
-   * Coalescing: lanes of a warp targeting the same QP form a group via
-   * coalesced_threads() + labeled_partition(qp). The leader reserves g
-   * = group.num_threads() contiguous slots; every member writes its own
+   * Coalescing: the active group's lanes targeting the same QP form a
+   * group via labeled_partition(qp). The leader reserves g
+   * = qpGroup.num_threads() contiguous slots; every member writes its own
    * WQE in parallel; the leader rings one doorbell for the batch.
    *
    * max_batch bound: a group may be larger than the EFA staging limit
@@ -235,17 +405,14 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
    *   - window-wait (leader): write only once the chunk fits within the
    *     released window [released, released + max_batch). This bounds
    *     un-doorbelled WQEs across ALL concurrent groups to max_batch.
-   *   - SQ ring-overflow wait (leader): the chunk's high-water slot must
-   *     be within sq_size of the NIC consumer (FI_WRITE counter).
    *   - members write their WQEs in parallel.
    *   - doorbell rendezvous (leader): wait until released == chunk_base
    *     (strict slot order across groups), ring the doorbell, then
    *     advance released to hand off to the next group. */
-  cooperative_groups::coalesced_group active = cooperative_groups::coalesced_threads();
-  auto group = cooperative_groups::labeled_partition(active, (unsigned long long)(uintptr_t)qp);
+  auto qpGroup = cooperative_groups::labeled_partition(active, (unsigned long long)(uintptr_t)qp);
 
-  int my_idx = group.thread_rank();
-  int group_size = group.num_threads();
+  int my_idx = qpGroup.thread_rank();
+  int group_size = qpGroup.num_threads();
   bool is_leader = (my_idx == 0);
   uint32_t max_batch = qp->sq.wq.max_batch;
 
@@ -261,7 +428,7 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
   if (is_leader) {
     base = pc_ref.fetch_add((uint32_t)group_size, cuda::memory_order_relaxed);
   }
-  base = group.shfl(base, 0);
+  base = qpGroup.shfl(base, 0);
 
   /* Chunk the group into windows of <= max_batch. */
   for (int chunk_start = 0; chunk_start < group_size; chunk_start += (int)max_batch) {
@@ -296,21 +463,8 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
           }
         }
       }
-      /* SQ ring-overflow backpressure on the chunk's high-water slot.
-       * Poll the NIC FI_WRITE counter with system-scope relaxed loads.
-       *
-       * In-flight count is computed as a 31-bit modular difference
-       * (producer chunk_next minus the NIC FI_WRITE counter): the HW
-       * counter wraps at 2^31 and chunk_next is uint32, so a plain
-       * widened subtraction would underflow once either side wraps.
-       * The true in-flight depth is bounded by sq_size (4096) « 2^31,
-       * so the masked difference is exact. */
-      while (((chunk_next - (uint32_t)hwCounterLoad<cuda::memory_order_relaxed>(local_cntr_ptr)) & EFA_CNTR_MASK) >
-             sq_size_val) {
-        /* spin */
-      }
     }
-    group.sync();   /* members wait for leader's backpressure before writing */
+    qpGroup.sync();   /* members wait for leader's backpressure before writing */
 
     /* Members in this window write their own WQE into their slot. */
     if (my_idx >= chunk_start && my_idx < chunk_start + chunk_size) {
@@ -338,7 +492,7 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
        * to the NIC whenever any doorbell rings a slot in this range. */
       cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_system);
     }
-    group.sync();   /* all members' WQE writes for this chunk are done */
+    qpGroup.sync();   /* all members' WQE writes for this chunk are done */
 
     if (is_leader) {
       /* Doorbell-order rendezvous: take the turn in strict slot order. */
@@ -368,7 +522,7 @@ NCCL_DEVICE_INLINE static void postRdmaOp(nccl_ofi_gin_gdaki_dev_endpoint_handle
       }
       base_ref.store(chunk_next, cuda::memory_order_release);   /* hand off to next group */
     }
-    group.sync();   /* chunk fully posted before the next chunk */
+    qpGroup.sync();   /* chunk fully posted before the next chunk */
   }
 }
 
@@ -548,7 +702,7 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
         const uint16_t dQpn = dev->data.target_remote_qpns[dataIdx];
         const uint32_t dQkey = dev->data.target_qkey[dataIdx];
         for (size_t i = 0; i < nLeading; i++) {
-          postRdmaOp<mode>(&dev->data, dAh, dQpn, dQkey, absDstAddr + i * cap, dstRkey,
+          postRdmaOp<mode>(dev, &dev->data, (uint32_t)peer, dAh, dQpn, dQkey, absDstAddr + i * cap, dstRkey,
                            RdmaSgeEncoder{absSrcAddr + i * cap, srcLkey, (uint32_t)cap}, ncclGinOptFlagsDefault);
         }
         /* EFA SRD is unordered: the tail landing does not imply the leading
@@ -561,19 +715,17 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
          * mean the data is there and the source buffer safe to reuse.
          * A plain put announces nothing, so nothing can observe its chunks
          * out of order; the wait is deferred to the caller's later flush /
-         * signaled put / barrier. The drain is whole-endpoint (outstanding
-         * == 0, same loop as flushImplMode) and must be: the FI_WRITE
-         * counter does not attribute completions to WQEs, so a fully
-         * drained endpoint is the only state that proves THIS put's chunks
-         * completed. That is required for correct signal delivery, even
-         * though it also waits on concurrent posters' writes. */
+         * signaled put / barrier.
+         *
+         * Before posting the signaled tail, this code waits for this
+         * peer's leading chunks to complete: it snapshots this peer's submitted count (which now
+         * covers the leading chunks) and waits for the host-published per-peer
+         * ordered prefix to reach it. The snapshot is per peer, so the wait covers
+         * only traffic to this peer and stays fixed against concurrent posters. */
         if (isIndexed || hasCounter) {
-          cuda::atomic_ref<uint64_t, ncclGinScope<mode>> submitted_ref(dev->data.submitted_count);
-          while (((((uint32_t)submitted_ref.load(cuda::memory_order_relaxed)) -
-                   (uint32_t)hwCounterLoad(dev->data.local_cntr_value)) &
-                  EFA_CNTR_MASK) != 0) {
-            /* spin: leading chunks in flight */
-          }
+          uint32_t target = scopedAtomicLoad<cuda::thread_scope_system, cuda::memory_order_acquire>(
+            &dev->submitted_count_per_peer[peer]);
+          (void)waitPeerCompleted</*HasTimeout=*/false>(dev, (uint32_t)peer, target, nullptr, 0, 0);
         }
         absSrcAddr += nLeading * cap;
         absDstAddr += nLeading * cap;
@@ -586,7 +738,7 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * addressed to the resolved target so the receiver's FI_REMOTE_WRITE
        * fires once. absSrcAddr/absDstAddr/writeBytes already point at the
        * payload or the scratch region per the hasPayload branch above. */
-      postRdmaOp<mode>(main_ep, main_ah, main_qpn, main_qkey, absDstAddr, dstRkey,
+      postRdmaOp<mode>(dev, main_ep, (uint32_t)peer, main_ah, main_qpn, main_qkey, absDstAddr, dstRkey,
                        RdmaSgeEncoder{absSrcAddr, srcLkey, writeBytes}, optFlags);
 
       /* Remaining (signalCount - 1) signal increments: 0-byte writes to
@@ -595,8 +747,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
        * signalCount > 1, which implies an INDEXED Add (and thus a
        * signal endpoint target). */
       for (uint32_t k = 1u; k < signalCount; k++) {
-        postRdmaOp<mode>(&dev->data, dataSigAh, dataSigQpn, dataSigQkey, dev->scratch_remote_addrs[peer],
-                         dev->scratch_remote_rkeys[peer],
+        postRdmaOp<mode>(dev, &dev->data, (uint32_t)peer, dataSigAh, dataSigQpn, dataSigQkey,
+                         dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer],
                          RdmaSgeEncoder{dev->scratch_local_addr, dev->scratch_lkey, 0u}, optFlags);
       }
     }
@@ -677,7 +829,7 @@ NCCL_DEVICE_INLINE static void getImplMode(ncclGinCtx ctx, Coop coop, int peer, 
     uint64_t localAddr = absLocalAddr;
     do {
       const size_t chunk = (remaining > cap) ? cap : remaining;
-      postRdmaOp<mode, EFA_GDA_RDMA_READ>(&dev->data, ah, qpn, qkey, remoteAddr, remoteRkey,
+      postRdmaOp<mode, EFA_GDA_RDMA_READ>(dev, &dev->data, (uint32_t)peer, ah, qpn, qkey, remoteAddr, remoteRkey,
                                           RdmaSgeEncoder{localAddr, localLkey, (uint32_t)chunk}, optFlags);
       remoteAddr += chunk;
       localAddr += chunk;
@@ -753,16 +905,20 @@ NCCL_DEVICE_INLINE static void putValueImplMode(ncclGinCtx ctx, Coop coop, int p
     uint64_t absDstAddr = dstMh->peers[peer].remote_addr + dstOff;
     uint32_t dstRkey = dstMh->peers[peer].rkey;
 
+      /* Value write: the value rides inline in the WQE and is RDMA-written to the
+     * destination. The arrival ticks the target sc EP's FI_REMOTE_WRITE once
+     * (signalled) or no signal (no-signal). */
     PutValuePayloadEncoder<T> payloadEncoder(srcVal);
-    postRdmaOp<mode>(ep, ah, qpn, qkey, absDstAddr, dstRkey, payloadEncoder, ncclGinOptFlagsDefault);
+    postRdmaOp<mode>(dev, ep, (uint32_t)peer, ah, qpn, qkey, absDstAddr, dstRkey, payloadEncoder,
+                     ncclGinOptFlagsDefault);
 
     /* Remaining (signalCount - 1) signal increments: 0-byte writes to
      * the peer scratch region on the DATA endpoint. The loop body is empty
      * unless signalCount > 1, which implies an INDEXED Add (and thus a
      * signal endpoint target). */
     for (uint32_t k = 1u; k < signalCount; k++) {
-      postRdmaOp<mode>(ep, ah, qpn, qkey, dev->scratch_remote_addrs[peer], dev->scratch_remote_rkeys[peer],
-                       RdmaSgeEncoder{dev->scratch_local_addr, dev->scratch_lkey, 0u});
+      postRdmaOp<mode>(dev, ep, (uint32_t)peer, ah, qpn, qkey, dev->scratch_remote_addrs[peer],
+                       dev->scratch_remote_rkeys[peer], RdmaSgeEncoder{dev->scratch_local_addr, dev->scratch_lkey, 0u});
     }
   }
   (void)hasDescriptor;
@@ -873,6 +1029,46 @@ NCCL_DEVICE_INLINE static ncclResult_t flushImpl(ncclGinCtx ctx, Coop coop, cuda
   }
 }
 
+/* ── FlushAsync / Wait: one per-peer count against one published word ── */
+
+/* This snapshots into the request how much this context has admitted to `peer`.
+ *
+ * submitted_count_per_peer[peer] is the counter the admission gate advances, so the
+ * snapshot covers every write that had taken a position in this peer's sequence
+ * before the call and stops there. Writes admitted after the call get positions
+ * above the snapshot, so the wait terminates. */
+NCCL_DEVICE_INLINE static void flushAsyncImpl(ncclGinCtx ctx, int peer, ncclGinEfaGdaRequest* req) {
+  nccl_ofi_gin_gdaki_dev_handle* dev = getDevHandle(ctx);
+  req->peer = (uint32_t)peer;
+  req->submitted_count_at_flush =
+    scopedAtomicLoad<cuda::thread_scope_system, cuda::memory_order_acquire>(&dev->submitted_count_per_peer[peer]);
+  req->reserved = 0;
+}
+
+/* This completes the flush that FlushAsync deferred: it waits for this peer's
+ * first submitted_count_at_flush writes to complete via waitPeerCompleted, then
+ * fences at the caller's memory order so the flushed writes' effects are visible
+ * at the requested scope. */
+template <bool HasTimeout>
+NCCL_DEVICE_INLINE static ncclResult_t waitImpl(ncclGinCtx ctx, ncclGinRequest_t& request, cuda::memory_order ord,
+                                                uint32_t* abortFlag, uint64_t timeoutCycles) {
+  nccl_ofi_gin_gdaki_dev_handle* dev = getDevHandle(ctx);
+  ncclGinEfaGdaRequest& req = reinterpret_cast<ncclGinEfaGdaRequest&>(request);
+
+  uint64_t startCycle = 0;
+  if NCCL_IF_CONSTEXPR (HasTimeout) startCycle = clock64();
+
+  ncclResult_t result =
+    waitPeerCompleted<HasTimeout>(dev, req.peer, req.submitted_count_at_flush, abortFlag, startCycle, timeoutCycles);
+  if (result != ncclSuccess) return result;
+
+  /* Publish the completions at the caller's chosen order, as Wait's contract
+   * requires: after this returns, the flushed writes' effects are visible at the
+   * requested scope. */
+  cuda::atomic_thread_fence(ord, cuda::thread_scope_system);
+  return ncclSuccess;
+}
+
 } // namespace efa_gda
 } // namespace gin
 } // namespace nccl
@@ -925,44 +1121,42 @@ struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_EFA_GDA> {
 
 /* ── FlushAsync ───────────────────────────────────────────────────── */
 
+/* Delegates to flushAsyncImpl. */
 template <>
 struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_EFA_GDA> {
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, int peer, ncclGinRequest_t* outRequest, bool hasDescriptor,
                                       ncclGinDescriptorSmem* descriptor, uint32_t optFlags) {
-    (void)ctx;
-    (void)peer;
-    (void)outRequest;
     (void)hasDescriptor;
     (void)descriptor;
     (void)optFlags;
+    ncclGinEfaGdaRequest* req = reinterpret_cast<ncclGinEfaGdaRequest*>(outRequest);
+    nccl::gin::efa_gda::flushAsyncImpl(ctx, peer, req);
   }
 };
 
 /* ── Wait ─────────────────────────────────────────────────────────── */
 
+/* Both overloads delegate to waitImpl. */
 template <>
 struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_EFA_GDA> {
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, ncclGinRequest_t& request, bool hasDescriptor,
                                       ncclGinDescriptorSmem* descriptor, cuda::memory_order ord, uint32_t* abortFlag) {
-    (void)ctx;
-    (void)request;
     (void)hasDescriptor;
     (void)descriptor;
-    (void)ord;
-    (void)abortFlag;
+    /* No return channel on this overload; a completion error is surfaced through
+     * queryLastError. */
+    (void)nccl::gin::efa_gda::waitImpl</*HasTimeout=*/false>(ctx, request, ord, abortFlag, 0);
   }
 
   NCCL_DEVICE_INLINE static ncclResult_t call(ncclGinCtx ctx, ncclGinRequest_t& request, bool hasDescriptor,
                                               ncclGinDescriptorSmem* descriptor, cuda::memory_order ord,
                                               uint32_t* abortFlag, uint64_t timeoutCycles) {
-    (void)ctx;
-    (void)request;
     (void)hasDescriptor;
     (void)descriptor;
-    (void)ord;
-    (void)abortFlag;
-    (void)timeoutCycles;
-    return ncclSuccess;
+    ncclResult_t result =
+      nccl::gin::efa_gda::waitImpl</*HasTimeout=*/true>(ctx, request, ord, abortFlag, timeoutCycles);
+    /* Abort is a teardown signal, the same as Flush, so this reports success. */
+    return (result == ncclInProgress) ? ncclSuccess : result;
   }
 };
 

--- a/src/include/nccl_device/gin/efa_gda/gin_efa_gda_dev.h
+++ b/src/include/nccl_device/gin/efa_gda/gin_efa_gda_dev.h
@@ -16,13 +16,11 @@
 
 /*
  * Common per-endpoint state shared by every endpoint flavor. Holds
- * the GPU-resident QP/CQ, the target addressing table, the
- * per-QP spinlock that serializes the device-side WQE-post sequence,
- * and the counter-based completion tracking fields.
+ * the GPU-resident QP, the target addressing table, and the
+ * counter-based completion tracking fields.
  */
 struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
   void* qp;                        /* GPU-resident QP (efa_cuda_qp layout) */
-  void* cq;                        /* GPU-resident CQ (efa_cuda_cq layout) */
 
   /* Target addressing for this (poster) endpoint's QP.
    *
@@ -50,35 +48,26 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
   uint16_t* target_remote_qpns;     /* [total_slots * nranks] */
   uint32_t* target_qkey;            /* [total_slots * nranks] */
 
-  /* Per-QP spinlock for the device-side WQE post path. efa-dp-direct's
-   * start_sq_batch / sq_batch_place_wr / flush_sq_wrs sequence is
-   * single-threaded per QP (per the efa-dp-direct CUDA README). One
-   * lock per endpoint lets multiple CTAs targeting different endpoints
-   * proceed in parallel; only CTAs targeting the same endpoint contend. */
-  uint32_t sq_lock;
-
   /* Counter-based completion tracking.
    *
    * `local_cntr_value` points at the FI_WRITE hardware counter for this
    * endpoint's QP. The NIC increments it on every locally-completed
    * outgoing WR. The kernel reads it directly from GPU memory.
    *
-   * `submitted_count` is incremented by the device under sq_lock after
-   * a successful flush_sq_wrs. (submitted_count - *local_cntr_value)
-   * gives the number of WRs still in flight on this QP — used by the
-   * SQ-overflow backpressure check and by Flush to wait for local
-   * completion. */
+   * `submitted_count` is incremented in ringDoorbell by the group leader,
+   * as an atomic add of the newly-doorbelled span.
+   * (submitted_count - *local_cntr_value) gives the number of WRs still in
+   * flight on this QP — used by Flush to wait for local completion. The
+   * counter wraps at 2^31, so callers compare it under EFA_CNTR_MASK. */
   /* `local_cntr_value` is read via cuda::atomic_ref with system scope
    * (see hwCounterLoad helper) since the NIC writes it via PCIe and
    * we need to bypass GPU caches when polling. */
   uint64_t* local_cntr_value;
   uint64_t submitted_count;
 
-  /* SQ ring size for this endpoint's QP. Used by Put to gate new
-   * batches against in-flight WRs (efa-dp-direct's start_sq_batch
-   * does not validate ring overflow on its own). The kernel spins
-   * until (submitted_count - *local_cntr_value + batch_size)
-   * <= sq_size before reserving slots. */
+  /* SQ ring size for this endpoint's QP. Bounds the number of WRs that can be
+   * outstanding on the QP, so callers know the masked (submitted - completed)
+   * difference stays far below the counter's 2^31 wrap. */
   uint32_t sq_size;
 
   uint32_t putvalue_pad;
@@ -91,13 +80,13 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
  * Per-signal/counter endpoint handle, returned to device code through
  * dev_handle->signal_handles[] and dev_handle->counter_handles[].
  *
- * Composes nccl_ofi_gin_gdaki_dev_endpoint_handle (qp / cq / addressing /
- * sq_lock / counter completion tracking) and adds the cntr_value
+ * Composes nccl_ofi_gin_gdaki_dev_endpoint_handle (qp / addressing /
+ * counter completion tracking) and adds the cntr_value
  * pointer that the kernel reads to observe signal arrivals
  * (FI_REMOTE_WRITE) or counter increments (FI_WRITE).
  */
 struct nccl_ofi_gin_gdaki_dev_counter_handle {
-  /* Endpoint-common fields (qp, cq, addressing, sq_lock,
+  /* Endpoint-common fields (qp, addressing,
    * counter completion tracking). */
   struct nccl_ofi_gin_gdaki_dev_endpoint_handle base;
   /* NIC writes the hardware counter value here (GPU memory). Read
@@ -176,6 +165,39 @@ struct nccl_ofi_gin_gdaki_dev_handle {
    * MR over the whole pool, uniform slot size). */
   uint32_t putvalue_lkey;
   uint32_t putvalue_slot_size;
+
+  /* submitted_count_per_peer[p] is device-owned, sized [nranks]: it counts the
+   *   writes to peer p that this CONTEXT admits across every QP. The admission
+   *   gate's atomicAdd returns the write's position (pseq), which the code stamps
+   *   into req_id's pseq field; FlushAsync snapshots the counter as its
+   *   ticket.
+   * ordered_completed_count_per_peer[p] is host-published, sized [nranks]: it is
+   *   the contiguous prefix of that peer's posting sequence, so N means the peer's
+   *   first N writes on this context have all completed even though SRD completes
+   *   out of order. Wait compares its ticket against this one number. */
+  uint32_t* submitted_count_per_peer;
+  uint32_t* ordered_completed_count_per_peer;
+
+  /* This is the per-peer outstanding cap, in writes: put refuses to create the
+   * (peer_window + 1)-th outstanding write to any single peer. This cap bounds the
+   * host's per-peer bitmap, and keeps every live write to a peer distinguishable by
+   * its pseq. The value is a power of two. */
+  uint32_t peer_window;
+
+  /* All of this context's QPs share one CQ, so the entries they have produced and
+   * the host has not yet read must stay within cq_depth: an overflow drops
+   * completions. Two counters bound that occupancy from either end.
+   *
+   * submitted_count_per_ctx is device-owned, one per context: the admission gate
+   *   claims a span of it with one atomic per admitted block, before those WQEs are
+   *   written, so a claimed span counts against the CQ from the moment it is taken.
+   * completed_count_per_ctx is host-published, one per context: the plugin's
+   *   progress pass bumps it once per entry it reads off that CQ.
+   * cq_depth is the CQ's entry count. put admits a block only once its claimed span
+   *   sits within cq_depth of what the host has read. */
+  uint64_t* submitted_count_per_ctx;
+  uint64_t* completed_count_per_ctx;
+  uint32_t cq_depth;
 };
 
 /*


### PR DESCRIPTION
## Description

efa_gda: encode PutValue payload inline
Keep SQ posting shared while PutValue writes values directly into 128-byte RDMA-write WQEs through efa-dp-direct's published payload encoder.

Signed-off-by: Anshuman Goswami [anshumgo@amazon.com](mailto:anshumgo@amazon.com)

feat(efa-gda): Implement FlushAsync and Wait
FlushAsync and Wait were stubs. The backend tracked completion only
through the per-QP FI_WRITE NIC counter, which cannot attribute a
completion to a peer or to a specific write, so a terminating per-peer
wait was impossible.

Implement both on a CQ-derived, per-peer completion prefix that the
host publishes (the plugin's CQ progress pass, driven by NCCL's GIN
progress thread):

Each WQE stamps req_id with a (peer, pseq) split, where pseq is the
write's position in that peer's own posting sequence. The host reads
peer/pseq from the echoed CQE and advances a contiguous
ordered_completed_count_per_peer.
FlushAsync snapshots the context's per-peer submitted count into the
request as a terminating ticket: writes issued after the call are
excluded and cannot extend it. Wait spins until the peer's ordered
prefix reaches the ticket, then fences at the caller's memory order.
A contiguous prefix, not a bare count, is required because EFA SRD
completes out of order even to a single peer: only "everything below N
completed" proves a given earlier write finished.

Post path:

Add per-peer backpressure (cap outstanding at peer_window) so the
host's per-peer state stays fixed size, and a per-context CQ-overflow
gate
(submitted_per_ctx - completed_per_ctx < cq_depth) since all QPs
share one CQ and an overflow drops completions.
Route put's signal-ordering wait through the same per-peer prefix
rather than a whole-endpoint drain, so a signal waits only on its own
peer's traffic.
A failed completion does not advance that peer's prefix, so a wait
covering it does not complete, and queryLastError reports the failure.
The device is given no completion status, matching the GDAKI backend.
The deadline Wait overload maps an abort to success, matching Flush.

Handle changes (gin_efa_gda_dev.h): add submitted_count_per_peer[],
ordered_completed_count_per_peer[], peer_window,
submitted_count_per_ctx, completed_count_per_ctx and cq_depth to the
dev handle; drop the now-unused cq pointer and sq_lock.
ordered_completed_count_per_peer is published by the aws-ofi-nccl
plugin, so its type and length must match the plugin's definition
(nccl_ofi_gin_gdaki_dev.h).

Signed-off-by: Arun Karthik [akkart@amazon.com](mailto:akkart@amazon.com)

## Changes & Impact

## Performance Impact
